### PR TITLE
Update DATs

### DIFF
--- a/dat/Atomiswave.dat
+++ b/dat/Atomiswave.dat
@@ -1,7 +1,7 @@
 clrmamepro (
 	name "Atomiswave"
 	description "Atomiswave"
-	version "2021.9.6"
+	version "2021.9.7"
 	author "libretro"
 )
 
@@ -12,9 +12,6 @@ game (
 	manufacturer "MOSS / Sammy"
 	genre "Sports"
 	rom ( name vm2001f01.u15 size 8388608 crc 2bb1be28 md5 384fcb0d63ec6f27e1a6d5b2d26d3999 sha1 fda7967d6c0341a608c52087ae3d461554760435 )
-	rom ( name vm2001f01.u2 size 8388608 crc 386070a1 md5 e988f6fa2272d3c14c2af59bed6ae481 sha1 bf46980ea822b4cfe67c622f0104bf793031f4ad )
-	rom ( name vm2001f01.u3 size 8388608 crc 4fb33380 md5 2612693f708207a2786fff3e23404e1b sha1 9070990515544e6e9a1d24b1e0597cdea926a4c9 )
-	rom ( name vm2001f01.u4 size 8388608 crc 7cb2e7c3 md5 d39ce04c27d211a35a0792e0526909e1 sha1 8b4e46cf19fbc1d613af75c52faebefb2776280b )
 )
 
 game (
@@ -24,13 +21,6 @@ game (
 	manufacturer "Sega"
 	genre "Sports"
 	rom ( name vera.u1 size 16777216 crc cfef27e5 md5 5429059ef4d1cb379ff9b36e68303bf4 sha1 e0e27adc1b3635a310c50c6374d85572db608675 )
-	rom ( name vera.u14 size 16777216 crc 35df044f md5 8362c0fe4b5ab63f590b9624b3b4bd77 sha1 eeac6c4062f697205558846d6ac262cb5c1b10cf )
-	rom ( name vera.u15 size 16777216 crc e588afd1 md5 57baf84ab78f405292ee47ab128aab73 sha1 0ce3aeb2bcea66beaec2410d1df6857c4365aecf )
-	rom ( name vera.u16 size 16777216 crc 3590072d md5 ca7ab2e8aa0891796c024d59bf358909 sha1 3375a0334c35de1d7d8231d7cc27775451042f91 )
-	rom ( name vera.u17 size 16777216 crc d78389a4 md5 162e4a0ed8d4d178ecbb908929c62171 sha1 50babfe3d58929a26a69dd4a4120fd87f507a95e )
-	rom ( name vera.u2 size 16777216 crc 0a463c37 md5 440d8284959d040780231c29e0522c47 sha1 630ad98d2f80fd458729bd56e8d665a88263da28 )
-	rom ( name vera.u3 size 16777216 crc 8cbec9d7 md5 f2fdc3bcb542b761cfb093ae3137ead8 sha1 080f5edd817993946b1008ebe8ba489f818d3f99 )
-	rom ( name vera.u4 size 16777216 crc bd1f13aa md5 f40ce8ff7bac208063325ce0120d456d sha1 1ef9a7e684418baf8a61fef2610839fd72887d4c )
 )
 
 game (
@@ -40,8 +30,6 @@ game (
 	manufacturer "MOSS / Sammy"
 	genre "Ball & Paddle"
 	rom ( name u1 size 16777216 crc ca097a3f md5 2b7271012b31516ebe605ead3862fd5c sha1 280fc0c9c36fc988b2ab57c229bbec760d09d5eb )
-	rom ( name u3 size 16777216 crc debaf8bd md5 e68442f46aff597e62cb50fa808b8f52 sha1 8f007e48828697ff7371998f04b2fdd84329fa22 )
-	rom ( name u4 size 16777216 crc d235dd29 md5 9ab8a9b75772209771ba56124bae93b2 sha1 bdd2318a7975fd985b4731700e290a4d0d9cde74 )
 )
 
 game (
@@ -51,13 +39,6 @@ game (
 	manufacturer "Sega"
 	genre "Shooter"
 	rom ( name 608-2161.u1 size 16777472 crc 526fc1af md5 f332ca2957a7ff6132f75b4c431d9dc5 sha1 dd8a37fa73a9ef193b6f4fb962345bdfc4854b5d )
-	rom ( name 608-2161.u14 size 16777472 crc 2e7d966f md5 5e99392b42f2196ca2ff8b7ba853fd11 sha1 3304fd0c5140a13f6fe2ea9aaa74d7885e1505e1 )
-	rom ( name 608-2161.u15 size 16777472 crc b82dcb0a md5 bcd62adaf143ce16d652c7839674cbc4 sha1 36dc89a388ac0c7e0a0e72428c8149cbda12805a )
-	rom ( name 608-2161.u16 size 16777472 crc 14f8ca87 md5 394338c9b11c1aad29aff65b309da902 sha1 778c048da9434ffda600e35ad5aca29e02cc98c0 )
-	rom ( name 608-2161.u17 size 16777472 crc 2f973eb4 md5 c7353341df333107a0ad7435ec11414f sha1 45409b5517cda119315f198892224889ac3a0f53 )
-	rom ( name 608-2161.u2 size 16777472 crc c40dae68 md5 149f80faca471b685760a817587e4bb3 sha1 29ec47c76373eeaa686684f10907d551de7d9c59 )
-	rom ( name 608-2161.u3 size 16777472 crc 5bb65194 md5 b8ef57c9f9a5f41811e7ab0cd6ce87da sha1 5fa8c38e6aadf5d999e260da24b001c0c7805d48 )
-	rom ( name 608-2161.u4 size 16777472 crc 55f4e762 md5 801395a6c6a37d7d1776d41ba8f9abf1 sha1 a11f7d69458e647dd2b8d86c98a54f309b1f1bbc )
 )
 
 game (
@@ -67,13 +48,6 @@ game (
 	manufacturer "Polygon Magic / Dimps"
 	genre "Fighter"
 	rom ( name ax0601m01.ic11 size 16777216 crc 12fda2c7 md5 57f44833ddb8e274091e95ff45019ea3 sha1 3afbac221ffe249386e4cb50b4edd013d9a40062 )
-	rom ( name ax0601p01.ic18 size 8388608 crc 0efb38ad md5 917b2ceaede4fd7b99bc45319e7821b5 sha1 9400e37efe3e936474d74400ebdf28ad0869b67b )
-	rom ( name ax0602m01.ic12 size 16777216 crc aea61fdf md5 4e48898c3dcb7c46e98ba48e942f9de9 sha1 0a088848bbf7a47df8b44b69bf72ed0d4a1088f8 )
-	rom ( name ax0603m01.ic13 size 16777216 crc d5879d35 md5 eb530f074e8806af442929397ec77f87 sha1 977cd3b373c6f94eb21ffb24ff564971d3d633e5 )
-	rom ( name ax0604m01.ic14 size 16777216 crc a7b09048 md5 b2e15ab78c88eba3a21baa46293b1184 sha1 229fa2332b58fec2a712c3ebd672662f35a9485a )
-	rom ( name ax0605m01.ic15 size 16777216 crc 18d8437e md5 c9181f59150f5b6ae43bbbb969885e95 sha1 fe2e189e40a89141335e754268d29d46e3eb3bb8 )
-	rom ( name ax0606m01.ic16 size 16777216 crc 42c81617 md5 4af7cbc9d6762dd3df6abe3b035403d4 sha1 1cc686af5e3fc56143836e3dcc0067893f82fcf9 )
-	rom ( name ax0607m01.ic17 size 16777216 crc 96e5aa84 md5 5569e83b31fd357db978f21e64e93e7a sha1 e9841f550f2ef409d97004542bcadabb6b9e84af )
 )
 
 game (
@@ -83,13 +57,6 @@ game (
 	manufacturer "Sammy"
 	genre "Sports"
 	rom ( name 695-0014.u1 size 16777216 crc a91d2fcb md5 23f0cada92075755fbda61d259f1f80e sha1 8414386c09ba36ea581c8161f6cf2a13cc5ae516 )
-	rom ( name 695-0014.u14 size 16777216 crc 55470242 md5 a5cc4513c15169118af1bbb6b74b02e4 sha1 789036189ae5488a9da565774bdf91b49cd8264e )
-	rom ( name 695-0014.u15 size 16777216 crc d239a549 md5 48d9c111cc51600a3e08667ec32b00a5 sha1 71f3c1c2ae2a9b6f09f30e7be3bb11ba111276ae )
-	rom ( name 695-0014.u16 size 16777216 crc 730180a4 md5 69e2b820b08091c41fcb90dbe048f994 sha1 017b82e2d2744695e3e521d35a8511ecc1c8ab43 )
-	rom ( name 695-0014.u17 size 16777216 crc 16bb5992 md5 7590c0f29b6417f69dbb9593bfeb9dcc sha1 18772587272aba1d50a48d384f472276c3b48d96 )
-	rom ( name 695-0014.u2 size 16777216 crc 4d82152f md5 69c6ef980de248ec362f5fddebfed51a sha1 a448983d4e81eb6485b62f23a6c99d1112a20c21 )
-	rom ( name 695-0014.u3 size 16777216 crc 9fdd7d07 md5 b5c1a4943950c2ff2785c1312b2452cf sha1 56d580dda116823ea5dc5e1bd5154463a476866a )
-	rom ( name 695-0014.u4 size 16777216 crc 3342f237 md5 3aade099e040e6924331f7bb0d3aefd2 sha1 e617b0e1f8d8da9783c58ab98eb91de2363ec36f )
 )
 
 game (
@@ -99,11 +66,6 @@ game (
 	manufacturer "Sammy"
 	genre "Platform"
 	rom ( name ax0401m01.ic11 size 16777216 crc 5e5dca57 md5 a401bc9b6051dd0d10c343418009c29d sha1 e0623c84f66cada37d4c9399a7a8fc6866933144 )
-	rom ( name ax0401p01.ic18 size 8388608 crc 195d6328 md5 21fb32279520a5f4077a19b2486ac8ca sha1 cf3b5699f81235919dd3b1974d2ecb0376cb4552 )
-	rom ( name ax0402m01.ic12 size 16777216 crc 77dd4771 md5 ff4e4dab69b1731a32c60293e89c9585 sha1 dcd23b8ddc82eab2f325266ffd7ed3fbc1bcdf71 )
-	rom ( name ax0403m01.ic13 size 16777216 crc 911d0674 md5 f5310c4040dc8c8156fd2460de7c9ac2 sha1 eec35badcfbfe412b7104a86c2111f5a1b5fb5cd )
-	rom ( name ax0404m01.ic14 size 16777216 crc f82a4ca3 md5 ff038d6862ed5eda244bf5a6705adaf1 sha1 da686d86e176a9f24874d2916b1932f03a99a52d )
-	rom ( name ax0405m01.ic15 size 16777216 crc b88298d7 md5 ad126d7349a8115b9a1c5db176d070fb sha1 490c3ec471018895b7268ee33498dddaccbbfd5a )
 )
 
 game (
@@ -113,13 +75,6 @@ game (
 	manufacturer "Arc System Works / Sega"
 	genre "Fighter"
 	rom ( name ax1901m01.ic11 size 16777216 crc ff5a1642 md5 b42e0708fed3f5c93876364c30f5e884 sha1 49cefcce173f9a811fe9c0c07bee53aeba2bc3a8 )
-	rom ( name ax1901p01.ic18 size 8388608 crc a06998b0 md5 eed289a5efe78c40343765fc6c32b71d sha1 d617691db5170f6db176e40fc732966d523fd8cf )
-	rom ( name ax1902m01.ic12 size 16777216 crc d9aae8a9 md5 3ef8864600ff52a6278b3b2dc352e590 sha1 bf87034088be0847b6e297b7665e0ea4d8cba631 )
-	rom ( name ax1903m01.ic13 size 16777216 crc 1711b23d md5 14bb86c77ec115afd20cd0209710abcd sha1 ab628b2ec678839c75245e245297818ef1592d3b )
-	rom ( name ax1904m01.ic14 size 16777216 crc 443bfb26 md5 fd9d056a78abe7ab594c4295e8e78f59 sha1 6f7751afa0ca55dd0679758b27bed92b31c1b050 )
-	rom ( name ax1905m01.ic15 size 16777216 crc eb1cada0 md5 09ee8e1e693c2b9ed8a3fc5f8ed3c1d5 sha1 459d21d622c72606f1d3095e8a25b6c4adccf8ab )
-	rom ( name ax1906m01.ic16 size 16777216 crc fe6da168 md5 5fb8c75d9b0af55fcc639b4af553df30 sha1 d4ab6443383469bb5a4337005de917627a2e21cc )
-	rom ( name ax1907m01.ic17 size 16777216 crc 9d3a0520 md5 90e1db84210ee7530069404526ca3f1f sha1 78583fd171b34439f77a04a97ebe3c9d1bab61cc )
 )
 
 game (
@@ -129,12 +84,6 @@ game (
 	manufacturer "Sammy"
 	genre "Driving"
 	rom ( name ax1701m01.ic11 size 16777216 crc 7dcdc784 md5 c0b56195e1bb5c817c16add25507a354 sha1 5eeef9a760a0b090ed5aad8b7bdee2baa69a088b )
-	rom ( name ax1701p01.ic18 size 8388608 crc 480cade7 md5 a3b99e68c2181d96886849648d6d714e sha1 487d4b27d7e5196d8321c5a80175ec7b1b32c1e8 )
-	rom ( name ax1702m01.ic12 size 16777216 crc 06c9bf85 md5 5bb115123bf5c9fb15a85539c54c0cbb sha1 636262dca7140397436646754fb204b97aa08ce9 )
-	rom ( name ax1703m01.ic13 size 16777216 crc 8f8e0224 md5 65e15c18c025387f867d599b62d0ddfa sha1 2a9a17ed726913c00bf1c6a94bdd4fb32e800868 )
-	rom ( name ax1704m01.ic14 size 16777216 crc fbb4bb16 md5 8694395f4a8d90a30616ae90b9f9db92 sha1 b582680a880166c5bbdd2ad77b7903fedf9b01ad )
-	rom ( name ax1705m01.ic15 size 16777216 crc 996f68e1 md5 8e269b0a3d9cc4a6df51834f361437f4 sha1 3fa505c641127d9027bfc7ec0ab16905344a4e2c )
-	rom ( name ax1706m01.ic16 size 16777216 crc 804b2eb2 md5 c37691321e12f050fe2111583f4b536e sha1 fcca02a5a8c09eb16548255115fb105c9c49c4e0 )
 )
 
 game (
@@ -144,15 +93,6 @@ game (
 	manufacturer "Arc System Works / Sammy"
 	genre "Fighter"
 	rom ( name am3aht.u1 size 524288 crc c4a21dbf md5 6b71feb8a239ed3eab7f93e038b3bc92 sha1 3200fdf209f8a6c8c9acdb60a2bc1d70af28fc5b )
-	rom ( name ax1201m01.ic10 size 16777216 crc df96ce30 md5 d2c79f9cc2a6b0d57c74e966c2deea12 sha1 25a9f743b1c2b11896d0c7a2dc1c198fc977aaca )
-	rom ( name ax1201p01.ic18 size 8388608 crc 0a78d52c md5 c34b023f3df349152d5792384348988e sha1 e9006dc43cd11d5ba49a092a1dff31dc10700c28 )
-	rom ( name ax1202m01.ic11 size 16777216 crc dfc6fd67 md5 808fb1c02f022a50cf78844a790b176d sha1 f9d35b18a03d22f70feda42d314b0f9dd54eea55 )
-	rom ( name ax1203m01.ic12 size 16777216 crc bf623df9 md5 1ddc0b678452e04652429d640b351e20 sha1 8b9a8e8100ff6d2ce9a982ab8eb1d542f1c7af03 )
-	rom ( name ax1204m01.ic13 size 16777216 crc c80c3930 md5 72cd485c3bf51f11a866032be0726255 sha1 5c39fde36e2ebbfe72967d7d0202eb454a8d3bbe )
-	rom ( name ax1205m01.ic14 size 16777216 crc e99a269d md5 29cf48c31bfb1c0dce7053917c468788 sha1 a52148b82b0338b8bad8b52985302eaf81a4cfde )
-	rom ( name ax1206m01.ic15 size 16777216 crc 807ab795 md5 0250b706f955cdd81c4ba3a2f06c35a2 sha1 17c86b1a56333c05b68ff84f83e964d013c1819c )
-	rom ( name ax1207m01.ic16 size 16777216 crc 6636d1b8 md5 6a5e1717ea2e085e74db9acd1c2c0c91 sha1 9bd8fc114557f6fbe772f85eeb246f7336d4255e )
-	rom ( name ax1208m01.ic17 size 16777216 crc 38bda476 md5 8273c15a804b8a9c716b2071a57801c1 sha1 0234a6f5fbaf5e958b3ba0db311dff157f80addc )
 )
 
 game (
@@ -162,13 +102,6 @@ game (
 	manufacturer "Arc System Works / Sammy"
 	genre "Fighter"
 	rom ( name ax0801m01.ic11 size 16777216 crc 61879b2d md5 9b56bcf378aa62a0e5a779341ddab34e sha1 9592fbd979cef9d8f465cd92d0f00b9c13ecf7ba )
-	rom ( name ax0801p01.ic18 size 8388608 crc d920c6bb md5 58644f9689369ef00207deb6d4201d05 sha1 ab34bbef3c71396447bc5322d8e8786041fc832a )
-	rom ( name ax0802m01.ic12 size 16777216 crc c0ff124d md5 61c134d07b93d17aab4613912ee17ae5 sha1 dd403d10de2f097fbaa6b93bc311e2b9e893828d )
-	rom ( name ax0803m01.ic13 size 16777216 crc 4400c89a md5 bc683cadeaf25282e1cc4f78331715ba sha1 4e13536c01103ecfbfc9e3e33746ceae7a91a520 )
-	rom ( name ax0804m01.ic14 size 16777216 crc 70f58ab4 md5 ed9404f5cb1ea73e7ab0a4653836cc63 sha1 cd2def19bbad945c87567f8d28f3a2a179a7f7f6 )
-	rom ( name ax0805m01.ic15 size 16777216 crc 72740e45 md5 00e29ef46715d2fb3f13273599829d1d sha1 646eded89f10008c9176cd6772a8ac9d1bf4271a )
-	rom ( name ax0806m01.ic16 size 16777216 crc 3bf8ecba md5 72eb99701a8c1d5d8b3f40221b27bdcb sha1 43e7fbf21d8ee60bab72ce558640730fd9c3e3b8 )
-	rom ( name ax0807m01.ic17 size 16777216 crc e397dd79 md5 26a1f731452ecdc3f05bd87dcbb6db0f sha1 5fec32dc19dd71ef0d451f8058186f998015723b )
 )
 
 game (
@@ -178,12 +111,6 @@ game (
 	manufacturer "Sammy / SNK Playmore"
 	genre "Fighter"
 	rom ( name ax2201en_p01.ic18 size 8388608 crc 27aab918 md5 f628e796953ece97ffe2b1ce4db6cd27 sha1 41c5ddd8bd4c91481750606ab44aa115b5fe01d0 )
-	rom ( name ax2201m01.ic11 size 16777216 crc 22ea665b md5 80b3d85961113a33f564a23af5bb94ad sha1 292c92c9ae43eea2d1c27cedfb89c3956b8dea32 )
-	rom ( name ax2202m01.ic12 size 16777216 crc 7fad1bea md5 3d0031c77b10d583b9b7cc16cd410848 sha1 89f3f88af48973a4685955d86ef97a1487b8e7a8 )
-	rom ( name ax2203m01.ic13 size 16777216 crc 78986ca4 md5 af03951c589d396c50ecf8847d9e3f07 sha1 5a6c8c12955573f33361d2c6f20f85de35ac7bae )
-	rom ( name ax2204m01.ic14 size 16777216 crc 6ffbeb04 md5 3689f99294ec45e10dd5705a73b89ba4 sha1 975062cf364589dbdd5c5cb5ca945f76d87fc120 )
-	rom ( name ax2205m01.ic15 size 16777216 crc 2851b791 md5 0e6027105110225bb7e5d04b2c477b28 sha1 566ef95ea066b7bf548986085670242be217befc )
-	rom ( name ax2206m01.ic16 size 16777216 crc e53eb965 md5 25bcf16708465b51dc67214f7b19ab3a sha1 f50cd53a5859f081d8a278d24a519c9d9b49ab96 )
 )
 
 game (
@@ -193,13 +120,6 @@ game (
 	manufacturer "Sammy / SNK Playmore"
 	genre "Fighter"
 	rom ( name ax3201m01.mrom1 size 33554432 crc 7f9d6af9 md5 c9e59b03eafb1da2cc96d57f8c22ab64 sha1 001064ad1b8c3408efe799dc766c2728dc6512a9 )
-	rom ( name ax3201p01.fmem1 size 8388608 crc 6dbdd71b md5 36cde602c9bb8dc7b1e0749d663db8b9 sha1 cce3897b104f5d923d8136485fc80eb9717ff4b5 )
-	rom ( name ax3202m01.mrom2 size 33554432 crc 1ae40afa md5 ab3941b4ba3a142b6813c3386a69eb46 sha1 9ee7957c86cc3a71e6971ddcd906a82c5b1e16f1 )
-	rom ( name ax3203m01.mrom3 size 33554432 crc 8c5e3bfd md5 a29a3d8ea095a2e03da2511cd2a483d0 sha1 b5443e2a1b88642cc57c5287a3122376c2d48de9 )
-	rom ( name ax3204m01.mrom4 size 33554432 crc ba97f80c md5 595dafbfd8c7baac14b1caffd4915883 sha1 36f672fe833e13f0bab036b02c39123066327e20 )
-	rom ( name ax3205m01.mrom5 size 33554432 crc 3c747067 md5 70bf8d4c68d859bb20afa75011ab6f0f sha1 54b7ff73d618e2e4e40c125c6cfe99016e69ad1a )
-	rom ( name ax3206m01.mrom6 size 33554432 crc cb81e5f5 md5 a36ffa2e7f41a9a54f9b5a099e0e90d9 sha1 07faee02a58ac9c600ab3cdd525d22c16b35222d )
-	rom ( name ax3207m01.mrom7 size 33554432 crc 164f6329 md5 4cb6df02d22523830178bb85b42f7249 sha1 a72c8cbe4ac7b98edda3d4434f6c81a370b8c39b )
 )
 
 game (
@@ -209,13 +129,6 @@ game (
 	manufacturer "IGS / Sammy"
 	genre "Fighter"
 	rom ( name ax1301m01.ic11 size 16777216 crc 58ae7ca1 md5 3d1be831a49735200a188093c31a2565 sha1 e91975697b797ea05488ace649cbb9964b4cd500 )
-	rom ( name ax1301m02.ic12 size 16777216 crc 871ea03f md5 03207617d9061284bcae64de0cfb2b6a sha1 6806910832ca271a9240aca8e91279556e5b0cb7 )
-	rom ( name ax1301m03.ic13 size 16777216 crc abc328bc md5 07f72d0bf27e14eb2f16546aace1d583 sha1 d9271d4e5abe76d31de0f60a5c106260338d42e9 )
-	rom ( name ax1301m04.ic14 size 16777216 crc 25a176d1 md5 2dc4f5a3996f76d8cde99751239fc5a2 sha1 6d815bf6acb645fead060733660e24fb0d44282d )
-	rom ( name ax1301m05.ic15 size 16777216 crc e6573a93 md5 a5de7de9469b5c47b4939aa74789ba2b sha1 0666e52d0088263f28938e4c8aae201e604ec1f2 )
-	rom ( name ax1301m06.ic16 size 16777216 crc cb8cacb4 md5 cdae3a82a3ef1ed70f4f15c9faa3f241 sha1 5d008e8a934451b9bfa33fedfd492c86d9226ef5 )
-	rom ( name ax1301m07.ic17 size 16777216 crc 0ca92213 md5 e30ac08b9418c22de1a744b8b08ba658 sha1 115c50fa55e6de3439de23e74621695510c6a7ba )
-	rom ( name ax1301p01.ic18 size 8388608 crc 6833a334 md5 ec694a4a471c2aa195db5a9b67c74b37 sha1 646aaa578e09ad23bc9c7f4fbdfb3c1486916fd3 )
 )
 
 game (
@@ -225,11 +138,6 @@ game (
 	manufacturer "SIMS / Sammy"
 	genre "Driving"
 	rom ( name ax0501m01.ic11 size 16777216 crc 4a847a59 md5 3caf268181b8a083974b6443ea2da542 sha1 7808bcd357b85861082b426dbe34a20ae7016f6a )
-	rom ( name ax0501p01.ic18 size 8388608 crc e1651867 md5 2e47814f6d0093c4968da2df44941642 sha1 49caf82f4b111da312b14bb0a9c31e3732b4b24e )
-	rom ( name ax0502m01.ic12 size 16777216 crc 2580237f md5 08bd4b5dee824d3511b042da0ce6394d sha1 2e92c940f95edae33d6a7e8a071544a9083a0fd6 )
-	rom ( name ax0503m01.ic13 size 16777216 crc e5a3766b md5 396c0bdcb5e67040a415b38712d418f0 sha1 1fe6e072adad27ac43c0bff04e3c448678aabc18 )
-	rom ( name ax0504m01.ic14 size 16777216 crc 7955b55a md5 54d77a7775a7f520b2ee812c52cd09c1 sha1 927f58d6961e702c2a8afce79bac5e5cff3dfed6 )
-	rom ( name ax0505m01.ic15 size 16777216 crc e8ccc660 md5 6dfddc52cab3574fe3b123568faa7bbc sha1 a5f414f200a0d41e958430d0fc2d4e1fda1cc67c )
 )
 
 game (
@@ -239,10 +147,6 @@ game (
 	manufacturer "Sega / SNK Playmore"
 	genre "Platform"
 	rom ( name ax3001m01.mrom1 size 33554432 crc e56417ee md5 7467f89ffc07aaa5dcc0e74982b52b37 sha1 27692ad5c1093aff0973d2aafd01a5e30c7bfbbe )
-	rom ( name ax3001p01.fmem1 size 8388608 crc af67dbce md5 06d82c12c4da1783bbb5eb277f991e10 sha1 5aba108caf3e4ced6994bc26e752d4e225c231e8 )
-	rom ( name ax3002m01.mrom2 size 33554432 crc 1be3bbc1 md5 d6b10f737e9ce641ef5880983b86f903 sha1 d75ce5c855c9c4eeacdbf84d440c73a94de060fe )
-	rom ( name ax3003m01.mrom3 size 33554432 crc 4fe37370 md5 d225f5705c512db4551a58b917126212 sha1 85d51db94c3e34265e37b636d6545ed2801ba5a6 )
-	rom ( name ax3004m01.mrom4 size 33554432 crc 2f4c4c6f md5 7f5eb0fb11e181cd2997fdc363ad6d5d sha1 5815c28fdaf0429003986e725c0015fe4c08721f )
 )
 
 game (
@@ -252,13 +156,6 @@ game (
 	manufacturer "Sammy / SNK Playmore"
 	genre "Fighter"
 	rom ( name ax3301en_p01.fmem1 size 8388608 crc f7e24e67 md5 e20a93036fb8649c7a218cfa9615fc5b sha1 8eef26d44b294faa509304b1b04f4d801337bc99 )
-	rom ( name ax3301m01.mrom1 size 33554432 crc e6013de9 md5 39910bfd03d97461155a40f88bb5f606 sha1 ccbc7c2e76153348646d75938d5c008dc80df17d )
-	rom ( name ax3302m01.mrom2 size 33554432 crc f7cfef6c md5 fc638848a2918a8a8b1d2bfa2592bf05 sha1 c9e6231499a9c9c8650d9e61f34ff1fcce8d442c )
-	rom ( name ax3303m01.mrom3 size 33554432 crc 0cdf8647 md5 9a69ddd4e2e92ffce5633abe84ede76a sha1 0423f96842bef2c2ff454318dc6960b5052c0551 )
-	rom ( name ax3304m01.mrom4 size 33554432 crc 2f031db0 md5 232e61c7e77152cf5982ee535287dd0b sha1 3214735f04fadf160137f0585bfc1a27eeecfac6 )
-	rom ( name ax3305m01.mrom5 size 33554432 crc f6668aaa md5 df3d9ffb6bdfa9f20a055be2c01dc81f sha1 6a78f8f0c7d7a71854ff87329290d38970cfb476 )
-	rom ( name ax3306m01.mrom6 size 33554432 crc 5cf32fbd md5 8f3fc5cc0ffb076aba78c16932a053c4 sha1 b6ae0abe5791b3d6f8db07b8c8ca22219a153801 )
-	rom ( name ax3307m01.mrom7 size 33554432 crc 26d9da53 md5 5c21da53768c94a611d6241dbfa1db0b sha1 0015b4be670005a451274de68279b4302fc42a97 )
 )
 
 game (
@@ -268,11 +165,6 @@ game (
 	manufacturer "RIZ Inc./ Sammy"
 	genre "Shooter"
 	rom ( name ax1601m01.ic11 size 16777216 crc f34eed33 md5 cfca6d39113604ea6ac872887546c4b3 sha1 1c171fb8aa95877f81ed78652d4a9ff80f7713ff )
-	rom ( name ax1601p01.ic18 size 8388608 crc 00a74fbb md5 942214d5e5b720f7db29e06744e3228f sha1 57cc1eedd22d1f553956a825e69a597309ee2bef )
-	rom ( name ax1602m01.ic12 size 16777216 crc a7d59efb md5 6d946eb1627f5538b635258ddd8fb4e4 sha1 a40938ce1399babefc8cf02f579a86cf08e211ef )
-	rom ( name ax1603m01.ic13 size 16777216 crc 7c0aa241 md5 87afe8fc0b53c6d1789f92baa3081800 sha1 3e0e5ff3307dcfa52998fb9b4b14bf54bd056a99 )
-	rom ( name ax1604m01.ic14 size 16777216 crc d2369144 md5 185172b5f6da6300195739b4890cce09 sha1 da1eae9957d27d1682c4191780cf51b32dfe6659 )
-	rom ( name ax1605m01.ic15 size 16777216 crc 0c11c1f9 md5 a830c842076c97d41fff372f122c6461 sha1 0585db60618c5b97f9b7c203baf7e5ac90883ca6 )
 )
 
 game (
@@ -282,13 +174,6 @@ game (
 	manufacturer "Sammy / Dimps"
 	genre "Fighter"
 	rom ( name ax1801m01.ic11 size 16777216 crc c38aa61c md5 60b8c96a6b29c04fae4bf2af25c5db60 sha1 e2f688a0aa8b0119f5fd3d53c8904e035d43a4b1 )
-	rom ( name ax1801p01.ic18 size 8388608 crc 2f7fb163 md5 8d6621766e778da50e83ad9f4aa9b3c5 sha1 bf819d798d9a3a7bc754e111a3f53b9db6d6042a )
-	rom ( name ax1802m01.ic12 size 16777216 crc 72e0ebc8 md5 df8f311ba0ffc44cd1eb74bad09ddb6d sha1 e85300a405ea14c4c9d857eb9685c93faaca1d56 )
-	rom ( name ax1803m01.ic13 size 16777216 crc d0f59d98 md5 b11c1c128be71ee784132534b5e39009 sha1 b854796087e9f76a13a21da8249f7224e451e129 )
-	rom ( name ax1804m01.ic14 size 16777216 crc 15595cba md5 9c41e0e5827880986a38201fbff1f898 sha1 8dd06d1f986cd21a58d20b662b11ed7ba8a6ff7a )
-	rom ( name ax1805m01.ic15 size 16777216 crc 3d3f8e0d md5 8526545b396155698325b802bb17aff4 sha1 364a0bda890722b9fb72171f96c742b8f3fef23e )
-	rom ( name ax1806m01.ic16 size 16777216 crc ac2751bb md5 bbf3b7740bd728030a54f542d98a7213 sha1 5070fa12bf109ab87e8f7ea46ac4ae78a73105da )
-	rom ( name ax1807m01.ic17 size 16777216 crc 3b2fbdb0 md5 7c2b61543e479451a615e2cdc02b00e4 sha1 f9f7e06785d3a07282247aaedd9999aa7c2670b9 )
 )
 
 game (
@@ -298,11 +183,6 @@ game (
 	manufacturer "Sammy / Dimps"
 	genre "Fighter"
 	rom ( name ax3401m01.mrom1 size 33554432 crc 60894d4c md5 9267524776e9186532dff90b145ff132 sha1 5b21af3c7c82d4d64bfd8498c26283111ada1298 )
-	rom ( name ax3401p01.fmem1 size 8388608 crc a33601cf md5 0c0bddd3cf6865dfae5d21506aff7717 sha1 2dd60a9c3a2517f2257ab69288fa95645de133fa )
-	rom ( name ax3402m01.mrom2 size 33554432 crc e4224cc9 md5 b0e3211271774ad88e2baa094a81a448 sha1 dcab06fcf48cda286f93d2b37f03a83abf3230cb )
-	rom ( name ax3403m01.mrom3 size 33554432 crc 081c0edb md5 4fd2e9c79de6766fa77ba3f48bfe6410 sha1 63a3f1b5f9d7ca4367868c492236406f23996cc3 )
-	rom ( name ax3404m01.mrom4 size 33554432 crc a426b443 md5 89b7c1fd9ae699e0d887b5c0e2ae3fee sha1 617aab42e432a80b0663281fb7faa6c14ef4f149 )
-	rom ( name ax3405m01.mrom5 size 33554432 crc 4766ce56 md5 f06d137ce45b9d62aba8f04edfd2629e sha1 349b82013a75905ae5520b14a87702c9038a5def )
 )
 
 game (
@@ -312,13 +192,6 @@ game (
 	manufacturer "Yuki Enterprise / Sammy"
 	genre "MultiGame"
 	rom ( name ax1401m01.ic11 size 16777216 crc fd7af845 md5 abb6251519c8444fc1065cb6110b84b5 sha1 0c8f5a91662e46d5c187a0758af95082183cdf69 )
-	rom ( name ax1401p01.ic18 size 8388608 crc 28d779e0 md5 0dfa1165573b397d817bd0cf669e1993 sha1 dab785a595de5f474c18c713e672949176a5b1b5 )
-	rom ( name ax1402m01.ic12 size 16777216 crc f6006f85 md5 651aa91f593ea3b6feb76e585bb24ec7 sha1 9275603673c663f73b977d0d14ed1d2a7002c627 )
-	rom ( name ax1403m01.ic13 size 16777216 crc 074f7c4b md5 e7c49eb7df265b842e97114533462a5f sha1 4955e4f333d15d5d9cc69bb9658f29a37e912012 )
-	rom ( name ax1404m01.ic14 size 16777216 crc af4e3829 md5 6df3be145b819f4ed07bb8e7232876d7 sha1 18d9e8a8d8e930ad697b686a98f31ea175f5fd4a )
-	rom ( name ax1405m01.ic15 size 16777216 crc b548446f md5 c66ddd242bf59dc192fa7bce53f35697 sha1 8b4661e601e36c067dff2530aff4f7ea76e1c21e )
-	rom ( name ax1406m01.ic16 size 16777216 crc 437673e6 md5 84eae6197ba3822540b9baf2a9f9322d sha1 66f7e5f246ebbb1bdbf074da41ec16bf32720a82 )
-	rom ( name ax1407m01.ic17 size 16777216 crc 6b6acc0a md5 906d2cd77e4b09e111ec6bd1d8342a95 sha1 a8c692c875271a0806460caa79c67fd756231273 )
 )
 
 game (
@@ -328,13 +201,6 @@ game (
 	manufacturer "Sammy / SNK Playmore"
 	genre "Fighter"
 	rom ( name ax2901m01.mrom1 size 33554432 crc dbbbd90d md5 6ced5b287fe86f210fb7d911d7c35715 sha1 102ee0b249a3e0ca2f659b6c515816c522ad78d0 )
-	rom ( name ax2901p01.fmem1 size 8388608 crc 58e0030b md5 f30a528ffa1110175e19a2c4f87fe9f4 sha1 ed8a66833beeb56d83770123eff28df0f25221d1 )
-	rom ( name ax2902m01.mrom2 size 33554432 crc a3bd7890 md5 c29387ba868560d9a286fd617366623e sha1 9b8d934d6ebc3ef688cd8a6de47657a0663fea10 )
-	rom ( name ax2903m01.mrom3 size 33554432 crc 56f50fdd md5 af0ccd286d30ea5323e96cd46fd650ec sha1 8a5a4a99108c0279056998046c7b332e80121dee )
-	rom ( name ax2904m01.mrom4 size 33554432 crc 8a3ae175 md5 7c804bc49042ee8749c429ff376bf262 sha1 966f527a92e24c8eb770344697f2edf6140cf971 )
-	rom ( name ax2905m01.mrom5 size 33554432 crc 429877ba md5 e98722a10da8385776dbcd11fa3a15ca sha1 88e1f3bc682b18d331e328ef8754065109cf9bda )
-	rom ( name ax2906m01.mrom6 size 33554432 crc cb95298d md5 2e3123441a314506e7e24e20a288551f sha1 5fb5d5a0d6801df61101a1b23de0c14ff29ef654 )
-	rom ( name ax2907m01.mrom7 size 33554432 crc 48015081 md5 f2351736159e329d736fb8a4eb64ae63 sha1 3c0a0a6dc9ab7bf889579477699e612c3092f9bf )
 )
 
 game (
@@ -344,10 +210,6 @@ game (
 	manufacturer "Sammy USA"
 	genre "Shooter"
 	rom ( name ax0101m01.ic11 size 16777216 crc 1e39184d md5 72f185c419bfc34efd31173d053a7e39 sha1 663e0cb9f43a0f89d9841e04b3d009f6c5e88d5e )
-	rom ( name ax0101p01.ic18 size 8388608 crc b3642b5d md5 3ccb32dfd28cd44d5ffdfbdb024881bc sha1 85eabd9551aefb825ae8eb6422092fb5a58d60f6 )
-	rom ( name ax0102m01.ic12 size 16777216 crc 700764d1 md5 04bc0be892ef35ff25335f1f8e5549b4 sha1 310f1606f7bbed1012c119f1ef5d89d231d8489e )
-	rom ( name ax0103m01.ic13 size 16777216 crc 6144e7a8 md5 a70120f9f474b2ec0c540ce156fde9f0 sha1 4d4341082f008dfd93ef5bf32a44c80869ef02a8 )
-	rom ( name ax0104m01.ic14 size 16777216 crc ccb72150 md5 fdfc26a4b31a3160871dcf97ac2b7eef sha1 a1032d321c27f9ff43da41f20b8687bf1958ddc9 )
 )
 
 game (
@@ -357,11 +219,6 @@ game (
 	manufacturer "Sammy"
 	genre "Puzzle"
 	rom ( name ic12 size 8388608 crc 06a2ed58 md5 cf2bbf9d22bfa89a0c7b317009a7525c sha1 a807fa8c1c83cb8b18595c210479d5f1dd6be4ca )
-	rom ( name ic14 size 8388608 crc 4860f944 md5 5d4cf840c50a8458b0fa3e72088c0b3d sha1 55c75630c33cba35512a1349650f28fd56757f9f )
-	rom ( name ic15 size 8388608 crc 7113506c md5 5623418f2d9cba873b800e380b62c20f sha1 0548d67b3a1c0b8f17fcafd4fe5c1e6b0e91b6e7 )
-	rom ( name ic16 size 8388608 crc 77e8e39e md5 0193da33dcd0d9cd222a246a4c9659e3 sha1 1286010cdba5c3c0ad5cbe19718fd0f8e5f579db )
-	rom ( name ic17 size 8388608 crc 0eba54ea md5 e1db6572f7f872db8173929fe3e8ff0e sha1 51842ec326a5ba65bd280e652e7d9b395a2586c6 )
-	rom ( name ic18 size 8388608 crc b9957c76 md5 23e97f298a8bac65c8b834c51a1e6bce sha1 6d72c7ac8e1e0cbed7eb01b66f71bedf46a833e1 )
 )
 
 game (
@@ -371,14 +228,6 @@ game (
 	manufacturer "Progress / Sammy"
 	genre "Sports"
 	rom ( name ax2001m01.ic11 size 16777216 crc 64460b24 md5 16a34ede4c7a7909e7d246fdb0187725 sha1 044857d6593897d303622e005a63ca7b3acd7453 )
-	rom ( name ax2001p01.ic18 size 8388608 crc 17ea9aa9 md5 174be7ae11ae628515d367fb45910016 sha1 c68500e9b3407a9d4b20f2678718ce475f179f7d )
-	rom ( name ax2001p01_alt.ic18 size 8388608 crc 845399dd md5 e86ae88acdd3ec9ae90cdbdb033e0159 sha1 21565b13292cead2b532861d2998e381df2672d5 )
-	rom ( name ax2002m01.ic12 size 16777216 crc d4da357f md5 8f570883548a84691f00b9184a3f083f sha1 c462cddec9a369a1a5595676de76499d56683ea9 )
-	rom ( name ax2003m01.ic13 size 16777216 crc aa1e1246 md5 7e995e6302a5cf48d7d2362b9c253c9c sha1 788cc9c070f82aeff1704361e3c72116fd5c4c9d )
-	rom ( name ax2004m01.ic14 size 16777216 crc 4d555d7c md5 e1094abea5ca38103368271fe783893c sha1 a5eccc920bdb7ad9cf57c0e1ef6a905c6b9eee45 )
-	rom ( name ax2005m01.ic15 size 16777216 crc 785208e2 md5 1398df2e220d677fbeef0ac57889377e sha1 6ba5bd3901c5b1d71abcc8d833a011bd4abae6b6 )
-	rom ( name ax2006m01.ic16 size 16777216 crc 8134ec55 md5 cee7349ce72ff513ef683a9c784d7680 sha1 843e473d4f99237ded641cce9515b7802cfe3742 )
-	rom ( name ax2007m01.ic17 size 16777216 crc d0557e8a md5 b60a53e4c7debbcd7fa1bd496a92488f sha1 df8057597eb690bd18c5d26736f5d4f86e3b1225 )
 )
 
 game (
@@ -388,7 +237,6 @@ game (
 	manufacturer "MOSS / Sammy"
 	genre "Driving"
 	rom ( name u1 size 16777216 crc b3c1c3bb md5 569eee3021891de001a601fdf31e8022 sha1 bda9b1e214a733cb1716ab130ecd986709ac136e )
-	rom ( name u3 size 16777216 crc 7acfb499 md5 4a00a6250f73bd338eeb0b54cf23dbb3 sha1 002a0a84dd7f55e1630e1ec2530d0760b0c12b4e )
 )
 
 game (
@@ -398,15 +246,6 @@ game (
 	manufacturer "Sega"
 	genre "Shooter"
 	rom ( name 610-0752.u1 size 16777216 crc 3086bc47 md5 e0e602298a8e80e637a1e0e08d7f01b8 sha1 eb7b04db90d296985528f0cfdd4545f184c40b64 )
-	rom ( name 610-0752.u14 size 16777216 crc ce83bcc7 md5 37e7a916e9231c13f9284573f8bd9d0a sha1 e2d324a5a7eacbec7b0df9a4b9e276521bb9ab80 )
-	rom ( name 610-0752.u15 size 16777216 crc 864a6342 md5 edbc109484da0e165dfe64a1bdf2a49a sha1 fb97532d5dd00f8520fdaf68dfcd1ea627bdf90a )
-	rom ( name 610-0752.u16 size 16777216 crc 8ac71c76 md5 442a28829985a0e3f8842906d5c1f7b6 sha1 080e41e633bf082fc536781541c6031d1ac81939 )
-	rom ( name 610-0752.u17 size 16777216 crc a79fb1fa md5 11ba564a76cd8c5de3a83d7fc82cda46 sha1 f75c5b574fd79677b926c595b369e95605a3c848 )
-	rom ( name 610-0752.u2 size 16777216 crc d3a88b31 md5 c7d9c6bc91559ef420c1cce163aedba7 sha1 ccf14367e4e7efbc2cc835f3b001fd6d64302a5e )
-	rom ( name 610-0752.u3 size 16777216 crc bab6182e md5 84180cc54d9132feca4c39015a1cc45e sha1 4d25256c81941316887cbb4524a203922f5b7104 )
-	rom ( name 610-0752.u4 size 16777216 crc 9787f145 md5 ae6604fa5e71bf238e3ea42456806bfc sha1 8445ede0477f70fbdc113810b80356945ce498d2 )
-	rom ( name flash128.ic4s size 16777216 crc 866ed675 md5 dd4c637a122df09d09a622b76718e497 sha1 2c4c06935b7ab1876e640cede51713b841833567 )
-	rom ( name fpr-24330a.ic2 size 4194304 crc 8d89877e md5 d400224f920ce92f98aeb933c8b8af71 sha1 6caafc49114eb0358e217bc2d1a3ab58a93c8d19 )
 )
 
 game (
@@ -416,10 +255,4 @@ game (
 	manufacturer "Sammy"
 	genre "Shooter"
 	rom ( name ax2401m01.ic11 size 16777216 crc 76dbc286 md5 f66db6114a81d9d0f9be7139c5dcd64e sha1 8f36ca94b8e67c76e0f90b21debc5ac7890f0da1 )
-	rom ( name ax2401p01.ic18 size 8388608 crc 8e2a11f5 md5 29f64bfbdb1a588fce642b7e251885a7 sha1 b5106314fb8d4483254e83ac3982039bb60a78e8 )
-	rom ( name ax2402m01.ic12 size 16777216 crc cd590ea2 md5 0200f1d1b615ed5f6f0063bef8566aca sha1 ee5e38bf68e95da665be478ebba9cc5ffed52bb7 )
-	rom ( name ax2403m01.ic13 size 16777216 crc 06f62eb5 md5 4faabc9d5c23f52ef1b814f8ba158729 sha1 f7e8d1dda6bb59ca2bc7cfa1105889b9e8e6d55d )
-	rom ( name ax2404m01.ic14 size 16777216 crc 759ef5cb md5 f82f106c1ee7ce3ba132764f931cba1b sha1 27ac2d12c6fb358b3d631c017c7b693e5ad95fd7 )
-	rom ( name ax2405m01.ic15 size 16777216 crc 940d77f1 md5 e8604c2c965750204b8c112cbba54c4a sha1 eefdfcb92873032dc7d9ff9310bf5ed715c8bf4f )
-	rom ( name ax2406m01.ic16 size 16777216 crc cbcf2c5d md5 8fdf8019b2a5bf0a34c4e9b68593f3f9 sha1 61362fabcbb3bfc01c996748a7ca65f8a0e02f2f )
 )

--- a/dat/Atomiswave.dat
+++ b/dat/Atomiswave.dat
@@ -1,82 +1,425 @@
 clrmamepro (
 	name "Atomiswave"
 	description "Atomiswave"
-	version 2021.7.9
+	version "2021.9.6"
 	author "libretro"
 )
 
 game (
-	name "Metal Slug 6"
-	description "Metal Slug 6"
-	genre "Action"
-	rom ( name mslug6.zip size 131422139 crc 3582912721 md5 17b550ce0b58778d3ac304801be03768 sha1 637811d275a2716cd9abfe1d794bece650b65736 )
+	name "anmlbskt"
+	description "Animal Basket"
+	year "2005"
+	manufacturer "MOSS / Sammy"
+	genre "Sports"
+	rom ( name vm2001f01.u15 size 8388608 crc 2bb1be28 md5 384fcb0d63ec6f27e1a6d5b2d26d3999 sha1 fda7967d6c0341a608c52087ae3d461554760435 )
+	rom ( name vm2001f01.u2 size 8388608 crc 386070a1 md5 e988f6fa2272d3c14c2af59bed6ae481 sha1 bf46980ea822b4cfe67c622f0104bf793031f4ad )
+	rom ( name vm2001f01.u3 size 8388608 crc 4fb33380 md5 2612693f708207a2786fff3e23404e1b sha1 9070990515544e6e9a1d24b1e0597cdea926a4c9 )
+	rom ( name vm2001f01.u4 size 8388608 crc 7cb2e7c3 md5 d39ce04c27d211a35a0792e0526909e1 sha1 8b4e46cf19fbc1d613af75c52faebefb2776280b )
 )
 
 game (
-	name "The King of Fighters Neo Wave"
-	description "The King of Fighters Neo Wave"
-	genre "Fighting"
-	rom ( name kofnw.zip size 104068918 crc 973292961 md5 4be678e11cfd4d1ea55810f68be759d3 sha1 d6aa69d9699404e3a957bf20c3802819d218a50e )
+	name "basschal"
+	description "Sega Bass Fishing Challenge"
+	year "2009"
+	manufacturer "Sega"
+	genre "Sports"
+	rom ( name vera.u1 size 16777216 crc cfef27e5 md5 5429059ef4d1cb379ff9b36e68303bf4 sha1 e0e27adc1b3635a310c50c6374d85572db608675 )
+	rom ( name vera.u14 size 16777216 crc 35df044f md5 8362c0fe4b5ab63f590b9624b3b4bd77 sha1 eeac6c4062f697205558846d6ac262cb5c1b10cf )
+	rom ( name vera.u15 size 16777216 crc e588afd1 md5 57baf84ab78f405292ee47ab128aab73 sha1 0ce3aeb2bcea66beaec2410d1df6857c4365aecf )
+	rom ( name vera.u16 size 16777216 crc 3590072d md5 ca7ab2e8aa0891796c024d59bf358909 sha1 3375a0334c35de1d7d8231d7cc27775451042f91 )
+	rom ( name vera.u17 size 16777216 crc d78389a4 md5 162e4a0ed8d4d178ecbb908929c62171 sha1 50babfe3d58929a26a69dd4a4120fd87f507a95e )
+	rom ( name vera.u2 size 16777216 crc 0a463c37 md5 440d8284959d040780231c29e0522c47 sha1 630ad98d2f80fd458729bd56e8d665a88263da28 )
+	rom ( name vera.u3 size 16777216 crc 8cbec9d7 md5 f2fdc3bcb542b761cfb093ae3137ead8 sha1 080f5edd817993946b1008ebe8ba489f818d3f99 )
+	rom ( name vera.u4 size 16777216 crc bd1f13aa md5 f40ce8ff7bac208063325ce0120d456d sha1 1ef9a7e684418baf8a61fef2610839fd72887d4c )
 )
 
 game (
-	name "The King of Fighters XI"
-	description "The King of Fighters XI"
-	genre "Fighting"
-	rom ( name kofxi.zip size 233065041 crc 4241294549 md5 8b6197d7e98fcb2d3b8b1e93e4b5f010 sha1 b8fb6c684a8015b5612701feb8cd7e5d78987356 )
+	name "blokpong"
+	description "Block Pong-Pong"
+	year "2004"
+	manufacturer "MOSS / Sammy"
+	genre "Ball & Paddle"
+	rom ( name u1 size 16777216 crc ca097a3f md5 2b7271012b31516ebe605ead3862fd5c sha1 280fc0c9c36fc988b2ab57c229bbec760d09d5eb )
+	rom ( name u3 size 16777216 crc debaf8bd md5 e68442f46aff597e62cb50fa808b8f52 sha1 8f007e48828697ff7371998f04b2fdd84329fa22 )
+	rom ( name u4 size 16777216 crc d235dd29 md5 9ab8a9b75772209771ba56124bae93b2 sha1 bdd2318a7975fd985b4731700e290a4d0d9cde74 )
 )
 
 game (
-	name "Samurai Shodown VI"
-	description "Samurai Shodown VI"
-	genre "Fighting"
-	rom ( name samsptk.zip size 217388988 crc 812549695 md5 8602f266d7e1bbea9919147e8fd334aa sha1 ff39bc7ce61d382f1621a8a00e015575fc6af898 )
+	name "claychal"
+	description "Sega Clay Challenge"
+	year "2008"
+	manufacturer "Sega"
+	genre "Shooter"
+	rom ( name 608-2161.u1 size 16777472 crc 526fc1af md5 f332ca2957a7ff6132f75b4c431d9dc5 sha1 dd8a37fa73a9ef193b6f4fb962345bdfc4854b5d )
+	rom ( name 608-2161.u14 size 16777472 crc 2e7d966f md5 5e99392b42f2196ca2ff8b7ba853fd11 sha1 3304fd0c5140a13f6fe2ea9aaa74d7885e1505e1 )
+	rom ( name 608-2161.u15 size 16777472 crc b82dcb0a md5 bcd62adaf143ce16d652c7839674cbc4 sha1 36dc89a388ac0c7e0a0e72428c8149cbda12805a )
+	rom ( name 608-2161.u16 size 16777472 crc 14f8ca87 md5 394338c9b11c1aad29aff65b309da902 sha1 778c048da9434ffda600e35ad5aca29e02cc98c0 )
+	rom ( name 608-2161.u17 size 16777472 crc 2f973eb4 md5 c7353341df333107a0ad7435ec11414f sha1 45409b5517cda119315f198892224889ac3a0f53 )
+	rom ( name 608-2161.u2 size 16777472 crc c40dae68 md5 149f80faca471b685760a817587e4bb3 sha1 29ec47c76373eeaa686684f10907d551de7d9c59 )
+	rom ( name 608-2161.u3 size 16777472 crc 5bb65194 md5 b8ef57c9f9a5f41811e7ab0cd6ce87da sha1 5fa8c38e6aadf5d999e260da24b001c0c7805d48 )
+	rom ( name 608-2161.u4 size 16777472 crc 55f4e762 md5 801395a6c6a37d7d1776d41ba8f9abf1 sha1 a11f7d69458e647dd2b8d86c98a54f309b1f1bbc )
 )
 
 game (
-	name "The Rumble Fish"
-	description "The Rumble Fish"
-	genre "Fighting"
-	rom ( name rumblef.zip size 109652847 crc 3149726176 md5 380349bf04cf73ac2df9205f33bcc4a0 sha1 887be089acaa912fdde63665efb4304f00df8dfe )
+	name "demofist"
+	description "Demolish Fist"
+	year "2003"
+	manufacturer "Polygon Magic / Dimps"
+	genre "Fighter"
+	rom ( name ax0601m01.ic11 size 16777216 crc 12fda2c7 md5 57f44833ddb8e274091e95ff45019ea3 sha1 3afbac221ffe249386e4cb50b4edd013d9a40062 )
+	rom ( name ax0601p01.ic18 size 8388608 crc 0efb38ad md5 917b2ceaede4fd7b99bc45319e7821b5 sha1 9400e37efe3e936474d74400ebdf28ad0869b67b )
+	rom ( name ax0602m01.ic12 size 16777216 crc aea61fdf md5 4e48898c3dcb7c46e98ba48e942f9de9 sha1 0a088848bbf7a47df8b44b69bf72ed0d4a1088f8 )
+	rom ( name ax0603m01.ic13 size 16777216 crc d5879d35 md5 eb530f074e8806af442929397ec77f87 sha1 977cd3b373c6f94eb21ffb24ff564971d3d633e5 )
+	rom ( name ax0604m01.ic14 size 16777216 crc a7b09048 md5 b2e15ab78c88eba3a21baa46293b1184 sha1 229fa2332b58fec2a712c3ebd672662f35a9485a )
+	rom ( name ax0605m01.ic15 size 16777216 crc 18d8437e md5 c9181f59150f5b6ae43bbbb969885e95 sha1 fe2e189e40a89141335e754268d29d46e3eb3bb8 )
+	rom ( name ax0606m01.ic16 size 16777216 crc 42c81617 md5 4af7cbc9d6762dd3df6abe3b035403d4 sha1 1cc686af5e3fc56143836e3dcc0067893f82fcf9 )
+	rom ( name ax0607m01.ic17 size 16777216 crc 96e5aa84 md5 5569e83b31fd357db978f21e64e93e7a sha1 e9841f550f2ef409d97004542bcadabb6b9e84af )
 )
 
 game (
-	name "The Rumble Fish 2"
-	description "The Rumble Fish 2"
-	genre "Fighting"
-	rom ( name rumblef2.zip size 146628887 crc 810592589 md5 3573dedc836e7298d1dc9469841cd0bb sha1 3573dedc836e7298d1dc9469841cd0bb )
-)
-	
-game (
-	name "Guilty Gear X"
-	description "Guilty Gear X version 1.5"
-	genre "Fighting"
-	rom ( name ggx15.zip size 113569804 crc 670702955 md5 10ad393caf5f576b14c19f0a40bd846e sha1 25fb928d1cc3b97dc1cad5bc1c6e2d436aadd2d7 )
-)
-
-game (
-	name "Guilty Gear Isuka"
-	description "Guilty Gear Isuka"
-	genre "Fighting"
-	rom ( name ggisuka.zip size 131961595 crc 916373942 md5 98da57b41be6681632c615c0fda5160f sha1 1bf01b65f160fc9e042de9384d5222201f710c7a )
+	name "dirtypig"
+	description "Dirty Pigskin Football"
+	year "2006"
+	manufacturer "Sammy"
+	genre "Sports"
+	rom ( name 695-0014.u1 size 16777216 crc a91d2fcb md5 23f0cada92075755fbda61d259f1f80e sha1 8414386c09ba36ea581c8161f6cf2a13cc5ae516 )
+	rom ( name 695-0014.u14 size 16777216 crc 55470242 md5 a5cc4513c15169118af1bbb6b74b02e4 sha1 789036189ae5488a9da565774bdf91b49cd8264e )
+	rom ( name 695-0014.u15 size 16777216 crc d239a549 md5 48d9c111cc51600a3e08667ec32b00a5 sha1 71f3c1c2ae2a9b6f09f30e7be3bb11ba111276ae )
+	rom ( name 695-0014.u16 size 16777216 crc 730180a4 md5 69e2b820b08091c41fcb90dbe048f994 sha1 017b82e2d2744695e3e521d35a8511ecc1c8ab43 )
+	rom ( name 695-0014.u17 size 16777216 crc 16bb5992 md5 7590c0f29b6417f69dbb9593bfeb9dcc sha1 18772587272aba1d50a48d384f472276c3b48d96 )
+	rom ( name 695-0014.u2 size 16777216 crc 4d82152f md5 69c6ef980de248ec362f5fddebfed51a sha1 a448983d4e81eb6485b62f23a6c99d1112a20c21 )
+	rom ( name 695-0014.u3 size 16777216 crc 9fdd7d07 md5 b5c1a4943950c2ff2785c1312b2452cf sha1 56d580dda116823ea5dc5e1bd5154463a476866a )
+	rom ( name 695-0014.u4 size 16777216 crc 3342f237 md5 3aade099e040e6924331f7bb0d3aefd2 sha1 e617b0e1f8d8da9783c58ab98eb91de2363ec36f )
 )
 
 game (
-	name "Dolphin Blue"
+	name "dolphin"
 	description "Dolphin Blue"
-	genre "Run N Gun"
-	rom ( name dolphin.zip size 82591477 crc 3281495115 md5 4ad602cc746e02eb930ab476e02e218d sha1 7e4371ac0da046389584d3ea56a3d99b568dc528 )
+	year "2003"
+	manufacturer "Sammy"
+	genre "Platform"
+	rom ( name ax0401m01.ic11 size 16777216 crc 5e5dca57 md5 a401bc9b6051dd0d10c343418009c29d sha1 e0623c84f66cada37d4c9399a7a8fc6866933144 )
+	rom ( name ax0401p01.ic18 size 8388608 crc 195d6328 md5 21fb32279520a5f4077a19b2486ac8ca sha1 cf3b5699f81235919dd3b1974d2ecb0376cb4552 )
+	rom ( name ax0402m01.ic12 size 16777216 crc 77dd4771 md5 ff4e4dab69b1731a32c60293e89c9585 sha1 dcd23b8ddc82eab2f325266ffd7ed3fbc1bcdf71 )
+	rom ( name ax0403m01.ic13 size 16777216 crc 911d0674 md5 f5310c4040dc8c8156fd2460de7c9ac2 sha1 eec35badcfbfe412b7104a86c2111f5a1b5fb5cd )
+	rom ( name ax0404m01.ic14 size 16777216 crc f82a4ca3 md5 ff038d6862ed5eda244bf5a6705adaf1 sha1 da686d86e176a9f24874d2916b1932f03a99a52d )
+	rom ( name ax0405m01.ic15 size 16777216 crc b88298d7 md5 ad126d7349a8115b9a1c5db176d070fb sha1 490c3ec471018895b7268ee33498dddaccbbfd5a )
 )
 
 game (
-	name "Neo Geo Battle Coliseum"
-	description "Neo Geo Battle Coliseum"
-	genre "Fighting"
-	rom ( name ngbc.zip size 218190674 crc 678071208 md5 81c0f660ed27707870134da144833d7c sha1 bcd8eee27af8eb9e9bef19632dc9f663027b311b )
+	name "fotns"
+	description "Fist Of The North Star"
+	year "2005"
+	manufacturer "Arc System Works / Sega"
+	genre "Fighter"
+	rom ( name ax1901m01.ic11 size 16777216 crc ff5a1642 md5 b42e0708fed3f5c93876364c30f5e884 sha1 49cefcce173f9a811fe9c0c07bee53aeba2bc3a8 )
+	rom ( name ax1901p01.ic18 size 8388608 crc a06998b0 md5 eed289a5efe78c40343765fc6c32b71d sha1 d617691db5170f6db176e40fc732966d523fd8cf )
+	rom ( name ax1902m01.ic12 size 16777216 crc d9aae8a9 md5 3ef8864600ff52a6278b3b2dc352e590 sha1 bf87034088be0847b6e297b7665e0ea4d8cba631 )
+	rom ( name ax1903m01.ic13 size 16777216 crc 1711b23d md5 14bb86c77ec115afd20cd0209710abcd sha1 ab628b2ec678839c75245e245297818ef1592d3b )
+	rom ( name ax1904m01.ic14 size 16777216 crc 443bfb26 md5 fd9d056a78abe7ab594c4295e8e78f59 sha1 6f7751afa0ca55dd0679758b27bed92b31c1b050 )
+	rom ( name ax1905m01.ic15 size 16777216 crc eb1cada0 md5 09ee8e1e693c2b9ed8a3fc5f8ed3c1d5 sha1 459d21d622c72606f1d3095e8a25b6c4adccf8ab )
+	rom ( name ax1906m01.ic16 size 16777216 crc fe6da168 md5 5fb8c75d9b0af55fcc639b4af553df30 sha1 d4ab6443383469bb5a4337005de917627a2e21cc )
+	rom ( name ax1907m01.ic17 size 16777216 crc 9d3a0520 md5 90e1db84210ee7530069404526ca3f1f sha1 78583fd171b34439f77a04a97ebe3c9d1bab61cc )
 )
 
 game (
-	name "Knights of Valour: The Seven Spirits"
-	description "Knights of Valour: The Seven Spirits"
-	genre "Beat'em Up"
-	rom ( name kov7sprt.zip size 109190361 crc 889301951 md5 ad3c47ae35ef333569aa372dca04cbe3 sha1 396bbae310d6575cbd2ad3d943102d49041717fc )
+	name "ftspeed"
+	description "Faster Than Speed"
+	year "2004"
+	manufacturer "Sammy"
+	genre "Driving"
+	rom ( name ax1701m01.ic11 size 16777216 crc 7dcdc784 md5 c0b56195e1bb5c817c16add25507a354 sha1 5eeef9a760a0b090ed5aad8b7bdee2baa69a088b )
+	rom ( name ax1701p01.ic18 size 8388608 crc 480cade7 md5 a3b99e68c2181d96886849648d6d714e sha1 487d4b27d7e5196d8321c5a80175ec7b1b32c1e8 )
+	rom ( name ax1702m01.ic12 size 16777216 crc 06c9bf85 md5 5bb115123bf5c9fb15a85539c54c0cbb sha1 636262dca7140397436646754fb204b97aa08ce9 )
+	rom ( name ax1703m01.ic13 size 16777216 crc 8f8e0224 md5 65e15c18c025387f867d599b62d0ddfa sha1 2a9a17ed726913c00bf1c6a94bdd4fb32e800868 )
+	rom ( name ax1704m01.ic14 size 16777216 crc fbb4bb16 md5 8694395f4a8d90a30616ae90b9f9db92 sha1 b582680a880166c5bbdd2ad77b7903fedf9b01ad )
+	rom ( name ax1705m01.ic15 size 16777216 crc 996f68e1 md5 8e269b0a3d9cc4a6df51834f361437f4 sha1 3fa505c641127d9027bfc7ec0ab16905344a4e2c )
+	rom ( name ax1706m01.ic16 size 16777216 crc 804b2eb2 md5 c37691321e12f050fe2111583f4b536e sha1 fcca02a5a8c09eb16548255115fb105c9c49c4e0 )
+)
+
+game (
+	name "ggisuka"
+	description "Guilty Gear Isuka"
+	year "2004"
+	manufacturer "Arc System Works / Sammy"
+	genre "Fighter"
+	rom ( name am3aht.u1 size 524288 crc c4a21dbf md5 6b71feb8a239ed3eab7f93e038b3bc92 sha1 3200fdf209f8a6c8c9acdb60a2bc1d70af28fc5b )
+	rom ( name ax1201m01.ic10 size 16777216 crc df96ce30 md5 d2c79f9cc2a6b0d57c74e966c2deea12 sha1 25a9f743b1c2b11896d0c7a2dc1c198fc977aaca )
+	rom ( name ax1201p01.ic18 size 8388608 crc 0a78d52c md5 c34b023f3df349152d5792384348988e sha1 e9006dc43cd11d5ba49a092a1dff31dc10700c28 )
+	rom ( name ax1202m01.ic11 size 16777216 crc dfc6fd67 md5 808fb1c02f022a50cf78844a790b176d sha1 f9d35b18a03d22f70feda42d314b0f9dd54eea55 )
+	rom ( name ax1203m01.ic12 size 16777216 crc bf623df9 md5 1ddc0b678452e04652429d640b351e20 sha1 8b9a8e8100ff6d2ce9a982ab8eb1d542f1c7af03 )
+	rom ( name ax1204m01.ic13 size 16777216 crc c80c3930 md5 72cd485c3bf51f11a866032be0726255 sha1 5c39fde36e2ebbfe72967d7d0202eb454a8d3bbe )
+	rom ( name ax1205m01.ic14 size 16777216 crc e99a269d md5 29cf48c31bfb1c0dce7053917c468788 sha1 a52148b82b0338b8bad8b52985302eaf81a4cfde )
+	rom ( name ax1206m01.ic15 size 16777216 crc 807ab795 md5 0250b706f955cdd81c4ba3a2f06c35a2 sha1 17c86b1a56333c05b68ff84f83e964d013c1819c )
+	rom ( name ax1207m01.ic16 size 16777216 crc 6636d1b8 md5 6a5e1717ea2e085e74db9acd1c2c0c91 sha1 9bd8fc114557f6fbe772f85eeb246f7336d4255e )
+	rom ( name ax1208m01.ic17 size 16777216 crc 38bda476 md5 8273c15a804b8a9c716b2071a57801c1 sha1 0234a6f5fbaf5e958b3ba0db311dff157f80addc )
+)
+
+game (
+	name "ggx15"
+	description "Guilty Gear X ver. 1.5"
+	year "2003"
+	manufacturer "Arc System Works / Sammy"
+	genre "Fighter"
+	rom ( name ax0801m01.ic11 size 16777216 crc 61879b2d md5 9b56bcf378aa62a0e5a779341ddab34e sha1 9592fbd979cef9d8f465cd92d0f00b9c13ecf7ba )
+	rom ( name ax0801p01.ic18 size 8388608 crc d920c6bb md5 58644f9689369ef00207deb6d4201d05 sha1 ab34bbef3c71396447bc5322d8e8786041fc832a )
+	rom ( name ax0802m01.ic12 size 16777216 crc c0ff124d md5 61c134d07b93d17aab4613912ee17ae5 sha1 dd403d10de2f097fbaa6b93bc311e2b9e893828d )
+	rom ( name ax0803m01.ic13 size 16777216 crc 4400c89a md5 bc683cadeaf25282e1cc4f78331715ba sha1 4e13536c01103ecfbfc9e3e33746ceae7a91a520 )
+	rom ( name ax0804m01.ic14 size 16777216 crc 70f58ab4 md5 ed9404f5cb1ea73e7ab0a4653836cc63 sha1 cd2def19bbad945c87567f8d28f3a2a179a7f7f6 )
+	rom ( name ax0805m01.ic15 size 16777216 crc 72740e45 md5 00e29ef46715d2fb3f13273599829d1d sha1 646eded89f10008c9176cd6772a8ac9d1bf4271a )
+	rom ( name ax0806m01.ic16 size 16777216 crc 3bf8ecba md5 72eb99701a8c1d5d8b3f40221b27bdcb sha1 43e7fbf21d8ee60bab72ce558640730fd9c3e3b8 )
+	rom ( name ax0807m01.ic17 size 16777216 crc e397dd79 md5 26a1f731452ecdc3f05bd87dcbb6db0f sha1 5fec32dc19dd71ef0d451f8058186f998015723b )
+)
+
+game (
+	name "kofnw"
+	description "The King of Fighters Neowave"
+	year "2004"
+	manufacturer "Sammy / SNK Playmore"
+	genre "Fighter"
+	rom ( name ax2201en_p01.ic18 size 8388608 crc 27aab918 md5 f628e796953ece97ffe2b1ce4db6cd27 sha1 41c5ddd8bd4c91481750606ab44aa115b5fe01d0 )
+	rom ( name ax2201m01.ic11 size 16777216 crc 22ea665b md5 80b3d85961113a33f564a23af5bb94ad sha1 292c92c9ae43eea2d1c27cedfb89c3956b8dea32 )
+	rom ( name ax2202m01.ic12 size 16777216 crc 7fad1bea md5 3d0031c77b10d583b9b7cc16cd410848 sha1 89f3f88af48973a4685955d86ef97a1487b8e7a8 )
+	rom ( name ax2203m01.ic13 size 16777216 crc 78986ca4 md5 af03951c589d396c50ecf8847d9e3f07 sha1 5a6c8c12955573f33361d2c6f20f85de35ac7bae )
+	rom ( name ax2204m01.ic14 size 16777216 crc 6ffbeb04 md5 3689f99294ec45e10dd5705a73b89ba4 sha1 975062cf364589dbdd5c5cb5ca945f76d87fc120 )
+	rom ( name ax2205m01.ic15 size 16777216 crc 2851b791 md5 0e6027105110225bb7e5d04b2c477b28 sha1 566ef95ea066b7bf548986085670242be217befc )
+	rom ( name ax2206m01.ic16 size 16777216 crc e53eb965 md5 25bcf16708465b51dc67214f7b19ab3a sha1 f50cd53a5859f081d8a278d24a519c9d9b49ab96 )
+)
+
+game (
+	name "kofxi"
+	description "The King of Fighters XI"
+	year "2005"
+	manufacturer "Sammy / SNK Playmore"
+	genre "Fighter"
+	rom ( name ax3201m01.mrom1 size 33554432 crc 7f9d6af9 md5 c9e59b03eafb1da2cc96d57f8c22ab64 sha1 001064ad1b8c3408efe799dc766c2728dc6512a9 )
+	rom ( name ax3201p01.fmem1 size 8388608 crc 6dbdd71b md5 36cde602c9bb8dc7b1e0749d663db8b9 sha1 cce3897b104f5d923d8136485fc80eb9717ff4b5 )
+	rom ( name ax3202m01.mrom2 size 33554432 crc 1ae40afa md5 ab3941b4ba3a142b6813c3386a69eb46 sha1 9ee7957c86cc3a71e6971ddcd906a82c5b1e16f1 )
+	rom ( name ax3203m01.mrom3 size 33554432 crc 8c5e3bfd md5 a29a3d8ea095a2e03da2511cd2a483d0 sha1 b5443e2a1b88642cc57c5287a3122376c2d48de9 )
+	rom ( name ax3204m01.mrom4 size 33554432 crc ba97f80c md5 595dafbfd8c7baac14b1caffd4915883 sha1 36f672fe833e13f0bab036b02c39123066327e20 )
+	rom ( name ax3205m01.mrom5 size 33554432 crc 3c747067 md5 70bf8d4c68d859bb20afa75011ab6f0f sha1 54b7ff73d618e2e4e40c125c6cfe99016e69ad1a )
+	rom ( name ax3206m01.mrom6 size 33554432 crc cb81e5f5 md5 a36ffa2e7f41a9a54f9b5a099e0e90d9 sha1 07faee02a58ac9c600ab3cdd525d22c16b35222d )
+	rom ( name ax3207m01.mrom7 size 33554432 crc 164f6329 md5 4cb6df02d22523830178bb85b42f7249 sha1 a72c8cbe4ac7b98edda3d4434f6c81a370b8c39b )
+)
+
+game (
+	name "kov7sprt"
+	description "Knights of Valour - The Seven Spirits"
+	year "2003"
+	manufacturer "IGS / Sammy"
+	genre "Fighter"
+	rom ( name ax1301m01.ic11 size 16777216 crc 58ae7ca1 md5 3d1be831a49735200a188093c31a2565 sha1 e91975697b797ea05488ace649cbb9964b4cd500 )
+	rom ( name ax1301m02.ic12 size 16777216 crc 871ea03f md5 03207617d9061284bcae64de0cfb2b6a sha1 6806910832ca271a9240aca8e91279556e5b0cb7 )
+	rom ( name ax1301m03.ic13 size 16777216 crc abc328bc md5 07f72d0bf27e14eb2f16546aace1d583 sha1 d9271d4e5abe76d31de0f60a5c106260338d42e9 )
+	rom ( name ax1301m04.ic14 size 16777216 crc 25a176d1 md5 2dc4f5a3996f76d8cde99751239fc5a2 sha1 6d815bf6acb645fead060733660e24fb0d44282d )
+	rom ( name ax1301m05.ic15 size 16777216 crc e6573a93 md5 a5de7de9469b5c47b4939aa74789ba2b sha1 0666e52d0088263f28938e4c8aae201e604ec1f2 )
+	rom ( name ax1301m06.ic16 size 16777216 crc cb8cacb4 md5 cdae3a82a3ef1ed70f4f15c9faa3f241 sha1 5d008e8a934451b9bfa33fedfd492c86d9226ef5 )
+	rom ( name ax1301m07.ic17 size 16777216 crc 0ca92213 md5 e30ac08b9418c22de1a744b8b08ba658 sha1 115c50fa55e6de3439de23e74621695510c6a7ba )
+	rom ( name ax1301p01.ic18 size 8388608 crc 6833a334 md5 ec694a4a471c2aa195db5a9b67c74b37 sha1 646aaa578e09ad23bc9c7f4fbdfb3c1486916fd3 )
+)
+
+game (
+	name "maxspeed"
+	description "Maximum Speed"
+	year "2003"
+	manufacturer "SIMS / Sammy"
+	genre "Driving"
+	rom ( name ax0501m01.ic11 size 16777216 crc 4a847a59 md5 3caf268181b8a083974b6443ea2da542 sha1 7808bcd357b85861082b426dbe34a20ae7016f6a )
+	rom ( name ax0501p01.ic18 size 8388608 crc e1651867 md5 2e47814f6d0093c4968da2df44941642 sha1 49caf82f4b111da312b14bb0a9c31e3732b4b24e )
+	rom ( name ax0502m01.ic12 size 16777216 crc 2580237f md5 08bd4b5dee824d3511b042da0ce6394d sha1 2e92c940f95edae33d6a7e8a071544a9083a0fd6 )
+	rom ( name ax0503m01.ic13 size 16777216 crc e5a3766b md5 396c0bdcb5e67040a415b38712d418f0 sha1 1fe6e072adad27ac43c0bff04e3c448678aabc18 )
+	rom ( name ax0504m01.ic14 size 16777216 crc 7955b55a md5 54d77a7775a7f520b2ee812c52cd09c1 sha1 927f58d6961e702c2a8afce79bac5e5cff3dfed6 )
+	rom ( name ax0505m01.ic15 size 16777216 crc e8ccc660 md5 6dfddc52cab3574fe3b123568faa7bbc sha1 a5f414f200a0d41e958430d0fc2d4e1fda1cc67c )
+)
+
+game (
+	name "mslug6"
+	description "Metal Slug 6"
+	year "2006"
+	manufacturer "Sega / SNK Playmore"
+	genre "Platform"
+	rom ( name ax3001m01.mrom1 size 33554432 crc e56417ee md5 7467f89ffc07aaa5dcc0e74982b52b37 sha1 27692ad5c1093aff0973d2aafd01a5e30c7bfbbe )
+	rom ( name ax3001p01.fmem1 size 8388608 crc af67dbce md5 06d82c12c4da1783bbb5eb277f991e10 sha1 5aba108caf3e4ced6994bc26e752d4e225c231e8 )
+	rom ( name ax3002m01.mrom2 size 33554432 crc 1be3bbc1 md5 d6b10f737e9ce641ef5880983b86f903 sha1 d75ce5c855c9c4eeacdbf84d440c73a94de060fe )
+	rom ( name ax3003m01.mrom3 size 33554432 crc 4fe37370 md5 d225f5705c512db4551a58b917126212 sha1 85d51db94c3e34265e37b636d6545ed2801ba5a6 )
+	rom ( name ax3004m01.mrom4 size 33554432 crc 2f4c4c6f md5 7f5eb0fb11e181cd2997fdc363ad6d5d sha1 5815c28fdaf0429003986e725c0015fe4c08721f )
+)
+
+game (
+	name "ngbc"
+	description "NeoGeo Battle Coliseum"
+	year "2005"
+	manufacturer "Sammy / SNK Playmore"
+	genre "Fighter"
+	rom ( name ax3301en_p01.fmem1 size 8388608 crc f7e24e67 md5 e20a93036fb8649c7a218cfa9615fc5b sha1 8eef26d44b294faa509304b1b04f4d801337bc99 )
+	rom ( name ax3301m01.mrom1 size 33554432 crc e6013de9 md5 39910bfd03d97461155a40f88bb5f606 sha1 ccbc7c2e76153348646d75938d5c008dc80df17d )
+	rom ( name ax3302m01.mrom2 size 33554432 crc f7cfef6c md5 fc638848a2918a8a8b1d2bfa2592bf05 sha1 c9e6231499a9c9c8650d9e61f34ff1fcce8d442c )
+	rom ( name ax3303m01.mrom3 size 33554432 crc 0cdf8647 md5 9a69ddd4e2e92ffce5633abe84ede76a sha1 0423f96842bef2c2ff454318dc6960b5052c0551 )
+	rom ( name ax3304m01.mrom4 size 33554432 crc 2f031db0 md5 232e61c7e77152cf5982ee535287dd0b sha1 3214735f04fadf160137f0585bfc1a27eeecfac6 )
+	rom ( name ax3305m01.mrom5 size 33554432 crc f6668aaa md5 df3d9ffb6bdfa9f20a055be2c01dc81f sha1 6a78f8f0c7d7a71854ff87329290d38970cfb476 )
+	rom ( name ax3306m01.mrom6 size 33554432 crc 5cf32fbd md5 8f3fc5cc0ffb076aba78c16932a053c4 sha1 b6ae0abe5791b3d6f8db07b8c8ca22219a153801 )
+	rom ( name ax3307m01.mrom7 size 33554432 crc 26d9da53 md5 5c21da53768c94a611d6241dbfa1db0b sha1 0015b4be670005a451274de68279b4302fc42a97 )
+)
+
+game (
+	name "rangrmsn"
+	description "Ranger Mission"
+	year "2004"
+	manufacturer "RIZ Inc./ Sammy"
+	genre "Shooter"
+	rom ( name ax1601m01.ic11 size 16777216 crc f34eed33 md5 cfca6d39113604ea6ac872887546c4b3 sha1 1c171fb8aa95877f81ed78652d4a9ff80f7713ff )
+	rom ( name ax1601p01.ic18 size 8388608 crc 00a74fbb md5 942214d5e5b720f7db29e06744e3228f sha1 57cc1eedd22d1f553956a825e69a597309ee2bef )
+	rom ( name ax1602m01.ic12 size 16777216 crc a7d59efb md5 6d946eb1627f5538b635258ddd8fb4e4 sha1 a40938ce1399babefc8cf02f579a86cf08e211ef )
+	rom ( name ax1603m01.ic13 size 16777216 crc 7c0aa241 md5 87afe8fc0b53c6d1789f92baa3081800 sha1 3e0e5ff3307dcfa52998fb9b4b14bf54bd056a99 )
+	rom ( name ax1604m01.ic14 size 16777216 crc d2369144 md5 185172b5f6da6300195739b4890cce09 sha1 da1eae9957d27d1682c4191780cf51b32dfe6659 )
+	rom ( name ax1605m01.ic15 size 16777216 crc 0c11c1f9 md5 a830c842076c97d41fff372f122c6461 sha1 0585db60618c5b97f9b7c203baf7e5ac90883ca6 )
+)
+
+game (
+	name "rumblef"
+	description "The Rumble Fish"
+	year "2004"
+	manufacturer "Sammy / Dimps"
+	genre "Fighter"
+	rom ( name ax1801m01.ic11 size 16777216 crc c38aa61c md5 60b8c96a6b29c04fae4bf2af25c5db60 sha1 e2f688a0aa8b0119f5fd3d53c8904e035d43a4b1 )
+	rom ( name ax1801p01.ic18 size 8388608 crc 2f7fb163 md5 8d6621766e778da50e83ad9f4aa9b3c5 sha1 bf819d798d9a3a7bc754e111a3f53b9db6d6042a )
+	rom ( name ax1802m01.ic12 size 16777216 crc 72e0ebc8 md5 df8f311ba0ffc44cd1eb74bad09ddb6d sha1 e85300a405ea14c4c9d857eb9685c93faaca1d56 )
+	rom ( name ax1803m01.ic13 size 16777216 crc d0f59d98 md5 b11c1c128be71ee784132534b5e39009 sha1 b854796087e9f76a13a21da8249f7224e451e129 )
+	rom ( name ax1804m01.ic14 size 16777216 crc 15595cba md5 9c41e0e5827880986a38201fbff1f898 sha1 8dd06d1f986cd21a58d20b662b11ed7ba8a6ff7a )
+	rom ( name ax1805m01.ic15 size 16777216 crc 3d3f8e0d md5 8526545b396155698325b802bb17aff4 sha1 364a0bda890722b9fb72171f96c742b8f3fef23e )
+	rom ( name ax1806m01.ic16 size 16777216 crc ac2751bb md5 bbf3b7740bd728030a54f542d98a7213 sha1 5070fa12bf109ab87e8f7ea46ac4ae78a73105da )
+	rom ( name ax1807m01.ic17 size 16777216 crc 3b2fbdb0 md5 7c2b61543e479451a615e2cdc02b00e4 sha1 f9f7e06785d3a07282247aaedd9999aa7c2670b9 )
+)
+
+game (
+	name "rumblef2"
+	description "The Rumble Fish 2"
+	year "2005"
+	manufacturer "Sammy / Dimps"
+	genre "Fighter"
+	rom ( name ax3401m01.mrom1 size 33554432 crc 60894d4c md5 9267524776e9186532dff90b145ff132 sha1 5b21af3c7c82d4d64bfd8498c26283111ada1298 )
+	rom ( name ax3401p01.fmem1 size 8388608 crc a33601cf md5 0c0bddd3cf6865dfae5d21506aff7717 sha1 2dd60a9c3a2517f2257ab69288fa95645de133fa )
+	rom ( name ax3402m01.mrom2 size 33554432 crc e4224cc9 md5 b0e3211271774ad88e2baa094a81a448 sha1 dcab06fcf48cda286f93d2b37f03a83abf3230cb )
+	rom ( name ax3403m01.mrom3 size 33554432 crc 081c0edb md5 4fd2e9c79de6766fa77ba3f48bfe6410 sha1 63a3f1b5f9d7ca4367868c492236406f23996cc3 )
+	rom ( name ax3404m01.mrom4 size 33554432 crc a426b443 md5 89b7c1fd9ae699e0d887b5c0e2ae3fee sha1 617aab42e432a80b0663281fb7faa6c14ef4f149 )
+	rom ( name ax3405m01.mrom5 size 33554432 crc 4766ce56 md5 f06d137ce45b9d62aba8f04edfd2629e sha1 349b82013a75905ae5520b14a87702c9038a5def )
+)
+
+game (
+	name "salmankt"
+	description "Net@Select: Salaryman Kintaro"
+	year "2004"
+	manufacturer "Yuki Enterprise / Sammy"
+	genre "MultiGame"
+	rom ( name ax1401m01.ic11 size 16777216 crc fd7af845 md5 abb6251519c8444fc1065cb6110b84b5 sha1 0c8f5a91662e46d5c187a0758af95082183cdf69 )
+	rom ( name ax1401p01.ic18 size 8388608 crc 28d779e0 md5 0dfa1165573b397d817bd0cf669e1993 sha1 dab785a595de5f474c18c713e672949176a5b1b5 )
+	rom ( name ax1402m01.ic12 size 16777216 crc f6006f85 md5 651aa91f593ea3b6feb76e585bb24ec7 sha1 9275603673c663f73b977d0d14ed1d2a7002c627 )
+	rom ( name ax1403m01.ic13 size 16777216 crc 074f7c4b md5 e7c49eb7df265b842e97114533462a5f sha1 4955e4f333d15d5d9cc69bb9658f29a37e912012 )
+	rom ( name ax1404m01.ic14 size 16777216 crc af4e3829 md5 6df3be145b819f4ed07bb8e7232876d7 sha1 18d9e8a8d8e930ad697b686a98f31ea175f5fd4a )
+	rom ( name ax1405m01.ic15 size 16777216 crc b548446f md5 c66ddd242bf59dc192fa7bce53f35697 sha1 8b4661e601e36c067dff2530aff4f7ea76e1c21e )
+	rom ( name ax1406m01.ic16 size 16777216 crc 437673e6 md5 84eae6197ba3822540b9baf2a9f9322d sha1 66f7e5f246ebbb1bdbf074da41ec16bf32720a82 )
+	rom ( name ax1407m01.ic17 size 16777216 crc 6b6acc0a md5 906d2cd77e4b09e111ec6bd1d8342a95 sha1 a8c692c875271a0806460caa79c67fd756231273 )
+)
+
+game (
+	name "samsptk"
+	description "Samurai Spirits Tenkaichi Kenkakuden"
+	year "2005"
+	manufacturer "Sammy / SNK Playmore"
+	genre "Fighter"
+	rom ( name ax2901m01.mrom1 size 33554432 crc dbbbd90d md5 6ced5b287fe86f210fb7d911d7c35715 sha1 102ee0b249a3e0ca2f659b6c515816c522ad78d0 )
+	rom ( name ax2901p01.fmem1 size 8388608 crc 58e0030b md5 f30a528ffa1110175e19a2c4f87fe9f4 sha1 ed8a66833beeb56d83770123eff28df0f25221d1 )
+	rom ( name ax2902m01.mrom2 size 33554432 crc a3bd7890 md5 c29387ba868560d9a286fd617366623e sha1 9b8d934d6ebc3ef688cd8a6de47657a0663fea10 )
+	rom ( name ax2903m01.mrom3 size 33554432 crc 56f50fdd md5 af0ccd286d30ea5323e96cd46fd650ec sha1 8a5a4a99108c0279056998046c7b332e80121dee )
+	rom ( name ax2904m01.mrom4 size 33554432 crc 8a3ae175 md5 7c804bc49042ee8749c429ff376bf262 sha1 966f527a92e24c8eb770344697f2edf6140cf971 )
+	rom ( name ax2905m01.mrom5 size 33554432 crc 429877ba md5 e98722a10da8385776dbcd11fa3a15ca sha1 88e1f3bc682b18d331e328ef8754065109cf9bda )
+	rom ( name ax2906m01.mrom6 size 33554432 crc cb95298d md5 2e3123441a314506e7e24e20a288551f sha1 5fb5d5a0d6801df61101a1b23de0c14ff29ef654 )
+	rom ( name ax2907m01.mrom7 size 33554432 crc 48015081 md5 f2351736159e329d736fb8a4eb64ae63 sha1 3c0a0a6dc9ab7bf889579477699e612c3092f9bf )
+)
+
+game (
+	name "sprtshot"
+	description "Sports Shooting USA"
+	year "2003"
+	manufacturer "Sammy USA"
+	genre "Shooter"
+	rom ( name ax0101m01.ic11 size 16777216 crc 1e39184d md5 72f185c419bfc34efd31173d053a7e39 sha1 663e0cb9f43a0f89d9841e04b3d009f6c5e88d5e )
+	rom ( name ax0101p01.ic18 size 8388608 crc b3642b5d md5 3ccb32dfd28cd44d5ffdfbdb024881bc sha1 85eabd9551aefb825ae8eb6422092fb5a58d60f6 )
+	rom ( name ax0102m01.ic12 size 16777216 crc 700764d1 md5 04bc0be892ef35ff25335f1f8e5549b4 sha1 310f1606f7bbed1012c119f1ef5d89d231d8489e )
+	rom ( name ax0103m01.ic13 size 16777216 crc 6144e7a8 md5 a70120f9f474b2ec0c540ce156fde9f0 sha1 4d4341082f008dfd93ef5bf32a44c80869ef02a8 )
+	rom ( name ax0104m01.ic14 size 16777216 crc ccb72150 md5 fdfc26a4b31a3160871dcf97ac2b7eef sha1 a1032d321c27f9ff43da41f20b8687bf1958ddc9 )
+)
+
+game (
+	name "sushibar"
+	description "Sushi Bar"
+	year "2003"
+	manufacturer "Sammy"
+	genre "Puzzle"
+	rom ( name ic12 size 8388608 crc 06a2ed58 md5 cf2bbf9d22bfa89a0c7b317009a7525c sha1 a807fa8c1c83cb8b18595c210479d5f1dd6be4ca )
+	rom ( name ic14 size 8388608 crc 4860f944 md5 5d4cf840c50a8458b0fa3e72088c0b3d sha1 55c75630c33cba35512a1349650f28fd56757f9f )
+	rom ( name ic15 size 8388608 crc 7113506c md5 5623418f2d9cba873b800e380b62c20f sha1 0548d67b3a1c0b8f17fcafd4fe5c1e6b0e91b6e7 )
+	rom ( name ic16 size 8388608 crc 77e8e39e md5 0193da33dcd0d9cd222a246a4c9659e3 sha1 1286010cdba5c3c0ad5cbe19718fd0f8e5f579db )
+	rom ( name ic17 size 8388608 crc 0eba54ea md5 e1db6572f7f872db8173929fe3e8ff0e sha1 51842ec326a5ba65bd280e652e7d9b395a2586c6 )
+	rom ( name ic18 size 8388608 crc b9957c76 md5 23e97f298a8bac65c8b834c51a1e6bce sha1 6d72c7ac8e1e0cbed7eb01b66f71bedf46a833e1 )
+)
+
+game (
+	name "vfurlong"
+	description "Net@Select: Horse Racing - Victory Furlong"
+	year "2005"
+	manufacturer "Progress / Sammy"
+	genre "Sports"
+	rom ( name ax2001m01.ic11 size 16777216 crc 64460b24 md5 16a34ede4c7a7909e7d246fdb0187725 sha1 044857d6593897d303622e005a63ca7b3acd7453 )
+	rom ( name ax2001p01.ic18 size 8388608 crc 17ea9aa9 md5 174be7ae11ae628515d367fb45910016 sha1 c68500e9b3407a9d4b20f2678718ce475f179f7d )
+	rom ( name ax2001p01_alt.ic18 size 8388608 crc 845399dd md5 e86ae88acdd3ec9ae90cdbdb033e0159 sha1 21565b13292cead2b532861d2998e381df2672d5 )
+	rom ( name ax2002m01.ic12 size 16777216 crc d4da357f md5 8f570883548a84691f00b9184a3f083f sha1 c462cddec9a369a1a5595676de76499d56683ea9 )
+	rom ( name ax2003m01.ic13 size 16777216 crc aa1e1246 md5 7e995e6302a5cf48d7d2362b9c253c9c sha1 788cc9c070f82aeff1704361e3c72116fd5c4c9d )
+	rom ( name ax2004m01.ic14 size 16777216 crc 4d555d7c md5 e1094abea5ca38103368271fe783893c sha1 a5eccc920bdb7ad9cf57c0e1ef6a905c6b9eee45 )
+	rom ( name ax2005m01.ic15 size 16777216 crc 785208e2 md5 1398df2e220d677fbeef0ac57889377e sha1 6ba5bd3901c5b1d71abcc8d833a011bd4abae6b6 )
+	rom ( name ax2006m01.ic16 size 16777216 crc 8134ec55 md5 cee7349ce72ff513ef683a9c784d7680 sha1 843e473d4f99237ded641cce9515b7802cfe3742 )
+	rom ( name ax2007m01.ic17 size 16777216 crc d0557e8a md5 b60a53e4c7debbcd7fa1bd496a92488f sha1 df8057597eb690bd18c5d26736f5d4f86e3b1225 )
+)
+
+game (
+	name "waidrive"
+	description "WaiWai Drive"
+	year "2005"
+	manufacturer "MOSS / Sammy"
+	genre "Driving"
+	rom ( name u1 size 16777216 crc b3c1c3bb md5 569eee3021891de001a601fdf31e8022 sha1 bda9b1e214a733cb1716ab130ecd986709ac136e )
+	rom ( name u3 size 16777216 crc 7acfb499 md5 4a00a6250f73bd338eeb0b54cf23dbb3 sha1 002a0a84dd7f55e1630e1ec2530d0760b0c12b4e )
+)
+
+game (
+	name "xtrmhnt2"
+	description "Extreme Hunting 2"
+	year "2006"
+	manufacturer "Sega"
+	genre "Shooter"
+	rom ( name 610-0752.u1 size 16777216 crc 3086bc47 md5 e0e602298a8e80e637a1e0e08d7f01b8 sha1 eb7b04db90d296985528f0cfdd4545f184c40b64 )
+	rom ( name 610-0752.u14 size 16777216 crc ce83bcc7 md5 37e7a916e9231c13f9284573f8bd9d0a sha1 e2d324a5a7eacbec7b0df9a4b9e276521bb9ab80 )
+	rom ( name 610-0752.u15 size 16777216 crc 864a6342 md5 edbc109484da0e165dfe64a1bdf2a49a sha1 fb97532d5dd00f8520fdaf68dfcd1ea627bdf90a )
+	rom ( name 610-0752.u16 size 16777216 crc 8ac71c76 md5 442a28829985a0e3f8842906d5c1f7b6 sha1 080e41e633bf082fc536781541c6031d1ac81939 )
+	rom ( name 610-0752.u17 size 16777216 crc a79fb1fa md5 11ba564a76cd8c5de3a83d7fc82cda46 sha1 f75c5b574fd79677b926c595b369e95605a3c848 )
+	rom ( name 610-0752.u2 size 16777216 crc d3a88b31 md5 c7d9c6bc91559ef420c1cce163aedba7 sha1 ccf14367e4e7efbc2cc835f3b001fd6d64302a5e )
+	rom ( name 610-0752.u3 size 16777216 crc bab6182e md5 84180cc54d9132feca4c39015a1cc45e sha1 4d25256c81941316887cbb4524a203922f5b7104 )
+	rom ( name 610-0752.u4 size 16777216 crc 9787f145 md5 ae6604fa5e71bf238e3ea42456806bfc sha1 8445ede0477f70fbdc113810b80356945ce498d2 )
+	rom ( name flash128.ic4s size 16777216 crc 866ed675 md5 dd4c637a122df09d09a622b76718e497 sha1 2c4c06935b7ab1876e640cede51713b841833567 )
+	rom ( name fpr-24330a.ic2 size 4194304 crc 8d89877e md5 d400224f920ce92f98aeb933c8b8af71 sha1 6caafc49114eb0358e217bc2d1a3ab58a93c8d19 )
+)
+
+game (
+	name "xtrmhunt"
+	description "Extreme Hunting"
+	year "2004"
+	manufacturer "Sammy"
+	genre "Shooter"
+	rom ( name ax2401m01.ic11 size 16777216 crc 76dbc286 md5 f66db6114a81d9d0f9be7139c5dcd64e sha1 8f36ca94b8e67c76e0f90b21debc5ac7890f0da1 )
+	rom ( name ax2401p01.ic18 size 8388608 crc 8e2a11f5 md5 29f64bfbdb1a588fce642b7e251885a7 sha1 b5106314fb8d4483254e83ac3982039bb60a78e8 )
+	rom ( name ax2402m01.ic12 size 16777216 crc cd590ea2 md5 0200f1d1b615ed5f6f0063bef8566aca sha1 ee5e38bf68e95da665be478ebba9cc5ffed52bb7 )
+	rom ( name ax2403m01.ic13 size 16777216 crc 06f62eb5 md5 4faabc9d5c23f52ef1b814f8ba158729 sha1 f7e8d1dda6bb59ca2bc7cfa1105889b9e8e6d55d )
+	rom ( name ax2404m01.ic14 size 16777216 crc 759ef5cb md5 f82f106c1ee7ce3ba132764f931cba1b sha1 27ac2d12c6fb358b3d631c017c7b693e5ad95fd7 )
+	rom ( name ax2405m01.ic15 size 16777216 crc 940d77f1 md5 e8604c2c965750204b8c112cbba54c4a sha1 eefdfcb92873032dc7d9ff9310bf5ed715c8bf4f )
+	rom ( name ax2406m01.ic16 size 16777216 crc cbcf2c5d md5 8fdf8019b2a5bf0a34c4e9b68593f3f9 sha1 61362fabcbb3bfc01c996748a7ca65f8a0e02f2f )
+)

--- a/dat/Sinclair - ZX 81.dat
+++ b/dat/Sinclair - ZX 81.dat
@@ -1,3149 +1,7303 @@
 clrmamepro (
 	name "Sinclair - ZX 81"
 	description "Sinclair - ZX 81"
-	version "2016.5.5"
+	version "2021.9.6"
 	author ""
-	comment "extracted from http://www.zx81stuff.org.uk, also with games from http://www.bobs-stuff.co.uk/zx81.html"
+	comment "Converted from Sinclair ZX81 - Games - [P] (TOSEC-v2021-07-25_CM)"
 )
+
 game (
-	name "1K Games (Sinclair Research)"
-	description "1K Games (Sinclair Research)"
-	manufacturer "Artic"
-	rom ( name "1KGames.tzx" size 8576 crc 2648f563 md5 915febe842110ada339f53db2a822812 sha1 11562494bb40cef9bcea606b1bd2ad375f47ef75 )
+	name "2D Labyrinth (19xx)(-)"
+	description "2D Labyrinth (19xx)(-)"
+	rom ( name "2D Labyrinth (19xx)(-).p" size 1378 crc 8b2bfb37 md5 80f9704f7d6ca109b1e44f78ccf8bd02 sha1 197ae77428df30a3b7b69fa87c38ce72c7bc5cea )
 )
+
 game (
-	name "1K Games Pack (Artic)"
-	description "1K Games Pack (Artic)"
-	manufacturer "Artic"
-	rom ( name "1KGames.tzx" size 8576 crc 2648f563 md5 915febe842110ada339f53db2a822812 sha1 11562494bb40cef9bcea606b1bd2ad375f47ef75 )
+	name "2D Labyrinth (19xx)(-)[a]"
+	description "2D Labyrinth (19xx)(-)[a]"
+	rom ( name "2D Labyrinth (19xx)(-)[a].p" size 1433 crc 5d6cc3f4 md5 2b8faf0a2450632917a2ed1077b8ee91 sha1 43d4f50e4489e91bdc28fa303aa13aa539e791f1 )
 )
+
 game (
-	name "1K ZX Chess (Artic)"
-	description "1K ZX Chess (Artic)"
-	manufacturer "Artic"
-	rom ( name "1KZXChess(Artic).A.ChessQueen.tzx" size 1165 crc 9c750652 md5 d6694fd23f6a9aa6ff644a0d7417332c sha1 ed848d9bd69311536da64c0414f7ae2ec9316622 )
-	rom ( name "chessqueen.p" size 941 crc 1a82385a md5 5292e4cac70342eed1b350846db0a90f sha1 dfad4c2de72aa4900367dbe92271f126ea192804 )
+	name "3D 3D (1981)(DK'Tronics)"
+	description "3D 3D (1981)(DK'Tronics)"
+	rom ( name "3D 3D (1981)(DK'Tronics).p" size 12366 crc 572b34bb md5 d281834dd53609d4f977086a2a5d7a65 sha1 738ad81449bfa32fd05bc0da3a7035f7c9a9728d )
 )
+
 game (
-	name "1K ZX Chess (Sinclair Research)"
-	description "1K ZX Chess (Sinclair Research)"
-	year 1982
-	manufacturer "Artic"
-	rom ( name "1KZXChess.tzx" size 2223 crc 2fc225b9 md5 ddf8021eef88111be73fbccf8392439e sha1 055730a794e227e02d6fa780f1bb82a68c1b86bf )
+	name "3D Defender (19xx)(J.K. Greye Software)"
+	description "3D Defender (19xx)(J.K. Greye Software)"
+	rom ( name "3D Defender (19xx)(J.K. Greye Software).p" size 11857 crc d9c0479c md5 1da932d29f72bcd722ac2cb83945d562 sha1 47297536f28f61708649c7abe0a1d2fbca9def12 )
 )
+
 game (
-	name "2K Games Pack (International Publishing and Software Inc.)"
-	description "2K Games Pack (International Publishing and Software Inc.)"
-	year 1982
-	rom ( name "2KGamesPack(IPS).tzx" size 6977 crc c1893b03 md5 25ebafa20015b01a383b70c19394e307 sha1 b33fdc40eb4631617c2687795de02904c92255c3 )
+	name "3D Defender (19xx)(J.K. Greye Software)(nl)"
+	description "3D Defender (19xx)(J.K. Greye Software)(nl)"
+	rom ( name "3D Defender (19xx)(J.K. Greye Software)(nl).p" size 11893 crc 913e624b md5 45d9059f6fce222575bd07fe7bef6a70 sha1 73dde0e2f6e2b5fc684ab89cb8f0e862f4e8fc84 )
 )
+
 game (
-	name "3D Defender (J. K. Greye)"
-	description "3D Defender (J. K. Greye)"
-	year 1981
-	manufacturer "J. K. Greye"
-	rom ( name "3ddefender.p" size 11857 crc 4f97cbc6 md5 b344194f7456805b053f3e6786cfcdd5 sha1 bbaf7cd6f122f2508efecca8a8b2e1006b728752 )
-	rom ( name "3DDefender.tzx" size 12095 crc a9e69d1c md5 cd64e962bfcc000a9e3bd8cdb6e1c3e1 sha1 7c6b0a1fdef5c43aeed21f9d98f4e0c9837214cf )
+	name "3D Defender (19xx)(J.K. Greye Software)(nl)[a]"
+	description "3D Defender (19xx)(J.K. Greye Software)(nl)[a]"
+	rom ( name "3D Defender (19xx)(J.K. Greye Software)(nl)[a].p" size 11857 crc 6dbc99ff md5 90952fb3f16f84c5b70fbdf66e046b18 sha1 c14897aa16fc09c1ea04df1dd14b20bb5b00b8b1 )
 )
+
 game (
-	name "3D Defender (New Generation)"
-	description "3D Defender (New Generation)"
-	year 1981
-	manufacturer "M. E. Evans"
-	rom ( name "3ddefender(ngs).p" size 11857 crc eb8178fd md5 57e5bdeaef06c83ae246bf132618a5ff sha1 1c9205c36224875446de0dc3abf0907200b7b993 )
-	rom ( name "3DDefender(NGS).tzx" size 12095 crc 0df02e27 md5 b2fe247ea9c9e64ba9fe419c96c9fc9c sha1 6aa9a12e6256bc2657326361c636571faf2cfb83 )
+	name "3D Defender (19xx)(J.K. Greye Software)[a]"
+	description "3D Defender (19xx)(J.K. Greye Software)[a]"
+	rom ( name "3D Defender (19xx)(J.K. Greye Software)[a].p" size 11857 crc 46df0343 md5 6095d19b9b4fcfccf4e70a7e289d678c sha1 d04c0bcea590bac85bcb353e7e5485522887b4a5 )
 )
+
 game (
-	name "3D Monster Maze (J. K. Greye)"
-	description "3D Monster Maze (J. K. Greye)"
-	year 1981
-	manufacturer "J. K. Greye"
-	rom ( name "3dmonstermaze.p" size 10552 crc 8f782725 md5 4e344f938d5600d81b7b0fde756abe7e sha1 cb254b2ce2012140211b641deeaf57177757ac25 )
-	rom ( name "3DMonsterMaze.tzx" size 10798 crc 436d8b0e md5 c38f7c7e81c6e781a9d665a4e468c6ef sha1 c6c141057d870b114d8844bb7578040ad8c5b151 )
+	name "3D Escape (19xx)(-)"
+	description "3D Escape (19xx)(-)"
+	rom ( name "3D Escape (19xx)(-).p" size 9616 crc 6c8079cf md5 f68ab71a2cc3e17404b6dc08c0d18e3c sha1 db4bf2e2e0f4bb7fb099d2c7a179e1495f5a675f )
 )
+
 game (
-	name "3D Monster Maze (New Generation)"
-	description "3D Monster Maze (New Generation)"
-	year 1982
-	manufacturer "J. K. Greye"
-	rom ( name "3dmonstermaze(ngs).p" size 10552 crc f4ce6079 md5 9cd5af6a9a9c61b2ea272f4f35058928 sha1 15093d2b89b5c5c4c0454af917be5554454864a7 )
-	rom ( name "3DMonsterMaze(NGS).tzx" size 10798 crc 38dbcc52 md5 5912b1261d2ed44f40d80bd6ca813405 sha1 2b0e9cd691979154c2d75ac76f93be076aab3423 )
+	name "3D Grand Prix (1982)(DK'Tronics)"
+	description "3D Grand Prix (1982)(DK'Tronics)"
+	rom ( name "3D Grand Prix (1982)(DK'Tronics).p" size 13184 crc b6c9da85 md5 1995913c75f3015c3b190ccf0b4057fc sha1 eea020b34112c1d912c4609083226caaefa4b2ca )
 )
+
 game (
-	name "5-2K Family Pak (Timeworks)"
-	description "5-2K Family Pak (Timeworks)"
-	manufacturer "Timeworks"
-	rom ( name "52KFamilyPak.tzx" size 7846 crc fa438ced md5 e0b79ae2de178ddab3c3ee2691c68f78 sha1 1d613e0ab6462ab52c757aa1b6b6262311eb6c8e )
+	name "3D Grand Prix (1982)(DK'Tronics)[a2]"
+	description "3D Grand Prix (1982)(DK'Tronics)[a2]"
+	rom ( name "3D Grand Prix (1982)(DK'Tronics)[a2].p" size 14007 crc 14eacddf md5 d88bb474b8d07e9ff2c1f7ddee91d230 sha1 283f87e4b7e516b50210c059bf3b22a9f202f246 )
 )
+
 game (
-	name "8 Programs by GM4IHJ (Amsat-UK Software Service)"
-	description "8 Programs by GM4IHJ (Amsat-UK Software Service)"
-	manufacturer "GM4IHJ (J Branegan)"
-	rom ( name "8Programs.tzx" size 56578 crc bb788390 md5 4cf8b801597ae314132d8de1d5dc5d9b sha1 e2185c5962d8c89bb020028a22e25470405bef0f )
+	name "3D Grand Prix (1982)(DK'Tronics)[a]"
+	description "3D Grand Prix (1982)(DK'Tronics)[a]"
+	rom ( name "3D Grand Prix (1982)(DK'Tronics)[a].p" size 13197 crc 55a1b582 md5 d133be4773727d3c962fc8a7834481ca sha1 b574f3799be62cf13151b063636bfa22f4545185 )
 )
+
 game (
-	name "10 Games (J. K. Greye)"
-	description "10 Games (J. K. Greye)"
-	year 1981
-	manufacturer "J. K. Greye"
-	rom ( name "10Games.tzx" size 7636 crc 141cddd1 md5 02eb203cd57645589a158495c2f7cebb sha1 3a776f7dbf4fd169572aad5b775b4ca27c61222a )
+	name "3D Highway Race (19xx)(Tarusoft)(de)"
+	description "3D Highway Race (19xx)(Tarusoft)(de)"
+	rom ( name "3D Highway Race (19xx)(Tarusoft)(de).p" size 4409 crc 35b726fc md5 0fc57fedd7bdad8ea137b28f4704afaf sha1 bd4963d17e38035d8430464833150ea8eb054bef )
 )
+
 game (
-	name "Admiral Graf Spee (Temptation Software)"
-	description "Admiral Graf Spee (Temptation Software)"
-	manufacturer "Simon Mansfield"
-	rom ( name "AdmiralGrafSpee.tzx" size 17024 crc c583887e md5 3bd4fac61bdb6fc0a1bbc04ec7270df9 sha1 741a2b608801fc12705535fa88f2d895af486e80 )
+	name "3D Highway Race (19xx)(Tarusoft)(nl)"
+	description "3D Highway Race (19xx)(Tarusoft)(nl)"
+	rom ( name "3D Highway Race (19xx)(Tarusoft)(nl).p" size 4700 crc 4fb56a66 md5 bc9b3ef113bd5af684f65cb520a62994 sha1 c0a8cc6146b14a1264b205c793d72bafe9311ff3 )
 )
+
 game (
-	name "Advanced Budget Manager (Softsync)"
-	description "Advanced Budget Manager (Softsync)"
-	year 1982
-	manufacturer "Robert E. Davis Jr."
-	rom ( name "advancedbudgetmanager.p" size 16065 crc 3c9470f1 md5 57f9a0131be02387c11ff873da3c4fd4 sha1 9fff89fe3b70caac516db12f50e35c44fdd2c8e9 )
-	rom ( name "AdvancedBudgetManager.tzx" size 16291 crc 72a0eeda md5 b27dc1e6bb1a68b163457dad74a83f06 sha1 617af815c0545f0832cd9502ba51a0a5db5dcd1d )
+	name "3D Highway Race v1.0 (1983)(Thomas A. Runkler)(de)"
+	description "3D Highway Race v1.0 (1983)(Thomas A. Runkler)(de)"
+	rom ( name "3D Highway Race v1.0 (1983)(Thomas A. Runkler)(de).p" size 4094 crc 978c58e6 md5 cba6d05c1465ac7435346bef8f9a9ca3 sha1 727fda3c5ed5e2d40a3b83d0ed21fd9f221b8354 )
 )
+
 game (
-	name "Advanced Mathematics (W. H. Smith)"
-	description "Advanced Mathematics (W. H. Smith)"
-	year 1982
-	manufacturer "ICL"
-	rom ( name "advancedmathematics.p" size 13415 crc 53d03118 md5 3057d11d80675cc9910181c915387cc6 sha1 944f9cfd8dbfd6038ae71c1c84343e17a3308f8b )
-	rom ( name "AdvancedMathematics.tzx" size 13671 crc e6a14eaa md5 0707dca0772a33981eb91f87dfab135d sha1 8caa2805da995945d9153828c921ad4ab96678a5 )
+	name "3D Labyrinth (1983)(H. Stamm)"
+	description "3D Labyrinth (1983)(H. Stamm)"
+	rom ( name "3D Labyrinth (1983)(H. Stamm).p" size 4926 crc fa056d31 md5 7c1faf8724d176877fcd3295542cf204 sha1 2501daef32e4816b60877fd8f30add33e9a790df )
 )
+
 game (
-	name "Adventure (Bug Byte)"
-	description "Adventure (Bug Byte)"
-	year 1982
-	manufacturer "Bug Byte"
-	rom ( name "adventure.p" size 15783 crc dd2dc75d md5 756ee1b0642b97ec7fa586aa0e8ef519 sha1 e06106ebb14581c6f69b351261f88f24be8c7bd2 )
-	rom ( name "Adventure.tzx" size 16017 crc 35d4be2a md5 55bae9d8b6d5e7d62ef8f1646c0dcc03 sha1 c5fb1e4aa356ec4a406a2da76495d9f9b368d058 )
+	name "3D Labyrinth (1983)(H. Stamm)[a2]"
+	description "3D Labyrinth (1983)(H. Stamm)[a2]"
+	rom ( name "3D Labyrinth (1983)(H. Stamm)[a2].p" size 4902 crc d8eef1f0 md5 cb1b58f0b21d0e9eb8a05ec1a45d89c4 sha1 43d2dbe96d5265e10a80b71fdd93599ca4b59bc7 )
 )
+
 game (
-	name "Adventure A - Planet of Death (Artic)"
-	description "Adventure A: Planet of Death (Artic)"
-	manufacturer "Artic"
-	rom ( name "planetofdeath.p" size 13445 crc ab715c00 md5 f0a90c314572232e860a486f47c34cfe sha1 247f37d1b70a0eec9abce64ea094d55e3e59b27c )
-	rom ( name "PlanetOfDeath.tzx" size 13675 crc cdef18a4 md5 4ecb3f0a3a9a9c9a25520bf1f7d2175e sha1 346412f09b472c931874fd441660ab5435d5f3c1 )
+	name "3D Labyrinth (1983)(H. Stamm)[a]"
+	description "3D Labyrinth (1983)(H. Stamm)[a]"
+	rom ( name "3D Labyrinth (1983)(H. Stamm)[a].p" size 4870 crc b9d61ff6 md5 62e2bc6559eee266c29387b7d64eef0d sha1 4bd2cc8304eb5be0009dfe8b685b017a31fe40c5 )
 )
+
 game (
-	name "Adventure A - Planet of Death (Sinclair Research)"
-	description "Adventure A: Planet of Death (Sinclair Research)"
-	year 1981
-	manufacturer "Artic"
-	rom ( name "planetofdeath.p" size 13445 crc ab715c00 md5 f0a90c314572232e860a486f47c34cfe sha1 247f37d1b70a0eec9abce64ea094d55e3e59b27c )
-	rom ( name "PlanetOfDeath.tzx" size 13675 crc cdef18a4 md5 4ecb3f0a3a9a9c9a25520bf1f7d2175e sha1 346412f09b472c931874fd441660ab5435d5f3c1 )
+	name "3D Labyrinth (19xx)(-)(de)"
+	description "3D Labyrinth (19xx)(-)(de)"
+	rom ( name "3D Labyrinth (19xx)(-)(de).p" size 15882 crc 5198af48 md5 1521137d0bc87c557b49e8c918958b7e sha1 c52500d06e353c7e4065e749f1b4df7f927529f3 )
 )
+
 game (
-	name "Adventure B - Inca Curse (Artic)"
-	description "Adventure B: Inca Curse (Artic)"
-	year 1981
-	manufacturer "Artic"
-	rom ( name "incacurse(artic).p" size 11975 crc e5a05a0a md5 e24f9ea9c889a9587479085276980fa1 sha1 b1b85676ade56e51488f2262ee60facc22989967 )
-	rom ( name "IncaCurse(Artic).tzx" size 12205 crc 76d699e6 md5 15459a76af72151af7309c00ff13abae sha1 c3840c1539239437150d7e300b0bae412ad6a987 )
+	name "3D Maze (19xx)(-)"
+	description "3D Maze (19xx)(-)"
+	rom ( name "3D Maze (19xx)(-).p" size 10017 crc d50316b2 md5 1c6160abe7fccd6b400a9f890f6eab95 sha1 da172f68d4b0dad8f76e1eb3652aecd978957883 )
 )
+
 game (
-	name "Adventure B - Inca Curse (Sinclair Research)"
-	description "Adventure B: Inca Curse (Sinclair Research)"
-	year 1981
-	manufacturer "Artic"
-	rom ( name "incacurse.p" size 11975 crc e37cddd8 md5 736fd7c4c8854760206a05361299faf1 sha1 acb41012d467f473cb452f3cf1acb8608f108725 )
-	rom ( name "IncaCurse.tzx" size 12205 crc 700a1e34 md5 438603d7eaed102378af94260a15be1a sha1 8948f63c75c80dffa4e317e4d8ed400bd6b11de9 )
+	name "3D Maze (19xx)(-)[a]"
+	description "3D Maze (19xx)(-)[a]"
+	rom ( name "3D Maze (19xx)(-)[a].p" size 10044 crc 3b064392 md5 c2c0a81052c24b299622de718a64b60b sha1 ea7924c46b29b250cf7a6b545d6e7ca136302cac )
 )
+
 game (
-	name "Adventure C (Monochrome) (Artic)"
-	description "Adventure C (Monochrome) (Artic)"
-	year 1982
-	manufacturer "Artic"
-	rom ( name "adventurec.p" size 14045 crc 52f0a175 md5 c824db7237c7299477c957becdf39335 sha1 152de35905f06389f06925e5a09cb30183669ad0 )
-	rom ( name "AdventureC.tzx" size 14275 crc 449ed54f md5 d4bbb25a3eb32b2e063a3ab9b09565ab sha1 ebc2d62e91088447c40bd394aa825acbe2982210 )
+	name "3D Monster Labyrinth (19xx)(-)(de)"
+	description "3D Monster Labyrinth (19xx)(-)(de)"
+	rom ( name "3D Monster Labyrinth (19xx)(-)(de).p" size 9707 crc ccceaec0 md5 e5c2b270cc2cfa725ae0094155d2be9e sha1 479d107367da87bbbf433eac7595508c31a5d65d )
 )
+
 game (
-	name "Adventure C - Ship of Doom (Artic)"
-	description "Adventure C: Ship of Doom (Artic)"
-	manufacturer "Artic"
-	rom ( name "shipofdoom(artic).p" size 14045 crc 3e244575 md5 47ae04d2d34190dd2f9d47fb9815f4de sha1 689552ef631facc558c6fc9b902f20495e870936 )
-	rom ( name "ShipOfDoom(Artic).tzx" size 14275 crc 284a314f md5 ca0bab03eeff0fc9bcc040148e20c7d2 sha1 96221bceba4ff6e90fdc59271da1d7973362e8f8 )
+	name "3D Monster Maze (19xx)(J.K. Greye Software)"
+	description "3D Monster Maze (19xx)(J.K. Greye Software)"
+	rom ( name "3D Monster Maze (19xx)(J.K. Greye Software).p" size 10612 crc 026eb1ed md5 979096cf53a9f925d7647dbd0d7bc9da sha1 f1815764327b732cccc0a2405682d22c686a0303 )
 )
+
 game (
-	name "Adventure C - The Ship of Doom (Sinclair Research)"
-	description "Adventure C: The Ship of Doom (Sinclair Research)"
-	year 1982
-	manufacturer "Artic"
-	rom ( name "shipofdoom.p" size 14045 crc b8e32f06 md5 2515ba4ad2c1758f83d4e2f2cc81d6ca sha1 c64b4ae9fdbd955695660e6bd6a04ef2a6f91f39 )
-	rom ( name "ShipOfDoom.tzx" size 14275 crc ae8d5b3c md5 6e53ef483b27d942ff3ad6e69256c116 sha1 a1e5ab55214da2ca312345586f684e65204d52ad )
+	name "3D Monster Maze (19xx)(J.K. Greye Software)[a]"
+	description "3D Monster Maze (19xx)(J.K. Greye Software)[a]"
+	rom ( name "3D Monster Maze (19xx)(J.K. Greye Software)[a].p" size 10553 crc 18850e9a md5 2fdfa40fddf39be6eb8e0ef971108a4f sha1 b9eeb78b7ea2420b4df00111a6331dca8a154f30 )
 )
+
 game (
-	name "Adventure D - Espionage Island (Artic)"
-	description "Adventure D: Espionage Island (Artic)"
-	manufacturer "Artic"
-	rom ( name "espionageisland(artic).p" size 15504 crc ac8df706 md5 348a6b4fbec8e375daf1be03d1c674df sha1 8ad3e1ae97a34a6f6b1e2f653aeed770ba33f01e )
-	rom ( name "EspionageIsland(Artic).tzx" size 15734 crc 06a3887c md5 30754aa09608d83deb1c0194c04b85cb sha1 7b36f0bce5eccb9fc3dc4fb553516e5e7f5adabe )
+	name "3D Netwerk (19xx)(-)"
+	description "3D Netwerk (19xx)(-)"
+	rom ( name "3D Netwerk (19xx)(-).p" size 1743 crc 3ceec3c5 md5 78c73813e72c25bec2a53e51c3d762ec sha1 8684edd2c1f4d655c0423b0c414407d5b7ead506 )
 )
+
 game (
-	name "Adventure D - Espionage Island (Sinclair Research)"
-	description "Adventure D: Espionage Island (Sinclair Research)"
-	year 1982
-	manufacturer "Artic"
-	rom ( name "espionageisland.p" size 15504 crc 81ddf2b0 md5 24c456b967f1b621685579289a656ceb sha1 9c2db35b667f12a155aad2f2e5725b9fcf54e290 )
-	rom ( name "EspionageIsland.tzx" size 15734 crc 2bf38dca md5 50a59a5a1ca60349959ba2283e4188f8 sha1 1afaa1c3773c78f8f92941d95de226a727cc8822 )
+	name "3D Nought and Crosses (19xx)(-)"
+	description "3D Nought and Crosses (19xx)(-)"
+	rom ( name "3D Nought and Crosses (19xx)(-).p" size 4277 crc 1a08e705 md5 4d40e3cbf404ea04c1bc7aac90ac5cec sha1 96021b34b156f9c6cef4645d4ed9fa5630926320 )
 )
+
 game (
-	name "Adventure One (Abersoft)"
-	description "Adventure One (Abersoft)"
-	year 1982
-	manufacturer "Abersoft"
-	rom ( name "adventureone.p" size 15612 crc 67617c4d md5 a3ddf09fae32bb1bebc9890bee01e788 sha1 34f97d91871439200f127334a675d01e5a918b4c )
-	rom ( name "AdventureOne.tzx" size 15848 crc b1cbaaa7 md5 95e5c9663fdd2dae7494826beb4b3d39 sha1 bad2e766140ee0159389ac513f37c0e8372ed5c8 )
+	name "3D Oxo (1984)(A.J. Heathcote)"
+	description "3D Oxo (1984)(A.J. Heathcote)"
+	rom ( name "3D Oxo (1984)(A.J. Heathcote).p" size 3100 crc 8baadd01 md5 85d042e18354b30518ef103e33cd77d7 sha1 2e7584c0628779bbdf27bb27da434232761c0168 )
 )
+
 game (
-	name "Adventure Tape 1 (Phipps Associates)"
-	description "Adventure Tape 1 (Phipps Associates)"
-	year 1983
-	manufacturer "Phipps Associates"
-	rom ( name "AdventureTape1.tzx" size 57316 crc f85217cb md5 ebf8c22018a8a88743ce8f926c7a5592 sha1 851fd8d8c082c534766deb7c7d724ed0e9ae9410 )
+	name "3D Rotatie (19xx)(Frank Moquette)(nl)"
+	description "3D Rotatie (19xx)(Frank Moquette)(nl)"
+	rom ( name "3D Rotatie (19xx)(Frank Moquette)(nl).p" size 8324 crc 3af11a95 md5 e71d2b918ee40846f183097d5f9277de sha1 402a209e06426bd719bca64fd62377277fc9f518 )
 )
+
 game (
-	name "Adventure Tape No. 1 (Phipps Associates)"
-	description "Adventure Tape No. 1 (Phipps Associates)"
-	year 1982
-	manufacturer "Phipps Associates"
-	rom ( name "AdventureTapeNo1.tzx" size 57280 crc 48254758 md5 80d738ef8e9bf92f06760da0bd986cbd sha1 bc8d49cbfa4156fcd10739b8ba17987a6708a2aa )
+	name "3D Tic-Tac-Toe (19xx)(-)"
+	description "3D Tic-Tac-Toe (19xx)(-)"
+	rom ( name "3D Tic-Tac-Toe (19xx)(-).p" size 10772 crc 9bc53e75 md5 954fd6960565a8c7e971850573ec8888 sha1 4e0823758481e8177036a16c2056930ba4de1184 )
 )
+
 game (
-	name "Airline (Cases Computer Simulations)"
-	description "Airline (Cases Computer Simulations)"
-	year 1982
-	rom ( name "airline.p" size 15842 crc ee5ebb38 md5 0d2270547b0e378edaa4f22d1058deb4 sha1 88e1c1454ce376710f1ef8d864b20af8d6bb2fd5 )
-	rom ( name "Airline.tzx" size 16072 crc 844cbaac md5 3f4f3645c603230b8eb3742585c743c3 sha1 56b18d5296da989927c05c0f33dc30d2a3b1ba4c )
+	name "3D Tic-Tac-Toe (19xx)(-)[a]"
+	description "3D Tic-Tac-Toe (19xx)(-)[a]"
+	rom ( name "3D Tic-Tac-Toe (19xx)(-)[a].p" size 10809 crc 00aafa57 md5 c68775f7caa4461a69aba6a3c3f27710 sha1 e211e3987551b068650406853baa24287a0cd186 )
 )
+
 game (
-	name "Algebra 1 (Timex)"
-	description "Algebra 1 (Timex)"
-	year 1982
-	manufacturer "Home Computer Software"
-	rom ( name "Algebra1.tzx" size 3926 crc 11f6af7c md5 06f5ba26638ce245da0d0c622bca75f1 sha1 4cfec3ba12646b6b5cf05860401750fa149fbce9 )
+	name "3D-Mover (19xx)(-)"
+	description "3D-Mover (19xx)(-)"
+	rom ( name "3D-Mover (19xx)(-).p" size 3963 crc 0c9c132d md5 c04f05df5374f413849a022deefdf1f8 sha1 a712b26584f1e00b1adb5057623660999a471ec0 )
 )
+
 game (
-	name "Alien (PSS)"
-	description "Alien (PSS)"
-	year 1982
-	manufacturer "PSS"
-	rom ( name "alien.p" size 11735 crc b85d2a16 md5 47ab0a499a9a5558d7b76d9acc02f86f sha1 bbfd196dc9ca7694987fc079c7ba445f29435b3b )
-	rom ( name "Alien.tzx" size 11961 crc febc8fef md5 bf6d8512bdb99c04e3f0e40157fc6b6a sha1 9545ca45d3440c9a34be3411bc7395f37af82777 )
+	name "4472 Flying Scotsman (19xx)(-)"
+	description "4472 Flying Scotsman (19xx)(-)"
+	rom ( name "4472 Flying Scotsman (19xx)(-).p" size 5269 crc ff92e9e2 md5 9c19a7fc97c3ac868bd2e98787a1f27c sha1 d0f99507a5caa4a3c0906b355b26b4b2fac92a2d )
 )
+
 game (
-	name "Alien Attack (Computer Rentals)"
-	description "Alien Attack (Computer Rentals)"
-	manufacturer "Computer Rentals"
-	rom ( name "alienattack.p" size 6209 crc 946e0ed7 md5 52cdd5d46f020af4a42c898919c866cf sha1 fb0be0363133dcd5dab240253fdcbf21c7f50c65 )
-	rom ( name "AlienAttack.tzx" size 6429 crc e6ce2fa6 md5 53ff8e58ba83e04522c87e4cb0d54002 sha1 f52df2571903d9aae931b359eabb67e2bbd6fc41 )
+	name "4472 Flying Scotsman (19xx)(-)(nl)"
+	description "4472 Flying Scotsman (19xx)(-)(nl)"
+	rom ( name "4472 Flying Scotsman (19xx)(-)(nl).p" size 5457 crc 4a2fedf5 md5 c3dad6a2fcdcac6a2f69970d98f1b629 sha1 b6bdf5521cecbfdb9d4c6bdc5baa7a9dc17a3298 )
 )
+
 game (
-	name "Alien-Dropout (Silversoft)"
-	description "Alien-Dropout (Silversoft)"
-	year 1982
-	manufacturer "Silversoft"
-	rom ( name "aliendropout.p" size 3192 crc d6570c8d md5 f20b18d295751068432cd101cecab2c9 sha1 a18219e3e44a6cacb38afabd21153a6abf72fe82 )
-	rom ( name "AlienDropout.tzx" size 3424 crc fe0f33f4 md5 80d3c0c640aa71a3c12691b83b4c26cf sha1 c51813b542dd1432421ad7bb222a6f5cef4cd641 )
+	name "8 Way Scroll (19xx)(-)"
+	description "8 Way Scroll (19xx)(-)"
+	rom ( name "8 Way Scroll (19xx)(-).p" size 1566 crc 95d2db59 md5 869807b887384f6493ccdca243203368 sha1 978d77c2f97f3bd533363f7d90cb55bce47c929c )
 )
+
 game (
-	name "Alphaprobe (Artic)"
-	description "Alphaprobe (Artic)"
-	manufacturer "Artic"
-	rom ( name "alphaprobe.p" size 11016 crc 4b8bb297 md5 0fadaebde9d1d1843b74415333eadc7b sha1 cdaba21f5432945bf9ae06b111804f3c4cd385e2 )
-	rom ( name "Alphaprobe.tzx" size 11252 crc 7b7603f0 md5 0c36b487eaccb85755604c91d05dd8fe sha1 a71fdaec9225187ad0724bdaaab65b2860e994fb )
+	name "84 Caves, The (19xx)(-)"
+	description "84 Caves, The (19xx)(-)"
+	rom ( name "84 Caves, The (19xx)(-).p" size 16008 crc 45af5f31 md5 f52272c2b4a543d383a0c756ddc56c16 sha1 bed9996e36fec0f7642df23e85120ad0411872b0 )
 )
+
 game (
-	name "Ant Attack"
-	description "Ant Attack (2013) - Bob's interpretation of Sandy White's classic isometric title from 1983."
-	rom ( name "AntAttack.p" size 16167 crc 2e30a8cf md5 1fe5cfe57b540868e31fd73e7e54388b sha1 1b4fc9eb5cd3373a9986fcd395d0117c6b3c4718 )
+	name "84 Caves, The (19xx)(-)[a]"
+	description "84 Caves, The (19xx)(-)[a]"
+	rom ( name "84 Caves, The (19xx)(-)[a].p" size 16045 crc a09ca03b md5 d24a1a226845a6b078658fb0caa0feeb sha1 1357d8da5f7cc4df7ddc4f48408249bec7bdf025 )
 )
+
 game (
-	name "Arcade Action (Micromega)"
-	description "Arcade Action (Micromega)"
-	manufacturer "Micromega"
-	rom ( name "ArcadeAction.tzx" size 4651 crc 5cb215e3 md5 5a76c5d34baa6d9aaf3bdd34e5c89597 sha1 04fc1ffa34592f093f1c0eae9d54b3ff31eb3e86 )
+	name "A Day at the Horseraces v2.0 (19xx)(-)"
+	description "A Day at the Horseraces v2.0 (19xx)(-)"
+	rom ( name "A Day at the Horseraces v2.0 (19xx)(-).p" size 4080 crc cbf6f6ec md5 ef5b5dcc2b781c70f51190a386fced49 sha1 ebdfa58fc56f4826fd57cf86731778387a2e9225 )
 )
+
 game (
-	name "Around Europe in 80 Hours (International Publishing and Software Inc.)"
-	description "Around Europe in 80 Hours (International Publishing and Software Inc.)"
-	year 1982
-	rom ( name "aroundeuropein80hours.p" size 15223 crc 2da984a7 md5 1dd7d90a090b80ea53c1b387b852d497 sha1 5d2a941cd7edca847bfd6c10b41b9025a81d4352 )
-	rom ( name "AroundEuropeIn80Hours.tzx" size 15451 crc 860758c6 md5 5feee6f195cee427cd9195a1c4462f58 sha1 cb59d966fe38c858df9a002f2eaaae2cb0e1ba73 )
+	name "ABC (1982)(R.J. Connolly)"
+	description "ABC (1982)(R.J. Connolly)"
+	rom ( name "ABC (1982)(R.J. Connolly).p" size 16242 crc dc399f52 md5 bfea4fa49c592004531af78c6840e52a sha1 3bf4b05f6e22c8f58cffe87676a132f0e3c34283 )
 )
+
 game (
-	name "Asteroids (Silversoft)"
-	description "Asteroids (Silversoft)"
-	year 1982
-	manufacturer "Silversoft"
-	rom ( name "asteroids.p" size 3542 crc 7484ac13 md5 0a392517e1d78420e0a5b5aafefe0c39 sha1 27d633e47d4e5a6b1594b16103e6a7ea12b5d0a7 )
-	rom ( name "Asteroids.tzx" size 3776 crc 939e50e5 md5 5f4836d37cb10b4bb5c7c71bb857409a sha1 85047ab187bfcd02195f00150419cee1bfc07a5f )
+	name "ABC (1982)(R.J. Connolly)[a]"
+	description "ABC (1982)(R.J. Connolly)[a]"
+	rom ( name "ABC (1982)(R.J. Connolly)[a].p" size 16294 crc 7b0a05bd md5 1576f70a5a7b624240eedd93218fcee3 sha1 03bfe9edee0bf5179fdfb4afe2f5fc24678ab009 )
 )
+
 game (
-	name "Asteroids (Software Farm)"
-	description "Asteroids (Software Farm)"
-	manufacturer "Software Farm"
-	rom ( name "asteroids(sf).p" size 8360 crc 0efcebd4 md5 583c3e31090f678a465c46d0cfcf2ad7 sha1 7f114cd978045301b7c63f7177d2fe2d0ee33264 )
-	rom ( name "Asteroids(SF).tzx" size 8594 crc 8b6f8743 md5 d7f2518bd65dbd7d99842f5a27aab588 sha1 d56d7e03a545b99607174faec186c42e64618189 )
+	name "Adressen Bestand (19xx)(M.E. Dias da Silva)(nl)"
+	description "Adressen Bestand (19xx)(M.E. Dias da Silva)(nl)"
+	rom ( name "Adressen Bestand (19xx)(M.E. Dias da Silva)(nl).p" size 4320 crc 9b122e26 md5 b9843021c14e128a8b5d693fffbe50d2 sha1 cb818a46c508da5c21401aa91721ca9b8cc79557 )
 )
+
 game (
-	name "Autochef (Cases Computer Simulations)"
-	description "Autochef (Cases Computer Simulations)"
-	year 1982
-	rom ( name "autochef.p" size 15430 crc 575560bb md5 21c42c6c6eaf0866dc56533f89688f4f sha1 dd0ee23e39d50738d91731c427063ac8e59ad9d3 )
-	rom ( name "Autochef.tzx" size 15648 crc 3869ae07 md5 81856a30f98ccaa2fdbd6c88d8c7897f sha1 2b7416327bdb907108d287f8cd4eaa0fd291ecba )
+	name "Adressenbestand (19xx)(A.V. Oosten)(nl)"
+	description "Adressenbestand (19xx)(A.V. Oosten)(nl)"
+	rom ( name "Adressenbestand (19xx)(A.V. Oosten)(nl).p" size 6136 crc f27cb476 md5 f959bd41ced5f279f59ad751a4e2095c sha1 786c7deff654428f32c632779e2142a0cde7a6bd )
 )
+
 game (
-	name "Avenger (Abacus)"
-	description "Avenger (Abacus)"
-	year 1982
-	manufacturer "K. Flynn"
-	rom ( name "avenger.p" size 7138 crc 53621a49 md5 1af4b6a7f31315a701b5dd54068c5596 sha1 0f402a98c52410358f2a3ec94280af6c7375f9ac )
-	rom ( name "Avenger.tzx" size 7368 crc b545fdae md5 b0e975a6cdff98f667536f3fd4d902bd sha1 529b2a9eb67c50db12494cc0ff7272925e9d18b4 )
+	name "Adressverwaltung (19xx)(-)(de)"
+	description "Adressverwaltung (19xx)(-)(de)"
+	rom ( name "Adressverwaltung (19xx)(-)(de).p" size 14550 crc 646bd23a md5 b875267a867278d6b519e6f08254b956 sha1 ed3b3f4bd7c8de0a5fbb7b260e51fbf8d3389816 )
 )
+
 game (
-	name "Backgammon (Keith Archer)"
-	description "Backgammon (Keith Archer)"
-	year 1982
-	manufacturer "Keith Archer"
-	rom ( name "backgammon(ka).p" size 11625 crc f4d9073b md5 b0a388f1b834d98852d96f998c1978cc sha1 c0c4e28934d05735b2200c41f2af8eb7b3abd1cb )
-	rom ( name "Backgammon(KA).tzx" size 11861 crc 153ed883 md5 71f46d576fe8bfa343d41949dabd2e55 sha1 81f25c1667c8eba6936eabfd080ccad3a3a34add )
+	name "Advanced Lawnmower Simulator (1998)(Joe Mackay)"
+	description "Advanced Lawnmower Simulator (1998)(Joe Mackay)"
+	rom ( name "Advanced Lawnmower Simulator (1998)(Joe Mackay).p" size 6252 crc 544e1fd2 md5 9c52c1d4ee9d2c6aaec7dc44ecc805d3 sha1 128cc0feae9a7732841c659765dba8651108453a )
 )
+
 game (
-	name "Backgammon (Timex)"
-	description "Backgammon (Timex)"
-	year 1982
-	manufacturer "Psion"
-	rom ( name "Backgammon(Timex).tzx" size 17108 crc 307aacd2 md5 d068903731302f4dc6c0e7810d1ed944 sha1 5a78754d849fe5284342089159af45588029c0a9 )
+	name "Adventure (19xx)(-)"
+	description "Adventure (19xx)(-)"
+	rom ( name "Adventure (19xx)(-).p" size 1514 crc 473c600c md5 961f456e08c0b913f346b47696615a1d sha1 277b970b14c2b71679d6ad09086c7241dd26204d )
 )
+
 game (
-	name "Bank Robber (Romik Software)"
-	description "Bank Robber (Romik Software)"
-	year 1983
-	manufacturer "Roland Stokes"
-	rom ( name "bankrobber.p" size 6560 crc 2973af44 md5 8ca20ed973a7a1b830087cd30db7edba sha1 5ebdbd6b13b82933c158bd439b89bf6ce69149a7 )
-	rom ( name "BankRobber.tzx" size 6798 crc f9a7ab7d md5 36e6e97bd4ea83c494b6134e1aeee1c2 sha1 40d0fcc8faaf73b0082d4f1937ef16626d289f66 )
+	name "Adventure (19xx)(-)(de)"
+	description "Adventure (19xx)(-)(de)"
+	rom ( name "Adventure (19xx)(-)(de).p" size 6522 crc eedfd4c3 md5 92f708f403a162bafc30da67f795bb2b sha1 b7fdea76e78a911cb73eec1edffb0b020c0909a6 )
 )
+
 game (
-	name "Baron (Temptation Software)"
-	description "Baron (Temptation Software)"
-	manufacturer "Simon Mansfield"
-	rom ( name "Baron.tzx" size 16716 crc 2813c7a1 md5 c6ae4f6cf29411686bde01114a682498 sha1 fd944cedd638d3a5d6b70a8a4d50f2d41c16ea74 )
+	name "Adventure A - The Planet of Death (1981)(Artic Computing)"
+	description "Adventure A - The Planet of Death (1981)(Artic Computing)"
+	rom ( name "Adventure A - The Planet of Death (1981)(Artic Computing).p" size 13446 crc de006856 md5 458fbee3663e166dd2dea340f5ecf35c sha1 74bb494eb2ed2e655a1dbc72e56d830327b1d656 )
 )
+
 game (
-	name "Basicode 2 (BBC)"
-	description "Basicode 2 (BBC)"
-	year 1984
-	manufacturer "The Chip Shop"
-	rom ( name "Basicode2.A.tzx" size 3570 crc db6f1818 md5 ad1857f473ca1de8ed5d7b855d566c54 sha1 9204245adf3f343e82c43d6ec70117c4dc491908 )
-	rom ( name "basicode2.p" size 3338 crc 89ce64f1 md5 cab7e8adf644459ce8c1dd54897a184c sha1 07a3de146663d0e77a98a0800fb6f0545d567d77 )
+	name "Adventure B - Inca Treasure (1981)(Artic Computing)"
+	description "Adventure B - Inca Treasure (1981)(Artic Computing)"
+	rom ( name "Adventure B - Inca Treasure (1981)(Artic Computing).p" size 11976 crc 07011c26 md5 429d7a7d23fbbdfb7a6e52487105a0ec sha1 e916708cdab0590a33c11dfcebdf35a9809d3181 )
 )
+
 game (
-	name "Bat Cage (Timex)"
-	description "Bat Cage (Timex)"
-	year 1982
-	manufacturer "Thomas J. Burke"
-	rom ( name "batcage.p" size 1222 crc a1b5d16f md5 0a716ad28c067c5938d776fabadfc176 sha1 e3dbde749ff3618ab07a6c8fc712531be6272bcf )
-	rom ( name "BatCage.tzx" size 1446 crc 650a94d8 md5 c3b8a71965f8ba025d546b7fe8f1531b sha1 8f6842f02e416e8b66c8d6172f2e852a5e14d2f8 )
+	name "Adventure C - Alien Spaceship (1982)(Artic Computing)"
+	description "Adventure C - Alien Spaceship (1982)(Artic Computing)"
+	rom ( name "Adventure C - Alien Spaceship (1982)(Artic Computing).p" size 14046 crc 9e67fd25 md5 c44d284853874c29bdc4494661bf787b sha1 0a93d32f64f383a478773146fe7c8c5adc77e4e2 )
 )
+
 game (
-	name "Battleships (JRS Software)"
-	description "Battleships (JRS Software)"
-	year 1982
-	manufacturer "JRS Software"
-	rom ( name "battleships.p" size 12732 crc a0a631a4 md5 99bdb02395ed7a85c8b13911c0344516 sha1 6897424919c684a7a18235d967c7f621f02d1cf0 )
-	rom ( name "Battleships.tzx" size 12962 crc a1057bc5 md5 8840352dd5514d5bc84e82f14f6211e2 sha1 0c36982f0243f39c028a21207a2218d40b1cb369 )
+	name "Adventure C - Alien Spaceship (1982)(Artic Computing)[a2]"
+	description "Adventure C - Alien Spaceship (1982)(Artic Computing)[a2]"
+	rom ( name "Adventure C - Alien Spaceship (1982)(Artic Computing)[a2].p" size 14138 crc 1c30bbb6 md5 ea09c7229fa0d941da10c1fba3316203 sha1 26f63a7f4c4a13bec2fbf5a622514fc75e0a6ddb )
 )
+
 game (
-	name "Bigflap Attack (Timex)"
-	description "Bigflap Attack (Timex)"
-	manufacturer "Timex"
-	rom ( name "bigflapattack.p" size 9829 crc 99887648 md5 66c706f432ad9277573b709c913b16a0 sha1 985f2f32ae4478051b5b7d91cb17bbc474fd26f6 )
+	name "Adventure C - Alien Spaceship (1982)(Artic Computing)[a]"
+	description "Adventure C - Alien Spaceship (1982)(Artic Computing)[a]"
+	rom ( name "Adventure C - Alien Spaceship (1982)(Artic Computing)[a].p" size 14045 crc c5dacb64 md5 efdbcf590e1430377e4c44fc40a50f84 sha1 3ad6bc4e0c243618935450f7ef4d22b7f4b04540 )
 )
+
 game (
-	name "Black Star (Quicksilva)"
-	description "Black Star (Quicksilva)"
-	year 1983
-	manufacturer "M. Sudworth"
-	rom ( name "blackstar.p" size 6811 crc 0407beac md5 d34202b6ac2f39323ad1212ca360e18b sha1 c17aa876dfeef10fd9d8da5bd83cc6fec9396fb9 )
-	rom ( name "BlackStar.tzx" size 7047 crc f227253f md5 c5b418b890bb6d828ec84d2fb36152ab sha1 0abe2ca4064679c23da82773fab70bf05c245844 )
+	name "Adventure D - Espionage Island (1982)(Artic Computing)"
+	description "Adventure D - Espionage Island (1982)(Artic Computing)"
+	rom ( name "Adventure D - Espionage Island (1982)(Artic Computing).p" size 15505 crc 5b7beab1 md5 e3ef761aafc4d5ccaf7bd5e4fe782840 sha1 476f5f7d171e2178cfbbbcdcd8a6a2045cd761a8 )
 )
+
 game (
-	name "Boulder Logic"
-	description "Boulder Logic (2011) - Bradford Walker-Smythe needs to find the perfect engagement ring to win the heart of his true love Tania when he asks for her hand in marriage. And so, to prove his devotion, he sets off to the Cornish mines in search of the perfect diamond..."
-	rom ( name "BoulderL.p" size 16240 crc 23cc342f md5 b040c3e750ef06a93c56b53ed299b9ca sha1 3c74569ef70327ecf17db982ef92b4557c17b538 )
+	name "Adventure D - Espionage Island (1982)(Artic Computing)[a]"
+	description "Adventure D - Espionage Island (1982)(Artic Computing)[a]"
+	rom ( name "Adventure D - Espionage Island (1982)(Artic Computing)[a].p" size 15504 crc c87b25a5 md5 30eb470148f9007745f93054531dc7d6 sha1 2fd8981ce9d8c913fc3d54a8e514ecac02890cb1 )
 )
+
 game (
-	name "Bouncing Bert (Software Farm)"
-	description "Bouncing Bert (Software Farm)"
-	year 1985
-	manufacturer "S C T"
-	rom ( name "bouncingbert.p" size 14919 crc fb88ad49 md5 e575aa04406a3f9eb1c095e8c0b6cd3a sha1 a56dddc42a1383c392d6988c9dafb4c8db37007a )
-	rom ( name "BouncingBert.tzx" size 15151 crc c30caf71 md5 ae2a31c5a4b92c6213b7547608110e86 sha1 ef3be8446d80452a155ed647a55c7d24aee58a6d )
+	name "Air Attack (19xx)(-)"
+	description "Air Attack (19xx)(-)"
+	rom ( name "Air Attack (19xx)(-).p" size 2599 crc e15c4e89 md5 1a50a1372a12fbdeb499e15936cb4678 sha1 c565e01579e7df87140c9d558db2486dcb7505b7 )
 )
+
 game (
-	name "Breakout 3 (Axis)"
-	description "Breakout 3 (Axis)"
-	year 1982
-	manufacturer "Axis"
-	rom ( name "breakout3.p" size 5485 crc a836659c md5 9ae6333ad0003617da56543e57a60903 sha1 f226df48cfcabea16956faff21e88e3eeeccf66c )
-	rom ( name "Breakout3.tzx" size 5705 crc 69b9a5bf md5 595c064a5d18089bec87664dc37ab2da sha1 faf622eff6cca236e0623d7f23cf35bfef74d823 )
+	name "Airline (1982)(CCS)"
+	description "Airline (1982)(CCS)"
+	rom ( name "Airline (1982)(CCS).p" size 15791 crc dbcd14de md5 32a2dbd0a161c9cd49081c3e547bb869 sha1 3aed206ac6860038b54710a5b0cffc9a40f6f338 )
 )
+
 game (
-	name "Breakout (CDS Micro Systems)"
-	description "Breakout (CDS Micro Systems)"
-	year 1982
-	manufacturer "CDS Micro Systems"
-	rom ( name "breakout.p" size 3235 crc 82836ac3 md5 3f4b0e39130be53ae22381f8a82a3081 sha1 eb36d14650c568ed47326dc094392c70fd249b3c )
-	rom ( name "Breakout.tzx" size 3467 crc 322fafd6 md5 0323a0d24248e0de2dce75c7cd3b71a9 sha1 1cb495c3b751e64e8b1fc38c68fabf0340365f39 )
+	name "Airline (1982)(CCS)[a]"
+	description "Airline (1982)(CCS)[a]"
+	rom ( name "Airline (1982)(CCS)[a].p" size 15823 crc 03b055aa md5 2384f090547aeea7ae0ef33b54358149 sha1 4c5bd57e01e550ff96208c3f19d6e06142d480c3 )
 )
+
 game (
-	name "Breakout (J. K. Greye)"
-	description "Breakout (J. K. Greye)"
-	year 1981
-	manufacturer "J. K. Greye"
-	rom ( name "breakout(jkg).p" size 716 crc 15cb56b4 md5 4655a4c1f58c705f303d31d2f2e64f7f sha1 2a4ddae5df3c18192c851be567daeb9ab59aa456 )
-	rom ( name "Breakout(JKG).tzx" size 948 crc e3f0284a md5 c52f2080dc8e969b4636da6f9d4f1e54 sha1 c8138f8960aedf4d848c65b676d76bf717ec9154 )
+	name "Alien (19xx)(-)"
+	description "Alien (19xx)(-)"
+	rom ( name "Alien (19xx)(-).p" size 7121 crc e11612b0 md5 405b146d8244a687c689d8f65dcb23cc sha1 984fe9eb7fd875f1b0e39ae7b5212f585829f15f )
 )
+
 game (
-	name "Breakout (New Generation)"
-	description "Breakout (New Generation)"
-	year 1982
-	manufacturer "J. K. Greye"
-	rom ( name "breakout(ngs).p" size 716 crc d4496e38 md5 e488ef1a3efc25f2abd308f9aef901b5 sha1 bd90a91d1ef17e19802d145dac955d0d34cab5f0 )
-	rom ( name "Breakout(NGS).tzx" size 948 crc 227210c6 md5 50fe074b25394a62a8fbbb8dac9513fb sha1 86b96863cffca1038110a78b99b4df5fbcc75daa )
+	name "Alien Attack (19xx)(J. Jones)"
+	description "Alien Attack (19xx)(J. Jones)"
+	rom ( name "Alien Attack (19xx)(J. Jones).p" size 1773 crc 8f65bbcc md5 95c7047ec5a82bd06d44efcff9701a5c sha1 723fb9a3b24c5be0912f4e8bc1da12b39fa75333 )
 )
+
 game (
-	name "Breakout, Space Invaders and Music (Macronics)"
-	description "Breakout, Space Invaders and Music (Macronics)"
-	year 1981
-	manufacturer "Macronics"
-	rom ( name "BreakoutSIAndMusic.tzx" size 2734 crc d383db01 md5 13110862adf0b4abb06573a2be710087 sha1 d5582e7a6a79bd6b8a2096ed968c91292b46483b )
+	name "Alien Attack (19xx)(J. Jones)[a]"
+	description "Alien Attack (19xx)(J. Jones)[a]"
+	rom ( name "Alien Attack (19xx)(J. Jones)[a].p" size 1810 crc dc34db5d md5 d3e35c667a7c9a741928c0a28362d85e sha1 07fe537b6afd0c260d4eb3dab5cc8d9573766b00 )
 )
+
 game (
-	name "Brick Stop (CDS Micro Systems)"
-	description "Brick Stop (CDS Micro Systems)"
-	year 1982
-	manufacturer "CDS Micro Systems"
-	rom ( name "brickstop.p" size 3126 crc 8ee66abe md5 b70594c6cb40ac4b3b7706574153563d sha1 fd697ae6ec522406f4e6b91a5c7a5d7c9058a4ff )
-	rom ( name "BrickStop.tzx" size 3362 crc 2e173afa md5 65a723688c0fd694ad600407fc12ec17 sha1 232822deb023be4037e9864a1ccd01e8c42a32bf )
+	name "Alien Descender (1983)(Fontana Publishing)"
+	description "Alien Descender (1983)(Fontana Publishing)"
+	rom ( name "Alien Descender (1983)(Fontana Publishing).p" size 2489 crc f878cc22 md5 4511f845e71a7c4db94f9be7c6cb21a8 sha1 77e52b020e1a7d921e88995d04b94f6e81f455f2 )
 )
+
 game (
-	name "Bubble Bugs (Romik Software)"
-	description "Bubble Bugs (Romik Software)"
-	year 1983
-	manufacturer "Roland Stokes"
-	rom ( name "bubblebugs.p" size 6409 crc 1e09b9ec md5 00b1a8fe3030cf7b4cd91b5eaf986516 sha1 8770497d4db9455f31dc6f422b710ba44dcab096 )
-	rom ( name "BubbleBugs.tzx" size 6647 crc 368c6f68 md5 3e4feeb96b4ff463ff81be369592c0de sha1 e52ddab32b1183910d1c74ae04999a8fb92dc158 )
+	name "All Change Routine (19xx)(-)"
+	description "All Change Routine (19xx)(-)"
+	rom ( name "All Change Routine (19xx)(-).p" size 1763 crc 9980ef60 md5 f0ecf79333604663c600e5541cd1988d sha1 2760e2be12bac54be13ba092b5dc8517eca3d16e )
 )
+
 game (
-	name "Bumper 7 (Axis)"
-	description "Bumper 7 (Axis)"
-	year 1981
-	manufacturer "Axis"
-	rom ( name "Bumper7.tzx" size 5179 crc 3c31d394 md5 7a42934f415ad9587a203974bbe2f6f2 sha1 2adc581baca7d49305c0ccd720f594c50618be5e )
+	name "Als Alfred Hitchcock's Birds (19xx)(nl)"
+	description "Als Alfred Hitchcock's Birds (19xx)(nl)"
+	rom ( name "Als Alfred Hitchcock's Birds (19xx)(nl).p" size 3304 crc 8bdaa8ac md5 2e72125e413137a4bed5a2ce97ea3876 sha1 55238e321bfebb5433378ced6cdb641bb9cd5ed9 )
 )
+
 game (
-	name "Byter (Protek)"
-	description "Byter (Protek)"
-	year 1983
-	manufacturer "Protek"
-	rom ( name "byter.p" size 5045 crc 1c53ac02 md5 8db34a0ed323545380ac2eb69190fa18 sha1 c396155336a5f43e908de08c5398b670f694b4f7 )
-	rom ( name "Byter.tzx" size 5271 crc 540854fe md5 423d68cc0edd3f4c360cc58f167f0e71 sha1 ab1f4d1f13735e7ffe4e143c1ee159a2ca1a0617 )
+	name "Amaze (1983)(Fontana Publishing)"
+	description "Amaze (1983)(Fontana Publishing)"
+	rom ( name "Amaze (1983)(Fontana Publishing).p" size 2791 crc b0a585e0 md5 c7068d132ad0c56a5ba1e7fca199eb40 sha1 1ffe5543cc3627f9768bbc2b6292a952946cbbeb )
 )
+
 game (
-	name "Can of Worms (Automata Cartography)"
-	description "Can of Worms (Automata Cartography)"
-	manufacturer "Automata Cartography"
-	rom ( name "CanOfWorms.tzx" size 7150 crc b2e6fa12 md5 3a724f1a32f350922012f1ff6b6e0193 sha1 9bb651b39206913bbe74600997114fcbcd70747c )
+	name "Ambassador ZX-81 (19xx)(-)(it)"
+	description "Ambassador ZX-81 (19xx)(-)(it)"
+	rom ( name "Ambassador ZX-81 (19xx)(-)(it).p" size 13525 crc 5dc8c90e md5 55f87403065610caba9a7a982b0af939 sha1 51b7bb8c7536dc8ff0ccbe806e526eb8a8fa08d0 )
 )
+
 game (
-	name "Cassette 3 (M. Orwin)"
-	description "Cassette 3 (M. Orwin)"
-	year 1982
-	manufacturer "Various"
-	rom ( name "Cassette3.tzx" size 96710 crc f612e596 md5 688fe0bd73cf475d632ebb2bc920f92c sha1 a3a02c88cd119f5acf87ef056a8b26dad0a79390 )
+	name "Ambulance (1984)(Sinclair User)[16K]"
+	description "Ambulance (1984)(Sinclair User)[16K]"
+	rom ( name "Ambulance (1984)(Sinclair User)[16K].p" size 3767 crc 0c337fd8 md5 35e17ece779224a55d237a9ef15c63c9 sha1 1f9b5ee5cb677e6c7223f55fc2bbc26e7fc73dc4 )
 )
+
 game (
-	name "Cassette 4 (M. Orwin)"
-	description "Cassette 4 (M. Orwin)"
-	year 1982
-	manufacturer "Various"
-	rom ( name "Cassette4.tzx" size 53160 crc 9c246427 md5 acfc26dd06d2a03808f0ff71e9be96d2 sha1 5cdb627ac5b3498225d7d4d5fb90d80751187218 )
+	name "Analiser (19xx)(-)(nl)"
+	description "Analiser (19xx)(-)(nl)"
+	rom ( name "Analiser (19xx)(-)(nl).p" size 1133 crc 6e544e35 md5 7660381c6dd588c7095f6365ed85473a sha1 75cbf4a29a3452e689b86e91897ec8f52e9da2d4 )
 )
+
 game (
-	name "Castle Adventure (Brown inlay) (CDS Micro Systems)"
-	description "Castle Adventure (Brown inlay) (CDS Micro Systems)"
-	year 1982
-	manufacturer "CDS Micro Systems"
-	rom ( name "castle.p" size 14488 crc 1d01ed81 md5 239c2112ae0b67a045bfeb0397d4f3e0 sha1 00755932ca214c899b866036e666df6325fdd59a )
-	rom ( name "Castle.tzx" size 14716 crc ba09cc38 md5 ef3141d3308bcd5dd7831a27e8cc5899 sha1 688abd7300f76e35f69ae025a4411f2767514b94 )
+	name "Appel (1983)(-)(nl)"
+	description "Appel (1983)(-)(nl)"
+	rom ( name "Appel (1983)(-)(nl).p" size 4007 crc 27dab104 md5 36e65797134d1e184509f53037c954ab sha1 5641da4293baf48bf479b17c87dbce026bbb398d )
 )
+
 game (
-	name "Castle Adventure (CDS Micro Systems)"
-	description "Castle Adventure (CDS Micro Systems)"
-	manufacturer "CDS Micro Systems"
-	rom ( name "castle.p" size 14488 crc 1d01ed81 md5 239c2112ae0b67a045bfeb0397d4f3e0 sha1 00755932ca214c899b866036e666df6325fdd59a )
-	rom ( name "Castle.tzx" size 14716 crc ba09cc38 md5 ef3141d3308bcd5dd7831a27e8cc5899 sha1 688abd7300f76e35f69ae025a4411f2767514b94 )
+	name "Append (19xx)(-)(nl)"
+	description "Append (19xx)(-)(nl)"
+	rom ( name "Append (19xx)(-)(nl).p" size 1327 crc f22695f3 md5 d2305cea6383cca649dc9f2218cbedd5 sha1 76ebd2836b357a12800590be8d5afedef615662f )
 )
+
 game (
-	name "Catacombs (J. K. Greye)"
-	description "Catacombs (J. K. Greye)"
-	year 1981
-	manufacturer "J. K. Greye"
-	rom ( name "catacombs.p" size 12506 crc b1ed0b59 md5 5e674ce62efd5ab861bbeef9de75d711 sha1 a5d32e1d50d291c485549c4740e5cc6ba3de36ab )
-	rom ( name "Catacombs.tzx" size 12740 crc f8d6aee6 md5 6ec147973d7561ede4726bc413409cdd sha1 c872d07e278df997df9a66185852f580fd851151 )
+	name "Apple Nuclear Power Plant (19xx)(Stephen R. Berggren)"
+	description "Apple Nuclear Power Plant (19xx)(Stephen R. Berggren)"
+	rom ( name "Apple Nuclear Power Plant (19xx)(Stephen R. Berggren).p" size 10598 crc ff473e0c md5 e9889f543bc29edcc544b66ff62eb3d2 sha1 cd343ab01fc3b6d7dfdba22c2f301e449a975de7 )
 )
+
 game (
-	name "Cave Crusade (AWA Software)"
-	description "Cave Crusade (AWA Software)"
-	manufacturer "S. Hughes"
-	rom ( name "cavecrusade.p" size 6270 crc a2eb2f80 md5 b6c9c3f387d5ba97d80fe92a03e6d0c5 sha1 5f05d170d3eba9a7c4915eecd7e65bbbb958feca )
-	rom ( name "CaveCrusade.tzx" size 6510 crc 9dec44e3 md5 4e27965613610224b2c60f824983f7a7 sha1 bc4a46fdec5734a88afc005df4864feae26549e1 )
+	name "Archery (19xx)(-)"
+	description "Archery (19xx)(-)"
+	rom ( name "Archery (19xx)(-).p" size 1401 crc 5a310459 md5 fb4b1aaf1b80bcb500d19787277fd3ee sha1 6fa36da72f888e1826dad89d3931bc28f52ca101 )
 )
+
 game (
-	name "Centipede (dktronics) (dK'tronics)"
-	description "Centipede (dktronics) (dK'tronics)"
-	year 1982
-	manufacturer "Jeff Minter"
-	rom ( name "centipede(dktronics).p" size 9790 crc 1e369ce6 md5 dd7d3f2e2b36ffbd2cc169624fc60421 sha1 7770684a912c0bb2116d9f73f1caafc1796a23df )
-	rom ( name "Centipede(dktronics).tzx" size 10008 crc f12c5ee1 md5 78b3d51b99fa1b99182d60b206fe2944 sha1 c90d0ca1dd3e1679c9c0e4a359d6b84978c129f7 )
+	name "Ardrijkskunde (19xx)(-)(nl)"
+	description "Ardrijkskunde (19xx)(-)(nl)"
+	rom ( name "Ardrijkskunde (19xx)(-)(nl).p" size 12244 crc cd4685b4 md5 608858c9e8d6a37cabf49764b65ad347 sha1 69e26bab8308806097ce21dc913683c7fafacb75 )
 )
+
 game (
-	name "Centipede (Green cover) (dK'tronics)"
-	description "Centipede (Green cover) (dK'tronics)"
-	manufacturer "dK'tronics"
-	rom ( name "centipede(green).p" size 9733 crc f5f4b919 md5 90610d4fa888969f53204a5ca98f6a20 sha1 418c10220fbf3bcf83c07b2a9c717dd12dc92c53 )
-	rom ( name "Centipede(Green).tzx" size 9967 crc 0ed972cd md5 9dd33fd4999f2d1de4bf52e4590d2521 sha1 1bf47ef2651d5d09a6971ce9eb931aa41ed846cb )
+	name "Area v1 (19xx)(-)"
+	description "Area v1 (19xx)(-)"
+	rom ( name "Area v1 (19xx)(-).p" size 1026 crc 7f011023 md5 d5fdb80a199496236650283708f2c443 sha1 d20e9fe7b3a1c9ed29b3370a382a58f732cbf7a6 )
 )
+
 game (
-	name "Centipede (Llamasoft)"
-	description "Centipede (Llamasoft)"
-	year 1982
-	manufacturer "Jeff Minter"
-	rom ( name "centipede.p" size 9706 crc f2414d13 md5 eeba50f572e820d43fb3f8d140c673e1 sha1 0f23aa3eac663bd04de225074b80701ba05fcb1b )
-	rom ( name "Centipede.tzx" size 9940 crc 163cf493 md5 74ac41b73e525977dd00e99e92a46e53 sha1 dd75bbb4ec90c8d054e1c0a41164e02a8f3121e3 )
+	name "Area v2 (19xx)(-)"
+	description "Area v2 (19xx)(-)"
+	rom ( name "Area v2 (19xx)(-).p" size 1132 crc f131009e md5 f8b5905909b25afeb4f8eb283068604d sha1 442bca18ef07dad7bebea2538e012a314b50e8f8 )
 )
+
 game (
-	name "Challenge (Micromega)"
-	description "Challenge (Micromega)"
-	manufacturer "Micromega"
-	rom ( name "Challenge.tzx" size 4865 crc 8439c8b1 md5 b963b33677e4e187630608606fecba67 sha1 b3dd53df21a684570b3120a8a996fae738dfb15a )
+	name "Area v3 (19xx)(-)"
+	description "Area v3 (19xx)(-)"
+	rom ( name "Area v3 (19xx)(-).p" size 1162 crc a3c00852 md5 42e6a0403d2a0a825350cbb8bd9dcfbc sha1 ddd01371af7189010acdd5eb0fb2e158dca1cee1 )
 )
+
 game (
-	name "Champions! (Peaksoft)"
-	description "Champions! (Peaksoft)"
-	manufacturer "Peaksoft"
-	rom ( name "champions.p" size 14858 crc d363867f md5 806e86a4e8c5807ce53717e4ba441c98 sha1 2148c6108e52c8c33a8c1593c47a1ee89ed711b8 )
-	rom ( name "Champions.tzx" size 15086 crc 7ae0415b md5 7f738befe88938ae2f5bfaf464cc2c16 sha1 1847183ffcaf74bb7f709d09d1d5fea24c720e6a )
+	name "Arithmetic Race (1982)(Sinclair User)[16K]"
+	description "Arithmetic Race (1982)(Sinclair User)[16K]"
+	rom ( name "Arithmetic Race (1982)(Sinclair User)[16K].p" size 2520 crc d69929bd md5 b95993f4829cf034aca56ed81f7e48a0 sha1 c0f4167e6776ebe4c9e42e790f88a142d50f95f4 )
 )
+
 game (
-	name "Chess (Timex)"
-	description "Chess (Timex)"
-	year 1982
-	manufacturer "Psion"
-	rom ( name "Chess(Timex).tzx" size 10227 crc 8f6bfdc7 md5 c0678ed697e11dfa85e483db93dd053c sha1 bd2a54d8ccb6bd918deaba02b0793cf0372c8f27 )
+	name "Armada (19xx)(-)(de)"
+	description "Armada (19xx)(-)(de)"
+	rom ( name "Armada (19xx)(-)(de).p" size 6071 crc 012c359c md5 ddff94e0ae2e86f3e2f16fe149d477ef sha1 8091b219d5e0b26ac0f176f1028dcc4911cca11f )
 )
+
 game (
-	name "Chrs Demo (Quicksilva)"
-	description "Chrs Demo (Quicksilva)"
-	manufacturer "Quicksilva"
-	rom ( name "ChrsDemo.tzx" size 5993 crc 3e8d1da7 md5 b69ea89a89170660517bf2284c791e12 sha1 8509b1fc61dc20c1e9280526858b0e95bd6359b5 )
+	name "Artillerie (1982)(Ch. Zwerschke)(de)"
+	description "Artillerie (1982)(Ch. Zwerschke)(de)"
+	rom ( name "Artillerie (1982)(Ch. Zwerschke)(de).p" size 3364 crc a67faa09 md5 08b88f42af146359edec546c06d46cb8 sha1 15aac768698795e6bb1de4b206dd528a3dbc9c4f )
 )
+
 game (
-	name "City of Xon (Pleasantrees)"
-	description "City of Xon (Pleasantrees)"
-	year 1982
-	manufacturer "Pleasantrees"
-	rom ( name "cityofxon.p" size 15507 crc e853667c md5 82a04afaf98222545389663888140b7b sha1 2111223fd0cab96c1aca585430336e60d501017f )
-	rom ( name "CityOfXon.tzx" size 15729 crc 3b72af94 md5 18b114ee78e469ea4b85e858802a716c sha1 0d07fb55913b3495b0c26178c84d010cd5eeb03e )
+	name "Artillerie (1982)(Ch. Zwerschke)(de)[a]"
+	description "Artillerie (1982)(Ch. Zwerschke)(de)[a]"
+	rom ( name "Artillerie (1982)(Ch. Zwerschke)(de)[a].p" size 3312 crc 86b314dc md5 51372c08211ea3d287061d7eebaf5070 sha1 09e55a1381c2a209307999404afa2b0dc2dd7bc0 )
 )
+
 game (
-	name "City Patrol (Sinclair Research)"
-	description "City Patrol (Sinclair Research)"
-	year 1982
-	manufacturer "Macronics (Don Priestley)"
-	rom ( name "citypatrol.p" size 9168 crc b9cf2e5f md5 a14424f16ed442e3c0af074f2ea01c95 sha1 333c2e1052dc734d76b19da5dddfaa9835177e12 )
-	rom ( name "CityPatrol.tzx" size 9388 crc 1ea8841e md5 71c94bc78806c1ea06d1996cbf6d64e8 sha1 99d5ae89cfe7940e67d8ede6dbd860020b1ad9df )
+	name "Artist (19xx)(-)[16K]"
+	description "Artist (19xx)(-)[16K]"
+	rom ( name "Artist (19xx)(-)[16K].p" size 1493 crc 9bc25fbc md5 173e41505ddda638955b95652e19a9a1 sha1 6a5f33de785ac7741ee60a123db9dcfebe3889ba )
 )
+
 game (
-	name "Clever Clogs Whizz Quiz for age 7+ (Computertutor)"
-	description "Clever Clogs Whizz Quiz for age 7+ (Computertutor)"
-	year 1983
-	manufacturer "Computertutor"
-	rom ( name "whizzquiz.p" size 16032 crc b8995dc4 md5 7f62be0efdc60665d015473550fafa0e sha1 436c07c66875f854b57a43b543c3002ad6c3e061 )
-	rom ( name "WhizzQuiz.tzx" size 16252 crc 831e3890 md5 9cb954c3643f9bbdac2f2fd5ee28a79b sha1 81b7fa7bc053ea09617edd5428ea8b9bc7d8e4d2 )
+	name "Artist - Shuttle (19xx)(-)[16K]"
+	description "Artist - Shuttle (19xx)(-)[16K]"
+	rom ( name "Artist - Shuttle (19xx)(-)[16K].p" size 2246 crc efaf0170 md5 aea5bfb5b12104febf164b84529648b9 sha1 664dc771aba657c6b7ce2845466156eb77b801d9 )
 )
+
 game (
-	name "Club Record Controller (Sinclair Research)"
-	description "Club Record Controller (Sinclair Research)"
-	year 1982
-	manufacturer "ICL"
-	rom ( name "clubrecordcontroller.p" size 6857 crc 16b8f22f md5 481daf4708c4217ff3c5446f049e5d61 sha1 73048e28d5c2f198a97c1ba33e9a2111a1901465 )
-	rom ( name "ClubRecordController.tzx" size 7075 crc c1bdaa09 md5 03638152afe7d50f7f3050d42423fb5a sha1 246f887ed316a62311165af8ac7abee59c0cfce6 )
+	name "Assembler (19xx)(-)"
+	description "Assembler (19xx)(-)"
+	rom ( name "Assembler (19xx)(-).p" size 8107 crc 788d33d8 md5 a8a8c516b5f92ff0a995217aa54c295c sha1 2ae6613247b297dd6703e93fb26bd99e1b70dd95 )
 )
+
 game (
-	name "Club Records (W. H. Smith)"
-	description "Club Records (W. H. Smith)"
-	year 1982
-	manufacturer "ICL"
-	rom ( name "clubrecords.p" size 7526 crc 770ead60 md5 43274f46a93f29e10650a6c0ea5d6ea6 sha1 06c9b03442650d03948bdd73095ba4541cf4fff4 )
-	rom ( name "ClubRecords.tzx" size 7744 crc 229bf155 md5 9061510c942e211db25159985fd39a7b sha1 d62dc88512d6dc336dad5637924e6056a19e12a7 )
+	name "Asteroid Belt (1983)(Fontana Publishing)"
+	description "Asteroid Belt (1983)(Fontana Publishing)"
+	rom ( name "Asteroid Belt (1983)(Fontana Publishing).p" size 3161 crc 23c99a64 md5 769cb61aef6e25d2ace2c9f487d14c37 sha1 40b18e1d42e7364dd11e358596d4ab0a0d6d6cd9 )
 )
+
 game (
-	name "Collector's Pack (Sinclair Research)"
-	description "Collector's Pack (Sinclair Research)"
-	year 1982
-	manufacturer "ICL"
-	rom ( name "collectorspack.p" size 7447 crc ad2faa57 md5 dc7c428a0df6b6140dd71f0924f80316 sha1 67ff172b4ec0b7b088b17ee62df3860851748705 )
-	rom ( name "CollectorsPack.tzx" size 7665 crc 4998a5d6 md5 8fd43049ae5c0246d79c82d59cef6cd4 sha1 bb2b43893119eabf30754be20992bf32e05e6832 )
+	name "Asteroid Storm (19xx)(-)"
+	description "Asteroid Storm (19xx)(-)"
+	rom ( name "Asteroid Storm (19xx)(-).p" size 3890 crc 71e80845 md5 56dbf5aa651fa888f2c69cecdcc60998 sha1 8de3e0a00257a04772e4466f85be2cb96b502bcc )
 )
+
 game (
-	name "Collector's Recording System (W. H. Smith)"
-	description "Collector's Recording System (W. H. Smith)"
-	manufacturer "ICL"
-	rom ( name "collectorsrecordingsystem.p" size 7447 crc fe3eb9cc md5 8af2b0e4d7a7480859b978aff6b8954d sha1 bf4b5d5c78b6a1e68784296567aa655362d6a552 )
-	rom ( name "CollectorsRecordingSystem.tzx" size 7665 crc 1a89b64d md5 d0735fc71d39a879e80fe130f3ca8226 sha1 7fb6cf85c4a0e47a2ad78f5f4371deeebadcb923 )
+	name "Asteroids (1984)(Mike Pike)"
+	description "Asteroids (1984)(Mike Pike)"
+	rom ( name "Asteroids (1984)(Mike Pike).p" size 5524 crc 574a4012 md5 1a4272effdc1b8597ed639f8fd3b264d sha1 711b729c43df6708ab41f1ddf27ac97e56a48580 )
 )
+
 game (
-	name "Community Chest (Artic)"
-	description "Community Chest (Artic)"
-	manufacturer "Artic"
-	rom ( name "communitychest.p" size 14048 crc 0fe4512d md5 a40b1c79c5b578238002454f2a4b92bc sha1 941725aeef9136f7b105bd1e8c21245ec671ac86 )
-	rom ( name "CommunityChest.tzx" size 14270 crc bf585c82 md5 a4b42d6021ceca0f9c09aa0e6596c110 sha1 c95af3f37795adabe7f251643efff51cb7e2579f )
+	name "Asteroids (1984)(Mike Pike)[a2]"
+	description "Asteroids (1984)(Mike Pike)[a2]"
+	rom ( name "Asteroids (1984)(Mike Pike)[a2].p" size 5656 crc 9918da4f md5 d1db0000587ff2352f1df0b08565345d sha1 d3e46a94d0cdccfc13ed7dee3b42c843d1df0bb9 )
 )
+
 game (
-	name "ComputaCalc ZX (Alternative cover) (Silicon Tricks)"
-	description "ComputaCalc ZX (Alternative cover) (Silicon Tricks)"
-	year 1981
-	manufacturer "S. C. Stephens"
-	rom ( name "computacalc.p" size 8990 crc 45eaf966 md5 7d48eecd455038a643e84cfd5feab476 sha1 d765d5c3aa5e516e07eb9465e222a777ed540fa8 )
-	rom ( name "ComputaCalc.tzx" size 9228 crc 06066afc md5 fe153257a523703b95488a6cdb4640bc sha1 496065dbc17d2461647bb76933ad9247f03cd1de )
+	name "Asteroids (1984)(Mike Pike)[a]"
+	description "Asteroids (1984)(Mike Pike)[a]"
+	rom ( name "Asteroids (1984)(Mike Pike)[a].p" size 5606 crc ddcaf17a md5 bb60ff5b850fb1f49d4cbc0eb6440612 sha1 4f007befcb6420f0340cba04698e49b4902a2370 )
 )
+
 game (
-	name "ComputaCalc ZX (Silicon Tricks)"
-	description "ComputaCalc ZX (Silicon Tricks)"
-	year 1981
-	manufacturer "S. C. Stephens"
-	rom ( name "computacalc.p" size 8990 crc 45eaf966 md5 7d48eecd455038a643e84cfd5feab476 sha1 d765d5c3aa5e516e07eb9465e222a777ed540fa8 )
-	rom ( name "ComputaCalc.tzx" size 9228 crc 06066afc md5 fe153257a523703b95488a6cdb4640bc sha1 496065dbc17d2461647bb76933ad9247f03cd1de )
+	name "Asteroids (19xx)(-)"
+	description "Asteroids (19xx)(-)"
+	rom ( name "Asteroids (19xx)(-).p" size 3425 crc b6dada0f md5 e48a350235215f9c62c734f897d18e57 sha1 d0c5eeea3b65071cfe2d54de0662577bc004eaf0 )
 )
+
 game (
-	name "Constellation (Bug Byte)"
-	description "Constellation (Bug Byte)"
-	manufacturer "Bug Byte"
-	rom ( name "constellation.p" size 12385 crc 82892356 md5 b7ff958c98e6955281aed8d50ce4a8b2 sha1 b020cec9fd14f00882de28165f4f2a207e020306 )
-	rom ( name "Constellation.tzx" size 12611 crc a0146b49 md5 500508c55bfae7c20d1191cf95b37e5d sha1 fb8bbc99988812c5ef372a7358a36ceadb53ae73 )
+	name "Asteroids (19xx)(-)[a2]"
+	description "Asteroids (19xx)(-)[a2]"
+	rom ( name "Asteroids (19xx)(-)[a2].p" size 3419 crc bbbb9be2 md5 2b69aec0b128c65dcc774ecee247d543 sha1 ddc38ba474906884c3c139846b7fb60bfbc7a4f4 )
 )
+
 game (
-	name "Constellation (Gladstone) (Gladstone Electronics)"
-	description "Constellation (Gladstone) (Gladstone Electronics)"
-	manufacturer "Bug Byte"
-	rom ( name "constellation(ge).p" size 15452 crc ca46cb85 md5 7eb28d1ad0f29be00794f00be04ff1e7 sha1 58f35fb046a9e20052dc7b838e1754c593fcdb53 )
-	rom ( name "Constellation(GE).tzx" size 15694 crc 89092de9 md5 e76748a332503ed9799fb76a16cf24f2 sha1 69da2b7f7a1f311a73858f4787f05c31460e7172 )
+	name "Asteroids (19xx)(-)[a3]"
+	description "Asteroids (19xx)(-)[a3]"
+	rom ( name "Asteroids (19xx)(-)[a3].p" size 3419 crc 24719e5d md5 2be620eed9b25cda390af351ca9c5775 sha1 c2ec566a981cdbf30d53b8a8233e84b912db6d1f )
 )
+
 game (
-	name "Control Technology Tapes 1,2,3 (Control Technology)"
-	description "Control Technology Tapes 1,2,3 (Control Technology)"
-	manufacturer "Control Technology"
-	rom ( name "ControlTechnology123.tzx" size 48433 crc d9610ea9 md5 1c5691270a4f2ef50a859f6eefe7891f sha1 8e630dbc2725862733cd138e69a7c8ca9eeed84f )
+	name "Asteroids (19xx)(-)[a4]"
+	description "Asteroids (19xx)(-)[a4]"
+	rom ( name "Asteroids (19xx)(-)[a4].p" size 3457 crc 1c45b63c md5 56f211a86c6ce8097d027c7a4e581c5e sha1 d337610b4a79766a8d268fe663a33442c314547a )
 )
+
 game (
-	name "Conversational German (Timex)"
-	description "Conversational German (Timex)"
-	year 1983
-	manufacturer "D. E. Hagan"
-	rom ( name "conversationalgerman.p" size 15375 crc 2a3a859e md5 b73d18d611af33ad7c555f03f0cc597d sha1 f03403678a5b6caa88cedee89aee74ba8d4270ab )
-	rom ( name "ConversationalGerman.tzx" size 15603 crc 810bdcc4 md5 1e27801fd4db30240671c6f1ecbbe73d sha1 ddb421fe807557a6f4a2eb7ea78e15c249b15de1 )
+	name "Asteroids (19xx)(-)[a]"
+	description "Asteroids (19xx)(-)[a]"
+	rom ( name "Asteroids (19xx)(-)[a].p" size 3419 crc 5816f698 md5 8e7e5f7a46b13d242a97ba25c1c144f4 sha1 64a1cc6092657d108c500cadb7fb73b5f2c9e39c )
 )
+
 game (
-	name "Cosmic Guerilla (Quicksilva)"
-	description "Cosmic Guerilla (Quicksilva)"
-	year 1983
-	manufacturer "C. K. Tame"
-	rom ( name "cosmicguerilla.p" size 7333 crc 8594884e md5 37c438dbf7ec1a61b574c870ab04b375 sha1 1f0226f4de15f5ee393761631a6d3aad46c75a10 )
-	rom ( name "CosmicGuerilla.tzx" size 7561 crc 001ef96d md5 de8ca35128d7ec90516dd6ee759e65a6 sha1 ef8e79312d0dc7efec6bf2a9a6ca785b0e4a94a0 )
+	name "Astral Convoy (1982)(Vortex Software)"
+	description "Astral Convoy (1982)(Vortex Software)"
+	rom ( name "Astral Convoy (1982)(Vortex Software).p" size 9119 crc be1abdd1 md5 f248b6de3880120bce91754c70c05427 sha1 2bd5ccaa3048d14d3bbcb3fef50f364da53b4eba )
 )
+
 game (
-	name "Counter Attack (Woodside Software)"
-	description "Counter Attack (Woodside Software)"
-	manufacturer "P. Hennessy"
-	rom ( name "counterattack.p" size 6975 crc 4095691a md5 846be5d9faf79197323d5c2b05b82136 sha1 45aae62dc5ed72ecba3c33b280b2c3d7310cf942 )
-	rom ( name "CounterAttack.tzx" size 7219 crc 6b8852ca md5 dfe0270c48c5af69bd0652f723f6c5b2 sha1 286cd36a713f95ffcc5e847539a59de6c55f6c42 )
+	name "Astral Convoy (1982)(Vortex Software)[a2]"
+	description "Astral Convoy (1982)(Vortex Software)[a2]"
+	rom ( name "Astral Convoy (1982)(Vortex Software)[a2].p" size 9155 crc 0411cf5f md5 90b311345feaf9269ac15cc20a0ce8f6 sha1 5ede1981bd72a8ddaf80d331380515c47c3aaf44 )
 )
+
 game (
-	name "Critical Path Analysis (Hilderbay)"
-	description "Critical Path Analysis (Hilderbay)"
-	year 1981
-	manufacturer "Hilderbay"
-	rom ( name "criticalpathanalysis.p" size 6053 crc 10fb4d01 md5 30f5b565eebb684d446a1d9073860bd2 sha1 e6e505e111c04a395e8a946cf2c5b7bbed948ba1 )
-	rom ( name "CriticalPathAnalysis.tzx" size 6275 crc 28ee5886 md5 47b2d99a813ea1744ad5a41d15016a8d sha1 3ee5a82dec70e4bd7eb1d514cdd4538cb433f24a )
+	name "Astral Convoy (1982)(Vortex Software)[a]"
+	description "Astral Convoy (1982)(Vortex Software)[a]"
+	rom ( name "Astral Convoy (1982)(Vortex Software)[a].p" size 9161 crc 743224aa md5 5029ce62df40665f111210550dab30f6 sha1 1917bb38e94c559c3e4a928de8466ef67b5d0fec )
 )
+
 game (
-	name "Critical Path Analysis (Timex)"
-	description "Critical Path Analysis (Timex)"
-	year 1982
-	manufacturer "W. Emery"
-	rom ( name "CriticalPathAnalysis(Timex).tzx" size 6720 crc c1835895 md5 af015196bc37c30e8f529da34262ed28 sha1 469f80fbf8e3979b8534e28dabd9d7089e55425e )
+	name "Auto Maintenance (1982)(Softsync)"
+	description "Auto Maintenance (1982)(Softsync)"
+	rom ( name "Auto Maintenance (1982)(Softsync).p" size 16182 crc 7f59043a md5 dcabd3d697f1833f2d59e90670da4ba2 sha1 1557ec05b470e5c661e798fb12eed1929b8c4f9e )
 )
+
 game (
-	name "Croaka-Crawla (Quicksilva)"
-	description "Croaka-Crawla (Quicksilva)"
-	year 1983
-	manufacturer "Quicksilva"
-	rom ( name "croakacrawla.p" size 14666 crc 2e8a9af1 md5 96fdeaf0f549a9198b633a19510be1fe sha1 4bb58b01e86aaf1dc21999e77ec7d557f4353ffe )
-	rom ( name "CroakaCrawla.tzx" size 14896 crc 1e07d1c3 md5 51e05750eda73cbd667e52d945c742d9 sha1 3489fd97ee769b1b59e0b74ccdeb667f135dbcbd )
+	name "Auto Maintenance (1982)(Softsync)[a]"
+	description "Auto Maintenance (1982)(Softsync)[a]"
+	rom ( name "Auto Maintenance (1982)(Softsync)[a].p" size 16050 crc 0322a4f7 md5 bd675cbe076df004adb69e60d0a04567 sha1 613950d51b340fac4801b73d30dbdf08af3dde09 )
 )
+
 game (
-	name "CroZXy Road"
-	description "CroZXy Road (2015) - Bob's interpretation of Hipster Whale's iconic 'Crossy Road'"
-	rom ( name "CrozxyRoad.p" size 16058 crc 38885a68 md5 dee3fff6ce7789a7a4a4c38cffdb7a5d sha1 98ef4e7a24f87c9d253da0dc68698850dcd2752f )
+	name "Autochef (1982)(CCS)"
+	description "Autochef (1982)(CCS)"
+	rom ( name "Autochef (1982)(CCS).p" size 15463 crc 34290b41 md5 dc31f1d493f32c14acabe6fc0eb5f7cb sha1 38b87eb715b948c2b2b75b6747e12f0d82150ec0 )
 )
+
 game (
-	name "D Coder (Cosma)"
-	description "D Coder (Cosma)"
-	manufacturer "Cosma"
-	rom ( name "DCoder.A.tzx" size 7680 crc 1684ba79 md5 229d7eb3cd3c17b82a1fb4e5daec5370 sha1 39f16bb21b52c566218f38aa07b1951e38c0f8bd )
+	name "Automatical Renumber (19xx)(-)"
+	description "Automatical Renumber (19xx)(-)"
+	rom ( name "Automatical Renumber (19xx)(-).p" size 1595 crc baf18fef md5 fca9a1e6efd5c6756a7909e351f92995 sha1 724eeaf3787c97148642fa2948e1c016082c59e3 )
 )
+
 game (
-	name "Dallas (French) (Cases Computer Simulations)"
-	description "Dallas (French) (Cases Computer Simulations)"
-	year 1983
-	manufacturer "Cases Computer Simulations"
-	rom ( name "dallas(french).p" size 16151 crc 6fc5f7ec md5 c76bd00587e4017e445c023ad12fdfcb sha1 1d1cd2f2ce3cdfc7a8c18e8bdd1cd0cdc8f2797e )
-	rom ( name "Dallas(French).tzx" size 16379 crc 4a65562e md5 6ea358b625c6deecce8b906983884a27 sha1 499bee247f3bdc37eca67e95eee1624de11ec5d6 )
+	name "Avenger (1982)(Abacus Programs)"
+	description "Avenger (1982)(Abacus Programs)"
+	rom ( name "Avenger (1982)(Abacus Programs).p" size 7184 crc 05157ecf md5 10a6ed4a247a3bc615ab16f156ccda74 sha1 42af4018be25b06b12ecce794eae8c386492f8f0 )
 )
+
 game (
-	name "Dictator (Bug Byte)"
-	description "Dictator (Bug Byte)"
-	year 1982
-	manufacturer "Bug Byte"
-	rom ( name "dictator.p" size 16074 crc 9ef1b3cf md5 8aa9775f53f519ded0ae7f7a2c5b3f60 sha1 42b98d75f715b69c1c54722a05a8d0d7b07783ec )
-	rom ( name "Dictator.tzx" size 16306 crc b01e01a7 md5 2e2e96ed20915990eb8280021ce7838e sha1 c14608ecc904b6ad8141d64bb4eed66c43b6316d )
+	name "Avoid (1983)(Fontana Publishing)"
+	description "Avoid (1983)(Fontana Publishing)"
+	rom ( name "Avoid (1983)(Fontana Publishing).p" size 1390 crc cb72e451 md5 603a057c3193257fbd018ae7edd6930d sha1 1aa63099ca751a1527654ed2457ad9a5e5c92d4f )
 )
+
 game (
-	name "Do Not Pass Go (Work Force)"
-	description "Do Not Pass Go (Work Force)"
-	manufacturer "Work Force"
-	rom ( name "donotpassgo.p" size 13355 crc 292a5505 md5 0480349fbee60fd0939f31cc6d210c2b sha1 a05ba8ad8560a15c5ecffff289d10daa421b5cb8 )
-	rom ( name "DoNotPassGo.tzx" size 13587 crc a2dd0f0c md5 d4cdfcee0472c465483738b520960d65 sha1 45ded58ce3255e5239722c956eef084bac20ad6d )
+	name "Avoider 1 (19xx)(-)[m]"
+	description "Avoider 1 (19xx)(-)[m]"
+	rom ( name "Avoider 1 (19xx)(-)[m].p" size 2347 crc 45fb1cd1 md5 16e2d3af7ec35f240ce69cda03693f0b sha1 2622047a767be0830e4e94cc6b63b67a9443eebc )
 )
+
 game (
-	name "Dodgems and Connect 4 (Brown inlay) (CDS Micro Systems)"
-	description "Dodgems and Connect 4 (Brown inlay) (CDS Micro Systems)"
-	year 1982
-	manufacturer "CDS Micro Systems"
-	rom ( name "DodgemsAndConnect4(Brown).tzx" size 9488 crc 39d4e107 md5 b6110b1177643dfb269784ee01902964 sha1 de9f3293e482ac4f92b3278d262e45321450fe79 )
+	name "Avoider 2 (19xx)(-)[m]"
+	description "Avoider 2 (19xx)(-)[m]"
+	rom ( name "Avoider 2 (19xx)(-)[m].p" size 4267 crc a472973a md5 ac914b93176e105b46ae73fe3c1077c2 sha1 4be8ae295297adab04c5db4dae8b2ae62c52b3dd )
 )
+
 game (
-	name "Domin8tr1s"
-	description "Domin8tr1s (2010) - Arrange the dominoes as they tumble from the sky so that matching digits are adjacent, either horizontally or vertically, to each other.  Align the same number of digits as the digit itself to make those dominoes disappear."
-	rom ( name "DOMIN8TR1S.P" size 6581 crc 96911e31 md5 d3e69b3bba27f609f426a6434f3a93ac sha1 8e8ee9c4fc589f386596ef3b3e8fab9b9ee799ef )
+	name "Avoider 3 (1989)(-)[m]"
+	description "Avoider 3 (1989)(-)[m]"
+	rom ( name "Avoider 3 (1989)(-)[m].p" size 4283 crc 0fdf313c md5 87654eb46948b74d44b0d3518e09d7b4 sha1 2153c0850cbeeb1a2b8ad9b849dad9b413773fc0 )
 )
+
 game (
-	name "Dominoes (Phipps Associates)"
-	description "Dominoes (Phipps Associates)"
-	year 1983
-	manufacturer "D. G. Cross"
-	rom ( name "dominoes.p" size 15143 crc f53499e9 md5 7c250a09c6e3e1fe996ab0df7fc312ff sha1 cd00bf0a030844133f39fbbac4712ba1c8591dca )
-	rom ( name "Dominoes.tzx" size 15375 crc 4fc4e410 md5 c9ec351812095d3a1a91e4db7926a5d8 sha1 b780954c535ccd6f6a778999b7244de33bb3ad53 )
+	name "Avventura Su Marte (19xx)(-)(it)"
+	description "Avventura Su Marte (19xx)(-)(it)"
+	rom ( name "Avventura Su Marte (19xx)(-)(it).p" size 13741 crc 7928d1c1 md5 eece748714d3ed7def29734ae31012c4 sha1 9cdd6ddb71220217972df13102cb7e8c35635824 )
 )
+
 game (
-	name "Dr. Floyd (Apropos Technology)"
-	description "Dr. Floyd (Apropos Technology)"
-	manufacturer "Apropos Technology"
-	rom ( name "drfloyd.p" size 14062 crc d16282da md5 4e26541f29e46baba6beac4ad8bccc31 sha1 c5531613742a634a5b41503198ae567adc6a42ab )
-	rom ( name "DrFloyd.tzx" size 14294 crc d5b0408f md5 5e0b05b046b113239ec5efdb9e23589e sha1 6982c898304a0e319434984a019b96682d177661 )
+	name "Awari (19xx)(-)"
+	description "Awari (19xx)(-)"
+	rom ( name "Awari (19xx)(-).p" size 8221 crc 0c6a777d md5 6c6801368bd0ca0ed35ae7352d51531e sha1 3fb954cc75c0981ccbbbd862ba83cbd91342cc26 )
 )
+
 game (
-	name "Dragon Maze (Macronics)"
-	description "Dragon Maze (Macronics)"
-	year 1981
-	manufacturer "Macronics"
-	rom ( name "dragonmaze.p" size 4750 crc b252b048 md5 d5520c004ecd8e8d15d36fa70fddec8e sha1 f6f90b253527935b27ce3674c49b33d914b37dfc )
-	rom ( name "DragonMaze.tzx" size 4970 crc c2a29e0d md5 3aaaadd623df3a672361715bb3b9c6f3 sha1 58e77f8d47f0a0061f0545e3d95485d9041d7025 )
+	name "Backgammon (19xx)(Chambers)"
+	description "Backgammon (19xx)(Chambers)"
+	rom ( name "Backgammon (19xx)(Chambers).p" size 12116 crc dcd251e7 md5 22bd89ea89235a36d599308358276893 sha1 20ea157e190bd6bf24ddc863f4437d169a2c8a19 )
 )
+
 game (
-	name "Dungeons of Doom (Temptation Software)"
-	description "Dungeons of Doom (Temptation Software)"
-	year 1982
-	manufacturer "Simon Mansfield"
-	rom ( name "DungeonsOfDoom.tzx" size 15074 crc d5034066 md5 747215bd1afebf2217addc18b14b1e36 sha1 b2884c73af5da39e4c32d9a11206769e006f456f )
+	name "Backgammon (19xx)(Chambers)(nl)"
+	description "Backgammon (19xx)(Chambers)(nl)"
+	rom ( name "Backgammon (19xx)(Chambers)(nl).p" size 10602 crc 21068c45 md5 bc8716fe54af90d80c53a8335a20c15a sha1 feafac3a029cfa84cfaffa1cdfb6549a5ddcd59d )
 )
+
 game (
-	name "E.E. 1 - Filter Design (Timex)"
-	description "E.E. 1 - Filter Design (Timex)"
-	year 1982
-	manufacturer "American Micro Products"
-	rom ( name "ee1filterdesign.p" size 11825 crc a6a157c9 md5 5e5b10ecc426f5820f3dab25b7c6ad92 sha1 152342a49020a5740a50650d9b2bbf9c5d66c9b7 )
-	rom ( name "EE1FilterDesign.tzx" size 12047 crc 1159b6aa md5 0a3fb9fd79259c485b0df31a4d387d20 sha1 d6714fe623f9e444c22cde90f56488a58fce0d33 )
+	name "Balken (19xx)(-)(de)"
+	description "Balken (19xx)(-)(de)"
+	rom ( name "Balken (19xx)(-)(de).p" size 2337 crc f0906fa2 md5 5eea44f206488da3993b8308047b4539 sha1 5b466bef5ee3ee2991484d847f8b08ed62785014 )
 )
+
 game (
-	name "Electric Cost Analyzer (Timex)"
-	description "Electric Cost Analyzer (Timex)"
-	year 1983
-	manufacturer "Tim Rossetti"
-	rom ( name "electriccostanalyzer.p" size 15557 crc bccae88d md5 adca050f5154d5e1107ca72433db06e1 sha1 dd7ae4f987b76d764d60d5a0fd95cf879310dde2 )
-	rom ( name "ElectricCostAnalyzer.tzx" size 15789 crc d6745b7a md5 ca1d14bad434d1ad36f829aaac3939a1 sha1 f5f5c2a8038df69484937ce4b853b4e83dfcf5f5 )
+	name "Ballistik (19xx)(-)"
+	description "Ballistik (19xx)(-)"
+	rom ( name "Ballistik (19xx)(-).p" size 1624 crc 71340d45 md5 f1435387d9ef3b8aacfd129624fed5ec sha1 f0c60a584bd19dc90307d795da9fc4968a928d93 )
 )
+
 game (
-	name "Electronics (Spectre)"
-	description "Electronics (Spectre)"
-	manufacturer "Spectre"
-	rom ( name "electronics.p" size 15899 crc b18d5d28 md5 8d3ee1b1eb0d3df446f50731c6659279 sha1 2f56472672d41361c60591d7cf177eb18148976b )
-	rom ( name "Electronics.tzx" size 16121 crc e777753a md5 48b223d7a2e94415ad4dc381b6a33fe8 sha1 d3a41d3aa66db93144eef927a1c37fc8bb9fab90 )
+	name "Bandit (19xx)(-)"
+	description "Bandit (19xx)(-)"
+	rom ( name "Bandit (19xx)(-).p" size 1579 crc 38f6c03a md5 8502ac351e9e3e2aeb263483b9cbf260 sha1 eaa82ba129ede32c5fc628d1c9ad0a02647343d9 )
 )
+
 game (
-	name "Encounter (Quicksilva)"
-	description "Encounter (Quicksilva)"
-	year 1982
-	manufacturer "Pixel"
-	rom ( name "Encounter.tzx" size 17612 crc af150f3f md5 d526d1745135dcc2bc1f357fa2cab910 sha1 ec8355c006d83dfc367a166ee6f33cb3530381ab )
+	name "Bar Chart (19xx)(-)"
+	description "Bar Chart (19xx)(-)"
+	rom ( name "Bar Chart (19xx)(-).p" size 9056 crc 49b3f602 md5 d174fe7371195722f9a58b8109d175ea sha1 65c504d711edff3225213123a42e0c2b4702218b )
 )
+
 game (
-	name "Escape From Manhattan (Computer Rentals)"
-	description "Escape From Manhattan (Computer Rentals)"
-	year 1983
-	manufacturer "N. Taylor"
-	rom ( name "escapefrommanhattan.p" size 16102 crc 63f8023f md5 135b8483bb5b316c8744d824acbb86c1 sha1 53799e5ea4da7a6c5ebba8537126f25ebbeb8285 )
-	rom ( name "EscapeFromManhattan.tzx" size 16320 crc 2cacbb72 md5 2b526ba624af0fdfc1733099ccec82ab sha1 975c976e36b9dbd47fcf5312fae4ad5c2521d6d7 )
+	name "Bar Chart (19xx)(-)(nl)"
+	description "Bar Chart (19xx)(-)(nl)"
+	rom ( name "Bar Chart (19xx)(-)(nl).p" size 5637 crc 93903615 md5 db361478eee811226d845b55b76f90e5 sha1 2ac72bf28a2b03159e871da5890a7e45dfce3716 )
 )
+
 game (
-	name "Escape from Shazzar (International Publishing and Software Inc.)"
-	description "Escape from Shazzar (International Publishing and Software Inc.)"
-	year 1983
-	manufacturer "A. F. Nuttall"
-	rom ( name "escapefromshazzar.p" size 16146 crc c587593d md5 b2dc9a81ac27d4bc267c8d4a0236acb5 sha1 48fa28f6b637e59f48a58e618617a98f83fe6813 )
-	rom ( name "EscapeFromShazzar.tzx" size 16376 crc 78075b95 md5 0854165d7caa9f5d43203e5f9c999fa0 sha1 992dfcece29b42c729bbca05422bf090dc7c275c )
+	name "Barquitos (1984)(Olegario Martinez)(es)"
+	description "Barquitos (1984)(Olegario Martinez)(es)"
+	rom ( name "Barquitos (1984)(Olegario Martinez)(es).p" size 11535 crc d8af5401 md5 bef2456a12e692452c603dfbca927236 sha1 61179650550f48eb5bd05ea3181f59f039c6aed1 )
 )
+
 game (
-	name "Fast Load Save (Musamy Software)"
-	description "Fast Load Save (Musamy Software)"
-	year 1982
-	manufacturer "Musamy Software"
-	rom ( name "FastLoadSave.tzx" size 11000 crc 939f03cb md5 be316fadc3492e475e6d07bdf9ae310e sha1 616dfc2662d46f415277990bebf0b09e187ed36e )
+	name "Base (19xx)(-)"
+	description "Base (19xx)(-)"
+	rom ( name "Base (19xx)(-).p" size 1535 crc 4eb99939 md5 4041fb0b74ef32161d7ca8ee41848bda sha1 75015db399fe355efd5498eee5a63b699932c3df )
 )
+
 game (
-	name "Flight Simulation (Sinclair Research)"
-	description "Flight Simulation (Sinclair Research)"
-	year 1982
-	manufacturer "Psion"
-	rom ( name "flightsimulation.p" size 13627 crc 7b1bb76a md5 7279ffb7409871741475587b3f707e70 sha1 f80f7b67fb2a629fa1492f67756ea2078e6d28d7 )
-	rom ( name "FlightSimulation.tzx" size 13855 crc 945da3c1 md5 cad45e8938878607ed1a6ca38f08c3c5 sha1 de020d7531c0904a8a152193e7b3d5203e5c1017 )
+	name "Base of Triangle (19xx)(-)"
+	description "Base of Triangle (19xx)(-)"
+	rom ( name "Base of Triangle (19xx)(-).p" size 1354 crc eca9bd4b md5 3c40727f702417aa13067a2723a1bedb sha1 f4a6f5607bf30809cfcf590844eda17f62fcdfe1 )
 )
+
 game (
-	name "Flug-Simulation (Sinclair Research)"
-	description "Flug-Simulation (Sinclair Research)"
-	year 1982
-	manufacturer "Psion"
-	rom ( name "flightsimulation.p" size 13627 crc 7b1bb76a md5 7279ffb7409871741475587b3f707e70 sha1 f80f7b67fb2a629fa1492f67756ea2078e6d28d7 )
-	rom ( name "FlightSimulation.tzx" size 13855 crc 945da3c1 md5 cad45e8938878607ed1a6ca38f08c3c5 sha1 de020d7531c0904a8a152193e7b3d5203e5c1017 )
+	name "Bases (19xx)(-)"
+	description "Bases (19xx)(-)"
+	rom ( name "Bases (19xx)(-).p" size 1460 crc 539d0630 md5 de5caff40ac72eeb5d06a9f1bbd00207 sha1 61e1aec084a866b5c47a9c8150471764d0681e21 )
 )
+
 game (
-	name "Football (Tyrant)"
-	description "Football (Tyrant)"
-	manufacturer "Tyrant"
-	rom ( name "football.p" size 15626 crc 33233387 md5 ef4f6c235f9017f7b4c83f19ffc72818 sha1 f0ee8a1607a606d22b7c2ba518a06bd2cd387fd9 )
-	rom ( name "Football.tzx" size 15858 crc 8503533c md5 673dfecb1920d35fcd55f23aab95dbf8 sha1 d75dfc7310f08160f7ff61f2e08f2ed4fa5aabb0 )
+	name "Battle (19xx)(-)"
+	description "Battle (19xx)(-)"
+	rom ( name "Battle (19xx)(-).p" size 15299 crc 95da43fa md5 db9696d93088bbf882e3a59130ca8fe6 sha1 19ed5ff18965525c298f3b290f415a0eee4e0dc6 )
 )
+
 game (
-	name "Football Manager (Addictive Games)"
-	description "Football Manager (Addictive Games)"
-	year 1982
-	manufacturer "Kevin J. Toms"
-	rom ( name "footballmanager.p" size 14736 crc fff630de md5 192646c148629b8f4b21cd9497c7c906 sha1 5a9fb7c31e7049ed46d1fce4f68551bb063d857d )
-	rom ( name "FootballManager.tzx" size 14968 crc 34e09721 md5 2c766ddb245dfa7cd4821b49875f63bd sha1 56180074fe4bbc0f6c0189b88482affd537b5645 )
+	name "Battleship (19xx)(-)"
+	description "Battleship (19xx)(-)"
+	rom ( name "Battleship (19xx)(-).p" size 4996 crc baae39c7 md5 7a324c9bfcca165e18012147eb0ccda6 sha1 37395b345c28eb23d022f77ad116f2603fe61f63 )
 )
+
 game (
-	name "Football Manager (Black inlay) (Addictive Games)"
-	description "Football Manager (Black inlay) (Addictive Games)"
-	year 1981
-	manufacturer "Kevin J. Toms"
-	rom ( name "footballmanager.p" size 14736 crc fff630de md5 192646c148629b8f4b21cd9497c7c906 sha1 5a9fb7c31e7049ed46d1fce4f68551bb063d857d )
-	rom ( name "FootballManager.tzx" size 14968 crc 34e09721 md5 2c766ddb245dfa7cd4821b49875f63bd sha1 56180074fe4bbc0f6c0189b88482affd537b5645 )
+	name "Battleship (19xx)(-)[m]"
+	description "Battleship (19xx)(-)[m]"
+	rom ( name "Battleship (19xx)(-)[m].p" size 4997 crc 89de2cbd md5 38e7ad33832b58a282353624e8395d5c sha1 a1f2aa7ba5a6c0bd6fb4d9d8e4fbf8cbf07d5db0 )
 )
+
 game (
-	name "Football Manager (Red) (Addictive Games)"
-	description "Football Manager (Red) (Addictive Games)"
-	year 1981
-	manufacturer "Kevin J. Toms"
-	rom ( name "footballmanager.p" size 14736 crc fff630de md5 192646c148629b8f4b21cd9497c7c906 sha1 5a9fb7c31e7049ed46d1fce4f68551bb063d857d )
-	rom ( name "FootballManager.tzx" size 14968 crc 34e09721 md5 2c766ddb245dfa7cd4821b49875f63bd sha1 56180074fe4bbc0f6c0189b88482affd537b5645 )
+	name "Battleships (1982)(Sinclair User)[16K]"
+	description "Battleships (1982)(Sinclair User)[16K]"
+	rom ( name "Battleships (1982)(Sinclair User)[16K].p" size 4616 crc c76a030b md5 e62692bc77730d93b4941af6e414a136 sha1 48202680cee7f466542b457be0fcc90241439430 )
 )
+
 game (
-	name "Football Pools Program (Hartland Software)"
-	description "Football Pools Program (Hartland Software)"
-	manufacturer "Hartland Software"
-	rom ( name "FootballPools.tzx" size 24422 crc 2d0ed98b md5 387bb8707269de22cfb13b4c8781d20c sha1 a2ae0611ad434600777c2ba0df4cc48d8109d9f8 )
+	name "Battlestar Galactica (1982)(Ch. Zwerschke)"
+	description "Battlestar Galactica (1982)(Ch. Zwerschke)"
+	rom ( name "Battlestar Galactica (1982)(Ch. Zwerschke).p" size 4648 crc 9145eaab md5 9eddb180c527f53084a8129c4c44bf6d sha1 cb34459a2a82d6cfc9efd6d9285c0fe13620a8a6 )
 )
+
 game (
-	name "Football-League (Video Software)"
-	description "Football-League (Video Software)"
-	year 1981
-	manufacturer "Video Software"
-	rom ( name "FootballLeague.A.tzx" size 14343 crc 78694c75 md5 64ad8a73b7b3b45c35aa937b09e14817 sha1 4887f03b6e5725d1acb156a485ddc9c450607d88 )
-	rom ( name "footballleague.p" size 14097 crc 9e4623c5 md5 b430448d983a97c6de8d0fd776bef9c8 sha1 c8b1bd7a85d2981ec2b6478e0c58b36dccb42ac3 )
+	name "Battlestar Galactica (1982)(Ch. Zwerschke)[a]"
+	description "Battlestar Galactica (1982)(Ch. Zwerschke)[a]"
+	rom ( name "Battlestar Galactica (1982)(Ch. Zwerschke)[a].p" size 5480 crc 830c4012 md5 d7b088f5884981b897edd7715581fb9c sha1 a07496498d3dfda8d0f1e3889de4d359d3149944 )
 )
+
 game (
-	name "Forth (Sinclair Research)"
-	description "Forth (Sinclair Research)"
-	year 1983
-	manufacturer "Artic"
-	rom ( name "Forth.tzx" size 14183 crc 376c5750 md5 5ad0f910d2987e3a51716dd82e6f4113 sha1 012a7e585c3f2d245e3d7ffba935ea1962be21c4 )
+	name "Beethoven (19xx)(-)(de)"
+	description "Beethoven (19xx)(-)(de)"
+	rom ( name "Beethoven (19xx)(-)(de).p" size 3408 crc 41ac447e md5 85cc98abfdefd7ca2e1ad3115a33264a sha1 8c0e248a0fc8a43ac9465d7081145be14b0b4274 )
 )
+
 game (
-	name "Fortress of Zorlac (Timex)"
-	description "Fortress of Zorlac (Timex)"
-	year 1982
-	manufacturer "Paul Carlson"
-	rom ( name "fortressofzorlac.p" size 7214 crc aded8203 md5 0852a128df135af9f240356567d626b8 sha1 872b7049cab2fea166921ba30d93fccdaf63f840 )
-	rom ( name "FortressOfZorlac.tzx" size 7442 crc 30d3ba7d md5 05b14472e34f62f64d40e71f0001f900 sha1 13f8969e92932f3f6e4c6f177bbe34512780b96f )
+	name "Bersagli (19xx)(Giuseppe E. Sargio)(it)"
+	description "Bersagli (19xx)(Giuseppe E. Sargio)(it)"
+	rom ( name "Bersagli (19xx)(Giuseppe E. Sargio)(it).p" size 2452 crc 6592f4ee md5 ce64080839f8a804650e032b1584596f sha1 20e8e674100fb3544d9e9f13187d1ac14c81db61 )
 )
+
 game (
-	name "Forty Niner (Software Farm)"
-	description "Forty Niner (Software Farm)"
-	manufacturer "Software Farm"
-	rom ( name "fortyniner.p" size 13868 crc b8650da4 md5 9729d9b8a4faee1d12f4384f789c0b44 sha1 694ac6d1410eade17ecc9e06a3c39191e8dda352 )
-	rom ( name "FortyNiner.tzx" size 14106 crc 1c4eff0a md5 fba0b998270a673af60ede6b1f6da4ff sha1 e563342e858b8c38a384ebfd695c479feb01a4a5 )
+	name "Best of Sync Vol. 1 (19xx)(-)"
+	description "Best of Sync Vol. 1 (19xx)(-)"
+	rom ( name "Best of Sync Vol. 1 (19xx)(-).p" size 1661 crc 645bee34 md5 bf9a37ceb4f58d570c8b8986046879a7 sha1 7005ad57c22f6ffdee47de1904c015fbb7159d54 )
 )
+
 game (
-	name "Frogger (DJL Software)"
-	description "Frogger (DJL Software)"
-	manufacturer "DJL Software"
-	rom ( name "frogger.p" size 13493 crc 8d24d478 md5 db791414f02377a0b2bb60e1539401f3 sha1 29d815b98770a1fbae3714642c5c70583d02ed17 )
-	rom ( name "Frogger.tzx" size 13723 crc bd7df880 md5 9a8c77a4c24e8e67f7308be91a2b95aa sha1 75499b16de8dfbabf668328109d0a36963bfd11b )
+	name "Big Chars (19xx)(-)"
+	description "Big Chars (19xx)(-)"
+	rom ( name "Big Chars (19xx)(-).p" size 1434 crc 6b4e4632 md5 cdd847ae9fde614670114c69fe9ba6b8 sha1 551d27dca2290be35fd82941249b4211a9a6606d )
 )
+
 game (
-	name "Frogger (Sega) (Timex)"
-	description "Frogger (Sega) (Timex)"
-	year 1981
-	manufacturer "Cornsoft/Sega"
-	rom ( name "frogger(sega).p" size 10638 crc 3993108b md5 1e6fdfe09452ba5609c693a7683c94f7 sha1 b17facf22bb6f66fe8eef0977cbdf1b1ecde6c6c )
-	rom ( name "Frogger(Sega).tzx" size 10868 crc 95952886 md5 e8ebe732890b6dc7d39674e7bf527716 sha1 08999372caf4a07b532e7360f1573c5262b56ed7 )
+	name "Big Foot Adventure (19xx)(-)"
+	description "Big Foot Adventure (19xx)(-)"
+	rom ( name "Big Foot Adventure (19xx)(-).p" size 16005 crc 1172885d md5 4d690233abbaf44493f097cef957e93b sha1 c02060113e89f77acc0b4d103601080a89930db9 )
 )
+
 game (
-	name "Froggy (DJL Software)"
-	description "Froggy (DJL Software)"
-	year 1982
-	manufacturer "DJL Software"
-	rom ( name "froggy.p" size 10394 crc 5624f4f4 md5 c0408bb2b6d716d9643fa64670d7c241 sha1 9f45088a30fdbddffccb01f55690cde7276df088 )
-	rom ( name "Froggy.tzx" size 10622 crc e84f00da md5 8a827657ccd27300bafaa4af1076045a sha1 c0d7d2db94e8fb84bb22428b0b6a5c5ccc11c52b )
+	name "Big One (19xx)(-)"
+	description "Big One (19xx)(-)"
+	rom ( name "Big One (19xx)(-).p" size 1288 crc a928ec34 md5 ac5a54c911ae0f790fbf5bc0de76eedb sha1 39be51bb617540c9c31f3c13b0eec0a015e54ecd )
 )
+
 game (
-	name "Frogs (Mikro-Gen)"
-	description "Frogs (Mikro-Gen)"
-	manufacturer "Mikro-Gen"
-	rom ( name "frogs.p" size 4223 crc b5335a99 md5 55d1b367c05a5f9259da78aad2b072da sha1 d3edabf6c4e7e88cb1224ace1c63b2735dbf2f0f )
-	rom ( name "Frogs.tzx" size 4453 crc efd0f05e md5 9409197480d2e19da908b0594580ee89 sha1 899d5cdf74208e30d17c5d34f5733d207222daaa )
+	name "Bigflap Attack (1982)(Timex)"
+	description "Bigflap Attack (1982)(Timex)"
+	rom ( name "Bigflap Attack (1982)(Timex).p" size 9899 crc d056b2f5 md5 ed0c0b9e8090bfea786a93d74210a3bf sha1 15b19ff1a75fb664ed1faaf6e20d2c9608f50d70 )
 )
+
 game (
-	name "Fun Fair Adventure (Fawkes Computing)"
-	description "Fun Fair Adventure (Fawkes Computing)"
-	year 1983
-	manufacturer "Fawkes Computing"
-	rom ( name "funfairadventure.p" size 15670 crc f5238943 md5 4f267d0ad39d72853cbb7ff914a491b0 sha1 d654cca3195f48a50e1391bc5bc8db72a1d4215f )
-	rom ( name "FunFairAdventure.tzx" size 15892 crc 477b0e8f md5 8b00dde0094158be9fa735e62bc99bf9 sha1 c828c69e2a899e1b15968dafeaeb19b6045b360b )
+	name "Bijenkorf, De (19xx)(-)(nl)"
+	description "Bijenkorf, De (19xx)(-)(nl)"
+	rom ( name "Bijenkorf, De (19xx)(-)(nl).p" size 9482 crc fd8388e9 md5 027213bb2ef916f60f3230da1b7c26ae sha1 8f92127c7a99b3f1731dd7185ae3ba8f264b1f73 )
 )
+
 game (
-	name "FUNdamentals of Math (Timex)"
-	description "FUNdamentals of Math (Timex)"
-	year 1983
-	manufacturer "ATM"
-	rom ( name "FUNdamentalsOfMath.tzx" size 39312 crc 75ade9a1 md5 fbe76752ce6fd550c78f7116e8472d37 sha1 0c1fd6d5034fa73e8d1d3dd525e088cd96971bd7 )
+	name "Bike Ride (19xx)(-)"
+	description "Bike Ride (19xx)(-)"
+	rom ( name "Bike Ride (19xx)(-).p" size 1370 crc 66f7b873 md5 f231106b5ddf4105e30d6adf1e81f66f sha1 7b8190a64e4512fe5f6276a225d1da89eaf20e76 )
 )
+
 game (
-	name "Galactic Gunner (Timex)"
-	description "Galactic Gunner (Timex)"
-	year 1983
-	manufacturer "Paul W. Carlson"
-	rom ( name "galacticgunner.p" size 8786 crc fef205ce md5 35300ca762e104fc8c6efba2280feb96 sha1 cbb2fb7c55caa311826d2a2481c6dffad40b5863 )
-	rom ( name "GalacticGunner.tzx" size 9014 crc 1ee1c007 md5 9e6d42b5ba230a9e298dfe1c49744b23 sha1 93f8f8b5fde8de8305d0946f25296da88e26d720 )
+	name "Billards (19xx)(-)"
+	description "Billards (19xx)(-)"
+	rom ( name "Billards (19xx)(-).p" size 11877 crc 7ea5c125 md5 1610a84868109035845f93aace99f130 sha1 246849f84df26d43b99e746840004a1e578a3319 )
 )
+
 game (
-	name "Galactic Patrol (Computer Rentals)"
-	description "Galactic Patrol (Computer Rentals)"
-	year 1983
-	manufacturer "Richard Brisbourne"
-	rom ( name "galacticpatrol.p" size 6063 crc 6fc3b9b1 md5 d88dcbd760136c7635c3cd44fc2f7548 sha1 e3c8afbb3e1dfd637aa974f33a887293965f573e )
-	rom ( name "GalacticPatrol.tzx" size 6295 crc 25cb9c4e md5 03a02bf71f85c41298c99424a97c1ffd sha1 ed32fc48477d367e241b4a7f311f7d0c7caa615a )
+	name "Billbord (19xx)(-)"
+	description "Billbord (19xx)(-)"
+	rom ( name "Billbord (19xx)(-).p" size 2078 crc e5d9d06b md5 7d9975c66773019cce0f6884003e6b79 sha1 83cef7f34634abfa2a7769d61a27a4713d2bfb90 )
 )
+
 game (
-	name "Galactic Patrol (Omega re-release) (Omega)"
-	description "Galactic Patrol (Omega re-release) (Omega)"
-	year 1984
-	manufacturer "CRL"
-	rom ( name "galacticpatrol.p" size 6063 crc 6fc3b9b1 md5 d88dcbd760136c7635c3cd44fc2f7548 sha1 e3c8afbb3e1dfd637aa974f33a887293965f573e )
-	rom ( name "GalacticPatrol.tzx" size 6295 crc 25cb9c4e md5 03a02bf71f85c41298c99424a97c1ffd sha1 ed32fc48477d367e241b4a7f311f7d0c7caa615a )
+	name "Billy Jumper (19xx)(-)(de)"
+	description "Billy Jumper (19xx)(-)(de)"
+	rom ( name "Billy Jumper (19xx)(-)(de).p" size 9060 crc 73cd995e md5 67447bf366b28e4d7e355a7f73acc9a8 sha1 ba538b5d60de04ff51c264ccf0b15527fa9bd6d9 )
 )
+
 game (
-	name "Galactic Trooper (Romik Software)"
-	description "Galactic Trooper (Romik Software)"
-	year 1983
-	manufacturer "Ian Morrison and David Anderson"
-	rom ( name "galactictrooper.p" size 4269 crc ae87f0a7 md5 74661343c5098f10bf44fdf40dc02f04 sha1 e6ba889b1f3d97366cc829d07e9d13fd665d40f5 )
-	rom ( name "GalacticTrooper.tzx" size 4517 crc 95146c5f md5 86cd07956e3d37c94d5cc19c7753f152 sha1 ee48ee10e53adbbbfe6d62c8b4fbadea8bc1eb16 )
+	name "Binair Decimall (19xx)(-)(nl)"
+	description "Binair Decimall (19xx)(-)(nl)"
+	rom ( name "Binair Decimall (19xx)(-)(nl).p" size 1293 crc 480c59cb md5 f0b36ca77fbcef7a12c1b879a984f1bc sha1 0374081651cfd20092429804e75ff38ee6ad1a2f )
 )
+
 game (
-	name "Galaxians (Artic)"
-	description "Galaxians (Artic)"
-	manufacturer "Artic"
-	rom ( name "galaxians.p" size 3562 crc b5fc1488 md5 ef30971ad58c33fe200bb36f95470350 sha1 190a30b1b54c09e681b8f07c196999e80105da98 )
-	rom ( name "Galaxians.tzx" size 3788 crc 1cb67cb3 md5 d81a74c24c6e4b923d3cde71b05ee5e0 sha1 8bec4c27d81da870a63ee5da3205855c27acb802 )
+	name "Binair Naar Decimaal (19xx)(P.M. Reuvers)(nl)"
+	description "Binair Naar Decimaal (19xx)(P.M. Reuvers)(nl)"
+	rom ( name "Binair Naar Decimaal (19xx)(P.M. Reuvers)(nl).p" size 1494 crc 5c96137c md5 f1c37aab808d16d3218061bc732d7dbc sha1 14769451c4d279b1081ac7f60a9251f341c9d16b )
 )
+
 game (
-	name "Galaxians (Monochrome) (Artic)"
-	description "Galaxians (Monochrome) (Artic)"
-	manufacturer "Artic"
-	rom ( name "galaxians.p" size 3562 crc b5fc1488 md5 ef30971ad58c33fe200bb36f95470350 sha1 190a30b1b54c09e681b8f07c196999e80105da98 )
-	rom ( name "Galaxians.tzx" size 3788 crc 1cb67cb3 md5 d81a74c24c6e4b923d3cde71b05ee5e0 sha1 8bec4c27d81da870a63ee5da3205855c27acb802 )
+	name "Bingo Numbers Generator (19xx)(-)[m]"
+	description "Bingo Numbers Generator (19xx)(-)[m]"
+	rom ( name "Bingo Numbers Generator (19xx)(-)[m].p" size 4097 crc 6b68dbbd md5 0b3bf22563e78de0fce56ec4d7b877dc sha1 b170f5226efcf98dbad26f1cd0d99ade444a708a )
 )
+
 game (
-	name "Galaxy Invaders (International Publishing and Software Inc.)"
-	description "Galaxy Invaders (International Publishing and Software Inc.)"
-	year 1982
-	manufacturer "International Publishing and Software Inc."
-	rom ( name "galaxyinvaders(ips).p" size 4002 crc 4328beba md5 fb94065d6c8b3a4aa2f12a7d015e569d sha1 1bb9b928230de4ab517bf8b248a687c94c3df639 )
-	rom ( name "GalaxyInvaders(IPS).tzx" size 4224 crc 6df4e24b md5 490e79f413dcb97060633218e014a62f sha1 23fc85b7e2ecfacd664dc991acf7e56393a345a1 )
+	name "Biorhythm Monitor (19xx)(-)"
+	description "Biorhythm Monitor (19xx)(-)"
+	rom ( name "Biorhythm Monitor (19xx)(-).p" size 13947 crc b264676a md5 b070078f3dc27231be3399dc08e312e9 sha1 1beb47ab159cda44b815c6b1ba5c8401d363a2b7 )
 )
+
 game (
-	name "Galaxy Jailbreak (Romik Software)"
-	description "Galaxy Jailbreak (Romik Software)"
-	year 1983
-	manufacturer "Roland Stokes"
-	rom ( name "galaxyjailbreak.p" size 5413 crc ae762991 md5 6493ac3cd7c77be6027bc00c3932c68c sha1 aeb080263f016d94bf0a13ff521bbc30d7032686 )
-	rom ( name "GalaxyJailbreak.tzx" size 5661 crc 8f630ce4 md5 f1ceb2d7e0cee7cb924a0b824dbf418b sha1 351dce4ff4d8d3dcc68508b39bb910b21cecfb84 )
+	name "Biorhythmus (19xx)(-)(de)"
+	description "Biorhythmus (19xx)(-)(de)"
+	rom ( name "Biorhythmus (19xx)(-)(de).p" size 3014 crc d3c4a090 md5 cac390efc6c7a524989d2ff2a26cbf2e sha1 d44bb5b936f84af2165002b15df8aedafead85c2 )
 )
+
 game (
-	name "Galaxy Warrior/Star Trek (Artic)"
-	description "Galaxy Warrior/Star Trek (Artic)"
-	manufacturer "Artic"
-	rom ( name "GalaxyWarriorAndStarTrek.tzx" size 11620 crc 1bcb3a5f md5 fff5135ca3ac8c8553e9eace62d55667 sha1 abfb5609bfa713c2f4841bc45ba11eb7363b6bf7 )
+	name "Biorhythmus (19xx)(-)(de)[a]"
+	description "Biorhythmus (19xx)(-)(de)[a]"
+	rom ( name "Biorhythmus (19xx)(-)(de)[a].p" size 2959 crc c098522b md5 ef227c8baf6212478a84b1d2d2ef9a7f sha1 6e92dd337262609a1bddd24d36d451fae85273e5 )
 )
+
 game (
-	name "Games Pack (JRS Software)"
-	description "Games Pack (JRS Software)"
-	year 1982
-	manufacturer "JRS Software"
-	rom ( name "GamesPack.tzx" size 20187 crc 4c92529e md5 893ed24f30dbba822dc001b87750b873 sha1 eb8aec55c92fc530591e033c862ce3b95c40a149 )
+	name "Biorythme (19xx)(-)(nl)"
+	description "Biorythme (19xx)(-)(nl)"
+	rom ( name "Biorythme (19xx)(-)(nl).p" size 8296 crc f96d7445 md5 5c8956a026f0582359634922c7ceb0ea sha1 740a2c60f15113ce6daecbcf2f6b7c6450535261 )
 )
+
 game (
-	name "General Statistics (W. H. Smith)"
-	description "General Statistics (W. H. Smith)"
-	year 1982
-	manufacturer "ICL"
-	rom ( name "generalstatistics.p" size 14214 crc 10c6ef87 md5 a779367a54ad8ac03543a2d70c2e88e1 sha1 f65e699472236439c262640299628cb01284223e )
-	rom ( name "GeneralStatistics.tzx" size 14466 crc 8889d5e3 md5 acf9669f43af8b165cda56888e9a1348 sha1 a1f94c7ca3a27e24ebfaba575700cfccf8640356 )
+	name "Bipods (19xx)(-)"
+	description "Bipods (19xx)(-)"
+	rom ( name "Bipods (19xx)(-).p" size 3370 crc 5a3a3041 md5 5dece2161fb76555fdeb24f5e5ca9dc8 sha1 1274433c270d7aa2ff1dbd77cf7d9105737bdaba )
 )
+
 game (
-	name "Geographics UK (Novus Software)"
-	description "Geographics UK (Novus Software)"
-	manufacturer "Novus"
-	rom ( name "geographicsuk.p" size 16037 crc fbc771bf md5 fea62f9b738c3f63cf9de62a37431588 sha1 fb07ebddca1f03eef2b4d06052d4abde520d4ae0 )
-	rom ( name "GeographicsUK.tzx" size 16281 crc 4af3cfc9 md5 4534b531e811c27a32effaa76a9a257e sha1 0d88e5bc5e71cc898a375156e40396b5b536d7a0 )
+	name "Bipods (19xx)(-)[a]"
+	description "Bipods (19xx)(-)[a]"
+	rom ( name "Bipods (19xx)(-)[a].p" size 3339 crc 27fd14aa md5 b5e6ddcd52e52a9238e1a1c34db9cdb9 sha1 6e97117d43724375c29b965ff6cc60e734815163 )
 )
+
 game (
-	name "Geometry 1 (Timex)"
-	description "Geometry 1 (Timex)"
-	year 1982
-	manufacturer "Home Computer Software"
-	rom ( name "Geometry1.tzx" size 5483 crc 80dad6c4 md5 d8c843396ea93e08a986ed3ec74a1b53 sha1 be9373f6519a369e7d2dba40a14319f4751b1b78 )
+	name "Black Holes (1983)(Peter Davis)[m David Buttery]"
+	description "Black Holes (1983)(Peter Davis)[m David Buttery]"
+	rom ( name "Black Holes (1983)(Peter Davis)[m David Buttery].p" size 1973 crc 260d3e7b md5 690cf138a8154626078da7638cc9a0bd sha1 e15d964b855c238219ec5cb8554ef3d06c8eea28 )
 )
+
 game (
-	name "Ghost Hunt (PSS)"
-	description "Ghost Hunt (PSS)"
-	year 1982
-	manufacturer "PSS"
-	rom ( name "ghosthunt.p" size 5302 crc dea898bd md5 dc3e16535dcf3395085a311decc1d8e5 sha1 da84c5b1e1e7cb26ebdbaa119a4e0f29f9e4ef4f )
-	rom ( name "GhostHunt.tzx" size 5538 crc 8e8d76f5 md5 c3b97b5345ea55bdc8c6307ee40f21b2 sha1 33ac921be892a02c115f7dfa73c54cafe178671b )
+	name "Black Jack (1982)(G. Dewey)"
+	description "Black Jack (1982)(G. Dewey)"
+	rom ( name "Black Jack (1982)(G. Dewey).p" size 13239 crc ad03e84a md5 68a896acf50f576dbad41783f8f0e914 sha1 5b7c993d7b06c5978ea7217b2946d9d5549429e8 )
 )
+
 game (
-	name "Gobbleman (Colour Inlay) (Artic)"
-	description "Gobbleman (Colour Inlay) (Artic)"
-	manufacturer "Artic"
-	rom ( name "gobbleman.p" size 4014 crc f834b214 md5 f55862be05b018ea8bb62590dfe5af5c sha1 a44e9611539d65664b6277c163436bf0ac0513d4 )
+	name "Black Jack (1982)(G. Dewey)(nl)"
+	description "Black Jack (1982)(G. Dewey)(nl)"
+	rom ( name "Black Jack (1982)(G. Dewey)(nl).p" size 13160 crc 8f4cae76 md5 4e8bbb3bb3520021031910542b95aca9 sha1 bfb935a07a855d4b485d7549a78214ce3635a0ce )
 )
+
 game (
-	name "Gobbleman (Monochrome Inlay) (Artic)"
-	description "Gobbleman (Monochrome Inlay) (Artic)"
-	manufacturer "Artic"
-	rom ( name "gobbleman.p" size 4014 crc f834b214 md5 f55862be05b018ea8bb62590dfe5af5c sha1 a44e9611539d65664b6277c163436bf0ac0513d4 )
+	name "Black Jack (1986)(Fred Nachbaur)"
+	description "Black Jack (1986)(Fred Nachbaur)"
+	rom ( name "Black Jack (1986)(Fred Nachbaur).p" size 15902 crc f07695e7 md5 bd5bfd9a24dec98e56cad48804cd7684 sha1 581454be0def1673eae4cf6966200b042a3ff9c8 )
 )
+
 game (
-	name "Gobblers (Software Farm)"
-	description "Gobblers (Software Farm)"
-	manufacturer "Software Farm"
-	rom ( name "gobblers.p" size 7162 crc b7687e93 md5 cb4cfa5b341c3d129405a82d97bc84bf sha1 fc15194e2cd43c8ed2121bc76331313532bd49da )
-	rom ( name "Gobblers.tzx" size 7394 crc dafe76e1 md5 8de20a364ca8693eb9c755a7da120189 sha1 681bd965a868d25b3ded5c9111c6f6a622a7df1e )
+	name "Black Jack (19xx)(-)"
+	description "Black Jack (19xx)(-)"
+	rom ( name "Black Jack (19xx)(-).p" size 12056 crc 2f098a63 md5 6eeab289105372f54145a75e40b84404 sha1 53997fa75bb315ca9d12bf98317f14432df7bb0c )
 )
+
 game (
-	name "Gold (Hilderbay)"
-	description "Gold (Hilderbay)"
-	year 1981
-	manufacturer "Hilderbay"
-	rom ( name "Gold.tzx" size 23791 crc a280fcba md5 6824a18251adf4cae7ca49ea6f04d865 sha1 33c0acac2f430cc9884739426e287098d646bd92 )
+	name "Black Jack (19xx)(-)[a]"
+	description "Black Jack (19xx)(-)[a]"
+	rom ( name "Black Jack (19xx)(-)[a].p" size 11890 crc 3c544e59 md5 e288c3c578389df2828d9b7f44b711c4 sha1 f9dd5067dd5f10b4cf711d3a77b566580f0e9457 )
 )
+
 game (
-	name "Golf (R & R Software)"
-	description "Golf (R & R Software)"
-	year 1982
-	manufacturer "R & R Software"
-	rom ( name "golf.p" size 9244 crc bdc6ff4e md5 761909f603ceaa4fb32bdfc288fbb19e sha1 0add3b45b1a4a246ddb24ce1d3eea288032f8d99 )
-	rom ( name "Golf.tzx" size 9468 crc 1b658fab md5 01ade7a91bd9f70953004cb25d9e1d88 sha1 3177bea82297a86a2c5c541cde8426fff95cc052 )
+	name "Black Jack (19xx)(-)[m]"
+	description "Black Jack (19xx)(-)[m]"
+	rom ( name "Black Jack (19xx)(-)[m].p" size 11868 crc 2fc7b687 md5 9a139c8b4cbcb7b0a240cb48af7de748 sha1 b7012885ed122dd982a4958b5b6ac75b21606687 )
 )
+
 game (
-	name "Graphics Kit (Softsync)"
-	description "Graphics Kit (Softsync)"
-	year 1981
-	manufacturer "Paul Holmes"
-	rom ( name "GraphicsKit.tzx" size 6203 crc 0e978f07 md5 53ac6583ca184c362108642e40f086cd sha1 2e26b56a9895655424d29d23d2836c28b0a26226 )
+	name "Black Star (19xx)(Quicksilva)"
+	description "Black Star (19xx)(Quicksilva)"
+	rom ( name "Black Star (19xx)(Quicksilva).p" size 4932 crc c39e2e8b md5 c25aad22d3a36c815aa299d8cc3494cd sha1 a09f03daa55950ae04904c715c5edc88d66b3633 )
 )
+
 game (
-	name "Great Britain Ltd (Simon W. Hessel)"
-	description "Great Britain Ltd (Simon W. Hessel)"
-	manufacturer "Simon W. Hessel"
-	rom ( name "greatbritainltd.p" size 15541 crc 23ad347c md5 e4b1812bd16ea7cfdd416e932467e4d4 sha1 8eafc58c5610b3901b85478da04d25156f00bff1 )
-	rom ( name "GreatBritainLtd.tzx" size 15767 crc 4b717923 md5 07bff59ab86d31689cf4450d21f3741d sha1 bbde7b36f9f2cb65cd0ef2f112c52ce612a19433 )
+	name "Blip (1982)(Peter Davis)[m David Buttery]"
+	description "Blip (1982)(Peter Davis)[m David Buttery]"
+	rom ( name "Blip (1982)(Peter Davis)[m David Buttery].p" size 2015 crc 6a241afa md5 1a1beb9f0f86dd7b05efb612243d43df sha1 d07d94da8cd5b17e60e5e2858401e674b7f683e1 )
 )
+
 game (
-	name "Grimm's Fairy Trails (Timex)"
-	description "Grimm's Fairy Trails (Timex)"
-	year 1982
-	manufacturer "Timex"
-	rom ( name "grimmsfairytrails.p" size 9331 crc ad7e74e0 md5 bdea9f593d45946fa07521844b0dd51e sha1 ee1b726655bfd5e897da2af3888f3c8545d85b99 )
-	rom ( name "GrimmsFairyTrails.tzx" size 9563 crc 55fe8f96 md5 2ed795d94caa50cd02cf68475e01aef5 sha1 cb65770be85add8b3aa5e01cecacc3b2b2835ecb )
+	name "Blitz (19xx)(-)"
+	description "Blitz (19xx)(-)"
+	rom ( name "Blitz (19xx)(-).p" size 2054 crc 97036edd md5 833d503eedecfca9b89495121eb2640d sha1 39ecc25bd32a248db649938bfa40cac0f9da8771 )
 )
+
 game (
-	name "Guitar For Beginners (Timex)"
-	description "Guitar For Beginners (Timex)"
-	year 1982
-	manufacturer "Tim Rossetti"
-	rom ( name "guitarforbeginners.p" size 11018 crc 73af3c6d md5 fb35abb3bce84cd543e1bb9d46f65c82 sha1 97adfd80a6abb57717469a3fdaf17f7a160793f2 )
-	rom ( name "GuitarForBeginners.tzx" size 11246 crc 10734bfb md5 69edfc6fcf6f8b26d2907aa32e3c5669 sha1 975deca435c26ed3e0604497454129186e139307 )
+	name "Block Move (19xx)(-)(nl)"
+	description "Block Move (19xx)(-)(nl)"
+	rom ( name "Block Move (19xx)(-)(nl).p" size 2371 crc 6ec9d1d0 md5 372bd5063ab0c6133e1e72c538483a26 sha1 b08a06dbc7341a9d806066f703f4ff31b70bd439 )
 )
+
 game (
-	name "Gulp 2 (Campbell Systems)"
-	description "Gulp 2 (Campbell Systems)"
-	year 1982
-	manufacturer "Campbell Systems"
-	rom ( name "gulp2.p" size 6116 crc 1bfd713d md5 c7db6f6ed8cba0f14aa92df6d55f93a7 sha1 2399dff41d799578005ad8b23cc5086e120971e0 )
-	rom ( name "Gulp2.tzx" size 6342 crc b041f1bf md5 7c1be7d5a5b5d0f65dafdd2a0f252a2d sha1 aa0fadd80146c2dab98dab49c88f52ba4852c861 )
+	name "Blokkade (1982)(AFJ)(nl)"
+	description "Blokkade (1982)(AFJ)(nl)"
+	rom ( name "Blokkade (1982)(AFJ)(nl).p" size 2988 crc 1e60feef md5 096c76354d86f908daa4db401fa224b7 sha1 18441af84bcb7a4b8df6ccca1e08fdf091b8f2ea )
 )
+
 game (
-	name "Gulp (Mindware)"
-	description "Gulp (Mindware)"
-	year 1982
-	manufacturer "Campbell Systems"
-	rom ( name "Gulp(Mindware).1.Gulp.tzx" size 1125 crc c651f1e5 md5 e342f3fcc020d8afd4bf4a496ca75f75 sha1 c91c14f5ec001c991ed3c67673fe38c8b7b9d02d )
-	rom ( name "gulp.p" size 901 crc be88df61 md5 338af799286fee95ca3f1131a2c00bac sha1 fbbe0822184c0a4594c5932358edcfbe3df4e7be )
+	name "Board (19xx)(-)"
+	description "Board (19xx)(-)"
+	rom ( name "Board (19xx)(-).p" size 1368 crc cdbfed26 md5 8137ee04bf6f5e3a1834a8a74f47a59c sha1 93ccabe2a1c0fefbd3fbc4533f89fa8758a60b7f )
 )
+
 game (
-	name "Gulpman (Micromega)"
-	description "Gulpman (Micromega)"
-	year 1982
-	manufacturer "Campbell Systems"
-	rom ( name "gulpman.p" size 6121 crc 74a38569 md5 3ef8b687b566f338a2c672133e638379 sha1 9551cfdf7d738e0db679f08b35b72724d2f5a7a2 )
-	rom ( name "Gulpman.tzx" size 6351 crc 7baebe9a md5 e47f73d6aadf86310e6379a22a7d6b7a sha1 d28c22863672b87a1f0f6b23f2262b0195b3e1fb )
+	name "Board Game (19xx)(-)"
+	description "Board Game (19xx)(-)"
+	rom ( name "Board Game (19xx)(-).p" size 3130 crc d36cf332 md5 8827876d4804098419257de500f8e144 sha1 d84f366c2ac92617c622ecd463e70e12d360d83f )
 )
+
 game (
-	name "Haute Resolution (Pluto)"
-	description "Haute Resolution (Pluto)"
-	year 1984
-	manufacturer "CRL"
-	rom ( name "HauteResolution.tzx" size 6970 crc f52d460f md5 42186664d3f698c0ede72a2b0c2ab398 sha1 91cd6738fcec38d4fc9d3e3ba08614634935918a )
+	name "Boekhouden (19xx)(-)(nl)"
+	description "Boekhouden (19xx)(-)(nl)"
+	rom ( name "Boekhouden (19xx)(-)(nl).p" size 15546 crc b2a496e4 md5 ea551e590ef91fb34d8e2e042b5c949b sha1 0e298f8b71c659929ac280ea39acda356588096d )
 )
+
 game (
-	name "Heating System Analyzer (Timex)"
-	description "Heating System Analyzer (Timex)"
-	year 1982
-	manufacturer "Tim Rossetti"
-	rom ( name "heatingsystemanalyzer.p" size 15494 crc 17d05fc2 md5 8b2aceadfbb20f65c305cdeaea598262 sha1 087d0e4680643e6d9e808cce10c918e58d3c72ab )
-	rom ( name "HeatingSystemAnalyzer.tzx" size 15718 crc ea836c43 md5 29fa5b64d2c89de8a19c0f678c6b2c94 sha1 9d5e5a4f1e26f6a5dba03028940310bb796da199 )
+	name "Boekhouding (1983)(-)(nl)"
+	description "Boekhouding (1983)(-)(nl)"
+	rom ( name "Boekhouding (1983)(-)(nl).p" size 12428 crc c58cc6ac md5 2f28b6ceba2bdfacebff0b82f707d455 sha1 46faaff52d93b94d55b045e194dc453059c54d37 )
 )
+
 game (
-	name "High Res (Macronics)"
-	description "High Res (Macronics)"
-	year 1981
-	manufacturer "Macronics"
-	rom ( name "highres.p" size 10763 crc e37bad7f md5 493817d98b6d96356df1e1c3f93866e9 sha1 d817b3db8f0065843e3b3d7eb4e55b673c08de03 )
-	rom ( name "HighRes.tzx" size 10985 crc fa40dbc1 md5 f48465678582d4fd7bd8325ddede7788 sha1 9b81b10a719af4c6c61a03ed003f1198f68bda1b )
+	name "Boerdery Zeldenrust (19xx)(-)(nl)"
+	description "Boerdery Zeldenrust (19xx)(-)(nl)"
+	rom ( name "Boerdery Zeldenrust (19xx)(-)(nl).p" size 12512 crc 31c83e95 md5 7d4bd1f0e0bb690d76f9ad52ec4caff0 sha1 66ab16fb28fafb1ddd0b79c82e4e5238e074dfbe )
 )
+
 game (
-	name "Hopper (PSS)"
-	description "Hopper (PSS)"
-	year 1982
-	manufacturer "PSS"
-	rom ( name "hopper.p" size 10833 crc 965d961a md5 f76d900361978e5a354569718c918783 sha1 9e5b1e824f492a88999c023646486a9620e1c89f )
-	rom ( name "Hopper.tzx" size 11061 crc f5601550 md5 30ed7cc222c8a94447629233bb357832 sha1 4102dbfe6c3cddb82877bb9b089f764420f0a249 )
+	name "Boliden (19xx)(-)(de)"
+	description "Boliden (19xx)(-)(de)"
+	rom ( name "Boliden (19xx)(-)(de).p" size 3046 crc 1cdc678d md5 1044f0dd7359729892e5cfc9ba81d0ad sha1 8492c334800498bfb75cbe22dbe5b1a3d53db0ab )
 )
+
 game (
-	name "Hopper (Truck) (PSS)"
-	description "Hopper (Truck) (PSS)"
-	year 1981
-	manufacturer "PSS"
-	rom ( name "hopper(truck).p" size 10833 crc 343ec159 md5 e49392779795505c5e776a86bb27de9b sha1 347965bc2ab0003c295c1005e89cde7053dd7040 )
-	rom ( name "Hopper(Truck).tzx" size 11061 crc 57034213 md5 ecc9da3396ba5f0eee543e3915a3ab8d sha1 5747373be057f05059c47d8acb42f2c9312eeb83 )
+	name "Bomb Disposal (1982)(Sinclair User)"
+	description "Bomb Disposal (1982)(Sinclair User)"
+	rom ( name "Bomb Disposal (1982)(Sinclair User).p" size 1616 crc 13496de2 md5 d39b849e3afa8e770bc31914dca96e0e sha1 c63850970ce8a42cb8ae6a63764f8e2e0e5c0114 )
 )
+
 game (
-	name "House of Death (A. J. Rushton)"
-	description "House of Death (A. J. Rushton)"
-	manufacturer "A. J. Rushton"
-	rom ( name "houseofdeath.p" size 15045 crc d88c206a md5 89e832d5035229bcfe30a9d77a0242a9 sha1 962346b1f5e5d9f8c025994824736ac497be1ea2 )
-	rom ( name "HouseOfDeath.tzx" size 15289 crc e78272e3 md5 68fb7bfd61e73901337800b912db3760 sha1 80ee47dd77a43c051c600a38def525950a110119 )
+	name "Bomb Squad (1984)(D. Green)"
+	description "Bomb Squad (1984)(D. Green)"
+	rom ( name "Bomb Squad (1984)(D. Green).p" size 2181 crc 059cee68 md5 dcebf2d19391014ff4d0d7b823762ff0 sha1 6a8e29a79f17371d52d35458091acfd3d98e4d5e )
 )
+
 game (
-	name "HRG 7.0 (Unknown)"
-	description "HRG 7.0 (Unknown)"
-	year 1983
-	manufacturer "J. M. Cohen"
-	rom ( name "HRG70.tzx" size 19444 crc 75adee54 md5 eec31c8470c05281f4e8c957e56889d3 sha1 9f062ea8b3bd11a868a773dd4fed573a51225a1e )
+	name "Bomber (1982)(Blake Kincaid)"
+	description "Bomber (1982)(Blake Kincaid)"
+	rom ( name "Bomber (1982)(Blake Kincaid).p" size 14779 crc aa2216d3 md5 987dc1f6f405e12b035336013f76dfa2 sha1 016ac6a14bc06e591a2585311794756d73c6345b )
 )
+
 game (
-	name "Impact!"
-	description "Impact! (2012) - Bob's interpretation of Atari's 1979 arcade game 'Asteroids'."
-	rom ( name "Impact.p" size 16154 crc d6e106b8 md5 b6ad9cb0b2dc0153eb080a9ce87c797c sha1 11c5fe8d44763d94a3eedf597b6daf0438364e22 )
+	name "Bomber (1983)(H. Dursch)(de)"
+	description "Bomber (1983)(H. Dursch)(de)"
+	rom ( name "Bomber (1983)(H. Dursch)(de).p" size 2017 crc 08cc515e md5 e435d8ad5e2d26c717801d02fb8b010b sha1 dcb2516115d1fe78738e98e1e7e5880ae50ec289 )
 )
+
 game (
-	name "Introduction To Chemistry (Timex)"
-	description "Introduction To Chemistry (Timex)"
-	year 1983
-	manufacturer "J. J. Hollandsworth"
-	rom ( name "IntroductionToChemistry.tzx" size 37232 crc 7b7d1b69 md5 f7c95b6d075d662664527efc3fc842d0 sha1 4a49f3c842e387dd1353dc859877b93c92aa8ace )
+	name "Bomber (19xx)(-)"
+	description "Bomber (19xx)(-)"
+	rom ( name "Bomber (19xx)(-).p" size 2537 crc c706c94b md5 018e4910e8153bfdc765515975a4a68e sha1 7ef6539e0c67dc95b879c739f5506802f67a09e7 )
 )
+
 game (
-	name "Invaders (A. G. Software)"
-	description "Invaders (A. G. Software)"
-	manufacturer "Andrew Glaister"
-	rom ( name "invaders(ags).p" size 2117 crc 134835d7 md5 b2cb96deb94f2caf1167c6aa9eed3c35 sha1 125d09e68f9ad9490b47adee512bf46db7286c2a )
-	rom ( name "Invaders(AGS).tzx" size 2349 crc 58299c24 md5 6a329b8b6bdca462dc2564297fb425f2 sha1 37503b2c552016a3265ff387afca6ffa6380c5e8 )
+	name "Bomber (19xx)(-)(nl)"
+	description "Bomber (19xx)(-)(nl)"
+	rom ( name "Bomber (19xx)(-)(nl).p" size 4673 crc ad86cecf md5 faf0251eb992d7ece62406f4c5810d97 sha1 c06083d53a7858f8bc7eb6505f99a62b340ea1d7 )
 )
+
 game (
-	name "Invaders (Bug Byte)"
-	description "Invaders (Bug Byte)"
-	year 1982
-	manufacturer "S. Munnery"
-	rom ( name "invaders.p" size 2373 crc 3b79c6ac md5 e3cd419e7f34dbfc4efd9b4c8e0a7633 sha1 8683fd832959844fb6357fd272dcde5ece0a601d )
-	rom ( name "Invaders.tzx" size 2605 crc 93d1d5d7 md5 1d391665fb5734a2b274e2c9630d35f7 sha1 bb79a0ea9ff54e882d45a7ca94dc71762488b2cd )
+	name "Bomber (19xx)(-)(nl)[a]"
+	description "Bomber (19xx)(-)(nl)[a]"
+	rom ( name "Bomber (19xx)(-)(nl)[a].p" size 5475 crc 8f119f8f md5 a22eaf882eb1df7b8c5b00539c78f21d sha1 2fc1997eb9d440126d1214e9cc82d0dd3edaffdc )
 )
+
 game (
-	name "Invaders (Forward Software)"
-	description "Invaders (Forward Software)"
-	manufacturer "Silversoft"
-	rom ( name "invaders(forward).p" size 3465 crc 7005eda5 md5 0e940cd5d0fab16b860c1e5648ea7b8a sha1 425223961fdb8c2825796b99bbc5358e51bf9b14 )
-	rom ( name "Invaders(Forward).tzx" size 3697 crc 3ea98bb5 md5 b52fecd042da1349d326508f77d3db33 sha1 a8ae592fe3b4b939b664be00454fb591b004f478 )
+	name "Booster (19xx)(Cosmic Cockerel)"
+	description "Booster (19xx)(Cosmic Cockerel)"
+	rom ( name "Booster (19xx)(Cosmic Cockerel).p" size 12615 crc e7c90439 md5 3884e9bcf5ab1716c55cb670c577de33 sha1 49a85ada6efa62d02c37f264ae2bc1f76dc12354 )
 )
+
 game (
-	name "Invaders (Monochrome) (Bug Byte)"
-	description "Invaders (Monochrome) (Bug Byte)"
-	manufacturer "S. Munnery"
-	rom ( name "invaders(mono).p" size 2373 crc 2840348b md5 1b95516181a57da16f56109cc87cfd94 sha1 1971694d7a009402c065f5d23cec3ad847839232 )
-	rom ( name "Invaders(Mono).tzx" size 2605 crc 80e827f0 md5 186d39211398bdbb5497d1ba89df5ab9 sha1 3aeb0fa4a5c458ace0affc01f528d4b15ee047b8 )
+	name "Bowling (19xx)(-)(de)"
+	description "Bowling (19xx)(-)(de)"
+	rom ( name "Bowling (19xx)(-)(de).p" size 2125 crc 1d9db343 md5 95a785dcc52ddcbc8791d4508ee83663 sha1 89bd76a5b086a3aafa79e21f6da36f50b063305e )
 )
+
 game (
-	name "Invaders (Re-release) (Bug Byte)"
-	description "Invaders (Re-release) (Bug Byte)"
-	year 1982
-	manufacturer "S. Munnery"
-	rom ( name "invaders(alt).p" size 2373 crc 4a1b632b md5 119058dbc93bb2ac6a7e804a878f03cc sha1 6beb1369d7f96b83092cd84c0e32fe2ad786c2ac )
-	rom ( name "Invaders(Alt).tzx" size 2605 crc e2b37050 md5 8886052187ad052bd05d2cb8e6d2a713 sha1 c5a9f1683d2730eaf40a879c0f5c676b5f718e03 )
+	name "Box (19xx)(-)(nl)"
+	description "Box (19xx)(-)(nl)"
+	rom ( name "Box (19xx)(-)(nl).p" size 1387 crc 4c478dfa md5 e109356819b8d3315dd0de7447debc97 sha1 68c76b64580b34b6a16df4b822589c6ae35127d6 )
 )
+
 game (
-	name "Invaders (Typed Inlay) (Bug Byte)"
-	description "Invaders (Typed Inlay) (Bug Byte)"
-	year 1981
-	manufacturer "S. Munnery"
-	rom ( name "invaders(typed).p" size 2373 crc eeefd34b md5 f426df7408433e814f04cf3909a5a2f5 sha1 5ff6048270fdd16665eb1b1169f2f026c84a3b24 )
-	rom ( name "Invaders(Typed).tzx" size 2605 crc 4647c030 md5 c6dbced1c948e5322109052583789338 sha1 a3669f5ce7897e144314b0a4ea5e3e1b79cff5ef )
+	name "Breaker (19xx)(-)"
+	description "Breaker (19xx)(-)"
+	rom ( name "Breaker (19xx)(-).p" size 1292 crc 89b9dd19 md5 ddc195c877145c000017c144ba5d1892 sha1 6e13d4703234e3c53cad95837a64b3e1fc363aa5 )
 )
+
 game (
-	name "Invasion Force (Artic)"
-	description "Invasion Force (Artic)"
-	year 1982
-	manufacturer "Simon Wadsworth"
-	rom ( name "invasionforce.p" size 7658 crc a997ef38 md5 111b625cefae5439236a45013066a7ae sha1 6a3516b9127e8345a56c076990a9ffb7bf5834e7 )
-	rom ( name "InvasionForce.tzx" size 7890 crc 84b20542 md5 c38ec3f7baba880dcb937e9419956a22 sha1 3bf53649fdf8249fdb8a601bb7ae7dbbb38b08de )
+	name "Breakout (19xx)(-)"
+	description "Breakout (19xx)(-)"
+	rom ( name "Breakout (19xx)(-).p" size 2518 crc 4cbe3546 md5 e2b11760af86086a174af8b4c7ef151e sha1 d0ec7d066bcdf324efd674bc286daf49c5428863 )
 )
+
 game (
-	name "Invasion Force (International Publishing and Software Inc.)"
-	description "Invasion Force (International Publishing and Software Inc.)"
-	year 1983
-	manufacturer "Simon Wadsworth"
-	rom ( name "invasionforce(ips).p" size 7658 crc eaa1c1ed md5 c38f1c2548052873d8fbff20f67a29dd sha1 39ebceafc98f2a8a7b2b4eb5cb35b4e2a4b34adf )
-	rom ( name "InvasionForce(IPS).tzx" size 7890 crc c7842b97 md5 4c05ebb64d88d13ec859403f5c7f2b1e sha1 3b59f5a004f92d081181834aa59073ba74b47909 )
+	name "Breakout (19xx)(J.K. Greye Software)"
+	description "Breakout (19xx)(J.K. Greye Software)"
+	rom ( name "Breakout (19xx)(J.K. Greye Software).p" size 716 crc a0abf234 md5 63d78959745e0fd449478ef095b6c437 sha1 315ef2dbcc2b3087a909fafcee61d20774e0306e )
 )
+
 game (
-	name "Inventory Control (Data-assette)"
-	description "Inventory Control (Data-assette)"
-	manufacturer "John Powers"
-	rom ( name "inventorycontrol(da).p" size 15941 crc eb911b8b md5 2e9c7b2134665a0fa235764e75cc2957 sha1 4f63db3c39ff4aabb3e0661500095f0c69dab41d )
-	rom ( name "InventoryControl(DA).tzx" size 16175 crc 21d56ec5 md5 bfadca8523ed9926c47c20b04e980289 sha1 390707e52e816a1df284b65ce1fd52e14110a504 )
+	name "Breakout (19xx)(J.K. Greye Software)[a]"
+	description "Breakout (19xx)(J.K. Greye Software)[a]"
+	rom ( name "Breakout (19xx)(J.K. Greye Software)[a].p" size 716 crc 3982d9eb md5 2e86b3c7b23246bf2a12cdf331345cfc sha1 c7392932229a8c27ed3b21838464ffec31549c62 )
 )
+
 game (
-	name "J.D.Arcades (Computer Rentals)"
-	description "J.D.Arcades (Computer Rentals)"
-	year 1982
-	manufacturer "John Davies"
-	rom ( name "jdarcades.p" size 8548 crc e7ea958d md5 e555ef74ec2f6346b82b363c24d97c96 sha1 7d47ec7d6670d7009cf6d059fe50c730e068d891 )
-	rom ( name "JDArcades.tzx" size 8782 crc 6fb5f451 md5 e4ab3d1820711eb5b96dcd106694aa1d sha1 08c17dc95d0a7e8a68fb9b534398d45656e25ea5 )
+	name "Breakout (19xx)(New Generation Software)"
+	description "Breakout (19xx)(New Generation Software)"
+	rom ( name "Breakout (19xx)(New Generation Software).p" size 1520 crc ae7bcb3a md5 6329e5f49b70046fa85bd37c7834ec85 sha1 7bdc107958d5551f1aa689dd681d87d4186a1cf8 )
 )
+
 game (
-	name "Kasino Kraps (Timex)"
-	description "Kasino Kraps (Timex)"
-	year 1983
-	manufacturer "Gerald Bennett"
-	rom ( name "kasinokraps.p" size 12557 crc f041256f md5 dedab418c1ee0b2e03200acf878164f3 sha1 c782994290da3a40a82433718fb877a59fcd771b )
-	rom ( name "KasinoKraps.tzx" size 12777 crc 7e27ad21 md5 32a434e44b75cfeedf737a25e4d22ae0 sha1 39950e34a01e852c6df5fb06e59dfae019d54e90 )
+	name "Breakout (19xx)(Vinsoft)(nl)"
+	description "Breakout (19xx)(Vinsoft)(nl)"
+	rom ( name "Breakout (19xx)(Vinsoft)(nl).p" size 6213 crc 70b9b43a md5 bbf1a701e6228c623669d3e862f8db75 sha1 ada126b7b86cea527bb27cc6b648ff8df25f4c14 )
 )
+
 game (
-	name "Keyboard Calculator (Timex)"
-	description "Keyboard Calculator (Timex)"
-	year 1982
-	manufacturer "J. Gishen"
-	rom ( name "KeyboardCalculator.tzx" size 6160 crc 56b36255 md5 781d98f620db9510336788eb8ff310ea sha1 064abd828a4d801e1e2029234762f6aadcba008e )
+	name "Breakout Basic (19xx)(-)"
+	description "Breakout Basic (19xx)(-)"
+	rom ( name "Breakout Basic (19xx)(-).p" size 2286 crc 509a4cbd md5 55269e5defbd9d7e58d612080bda7fe6 sha1 8a3552822635cbd33bea9ddb5a712d96bdabb357 )
 )
+
 game (
-	name "Keys To Gondrun (International Publishing and Software Inc.)"
-	description "Keys To Gondrun (International Publishing and Software Inc.)"
-	year 1982
-	manufacturer "International Publishing and Software Inc."
-	rom ( name "keystogondrun.p" size 15704 crc f8340d3b md5 aaca5c9eb8ae112eb41d7a3b99e93a6b sha1 639d2eb5931fd7b874d0ca9b1374bce68971ded6 )
-	rom ( name "KeysToGondrun.tzx" size 15928 crc 97e9ac6d md5 9d45dcb3c159ffb5396641c88e7e5196 sha1 38c82913732383ae4fae62dd1be8f5a04927cdfd )
+	name "Breuken (19xx)(-)(nl)"
+	description "Breuken (19xx)(-)(nl)"
+	rom ( name "Breuken (19xx)(-)(nl).p" size 11025 crc 3632fae1 md5 77db1e20e309a89c8d2a32b52a912deb sha1 60817e26e13cb600d9b259e479ea3781020a4fe6 )
 )
+
 game (
-	name "Kingdom of Nam (Microgame Simulations)"
-	description "Kingdom of Nam (Microgame Simulations)"
-	year 1981
-	manufacturer "R. Erskine"
-	rom ( name "kingdomofnam.p" size 7958 crc a997242d md5 eccad4f7e6ca9806b1d2976970ee39fd sha1 718235cfddafacfdf7276438614712042488ecf5 )
-	rom ( name "KingdomOfNam.tzx" size 8202 crc ca57c0c9 md5 5d075c2ea9428e0c2d3b09597056d810 sha1 d5c07352365144b1f0c9eb4c89a3f854747b7a90 )
+	name "Bug Burst (19xx)(Hogroprog)"
+	description "Bug Burst (19xx)(Hogroprog)"
+	rom ( name "Bug Burst (19xx)(Hogroprog).p" size 7695 crc 9e97b981 md5 96fffa5d180cabe37df300296c136f82 sha1 ed707ba570b0662e7899df016ce3c6256c7fef2f )
 )
+
 game (
-	name "Kongs Revenge (Stephen Hartley Computing)"
-	description "Kongs Revenge (Stephen Hartley Computing)"
-	year 1984
-	manufacturer "I. Kendrick"
-	rom ( name "kongsrevenge.p" size 14601 crc daf31c48 md5 a88f23545d67709d83d214efc9344173 sha1 6915c841a5af606e7e0a0198efec07aed4c8cb91 )
-	rom ( name "KongsRevenge.tzx" size 14843 crc cc315aca md5 c82fd9679ee58446a0c54271e2f56287 sha1 c87d1a7f00cca913b0d9bdbe8a8752e82c72fd6c )
+	name "Bug Burst (19xx)(Hogroprog)[a2]"
+	description "Bug Burst (19xx)(Hogroprog)[a2]"
+	rom ( name "Bug Burst (19xx)(Hogroprog)[a2].p" size 7317 crc 20a81323 md5 1bd49d7b50954751a6635dacb97bca17 sha1 4d995328fa52b30154f3ce32e2801fef94defa3b )
 )
+
 game (
-	name "Krazy Kong (Intercomputer Inc)"
-	description "Krazy Kong (Intercomputer Inc)"
-	year 1983
-	manufacturer "C. P. Cullen"
-	rom ( name "krazykong(inter).p" size 7563 crc ad4fe8ff md5 c1aaf449bdc105ee2ccd74de7ba82ec5 sha1 554d1d5b991c9a221183dd6f6067e41c77746d7b )
-	rom ( name "KrazyKong(Inter).tzx" size 7799 crc d5a3ddd8 md5 b355c229f453610568ab040ea9cebb5e sha1 1e4edf41f7a576a8b68ecfaab4f936ba80460360 )
+	name "Bug Burst (19xx)(Hogroprog)[a]"
+	description "Bug Burst (19xx)(Hogroprog)[a]"
+	rom ( name "Bug Burst (19xx)(Hogroprog)[a].p" size 11693 crc 676509ed md5 0eff3d2af0ce9f18e6ffb574fe36aa3f sha1 2a49a97860dad86c8282548d2d4222da77b6bb33 )
 )
+
 game (
-	name "Krazy Kong (PSS)"
-	description "Krazy Kong (PSS)"
-	year 1982
-	manufacturer "C. P. Cullen"
-	rom ( name "krazykong.p" size 8229 crc e5e30579 md5 fea1dd4edf42f770255b5d90d6da9cff sha1 0bbee2723aaa7a2758b5394d2ad269ffc561ede8 )
-	rom ( name "KrazyKong.tzx" size 8465 crc a5dd2afe md5 4df17878870a7bc5b63fa607c8eb4c36 sha1 ac74298badc343b3c81a96fca8bcab1b43faad87 )
+	name "Camel (19xx)(-)(de)"
+	description "Camel (19xx)(-)(de)"
+	rom ( name "Camel (19xx)(-)(de).p" size 7595 crc f9811981 md5 5b9357a6a3958f90740ce7d0a84460ee sha1 897e5c6c4a95f13c4656962c229731f6e7608d40 )
 )
+
 game (
-	name "Labyrinth (Axis)"
-	description "Labyrinth (Axis)"
-	year 1981
-	manufacturer "Axis"
-	rom ( name "labyrinth.p" size 10722 crc 46400a6f md5 0a3f962c532cb046d7a71998cc29d412 sha1 8ad0df41d206ad534aeed2be3fe208bb00f99bb6 )
-	rom ( name "Labyrinth.tzx" size 10956 crc 2bd7dd50 md5 25eb8d058ab8aeb9d5ce8ff64dfcc0d8 sha1 2ce0f07c10363839828a54fb00fb278f1ed5aeac )
+	name "Camelot (1983)(CCS)"
+	description "Camelot (1983)(CCS)"
+	rom ( name "Camelot (1983)(CCS).p" size 15328 crc c8222ffb md5 d593451336bf42e99d04d41dec34ac9b sha1 04e387154337fbbfe45bbb8ca01ae38b4a1aef75 )
 )
+
 game (
-	name "Labyrinth (Colour Inlay) (Axis)"
-	description "Labyrinth (Colour Inlay) (Axis)"
-	year 1981
-	manufacturer "Axis"
-	rom ( name "labyrinth.p" size 10722 crc 46400a6f md5 0a3f962c532cb046d7a71998cc29d412 sha1 8ad0df41d206ad534aeed2be3fe208bb00f99bb6 )
-	rom ( name "Labyrinth.tzx" size 10956 crc 2bd7dd50 md5 25eb8d058ab8aeb9d5ce8ff64dfcc0d8 sha1 2ce0f07c10363839828a54fb00fb278f1ed5aeac )
+	name "Camelot (1983)(CCS)[a]"
+	description "Camelot (1983)(CCS)[a]"
+	rom ( name "Camelot (1983)(CCS)[a].p" size 15360 crc 1d21bec5 md5 ba6ba8375e221818e7f1d2f3011772fd sha1 1d44b680d714294830332eadbadc4d2f6f70f170 )
 )
+
 game (
-	name "Language Usage (Timex)"
-	description "Language Usage (Timex)"
-	year 1982
-	manufacturer "Software for Excellence"
-	rom ( name "LanguageUsage.tzx" size 43685 crc f83ba0cd md5 81f643d82c2f273248421f15f4e8f91b sha1 8892aac163feb54128ee568636c905c0cb18e7e5 )
+	name "Car Crash (19xx)(-)"
+	description "Car Crash (19xx)(-)"
+	rom ( name "Car Crash (19xx)(-).p" size 1674 crc 512c9096 md5 e7a786b969689edacadb89f00fb155b8 sha1 cb178a49121da0317b42548b38f0403a3be77d1e )
 )
+
 game (
-	name "Lap Record (Macronics)"
-	description "Lap Record (Macronics)"
-	year 1981
-	manufacturer "Macronics"
-	rom ( name "laprecord.p" size 4895 crc 13522b1e md5 4e017f1d09e8cd51b3b3656b5c1efdfa sha1 5091eaf17d8816a7766811f0d57ea54611825670 )
-	rom ( name "LapRecord.tzx" size 5115 crc 4ab33041 md5 075644fa16a629b4b732265c9129998c sha1 28d2a56bc5974bed6e848a495367140893f35eb1 )
+	name "Car Race (19xx)(Ch. Zwerschke)"
+	description "Car Race (19xx)(Ch. Zwerschke)"
+	rom ( name "Car Race (19xx)(Ch. Zwerschke).p" size 1749 crc 2533b3c3 md5 e190c39cbe6c241714d6bd8ed51a35ba sha1 9afa2402be709c169d67d26a4806d4b1f3652ab6 )
 )
+
 game (
-	name "Lost Island (JRS Software)"
-	description "Lost Island (JRS Software)"
-	year 1982
-	manufacturer "JRS Software"
-	rom ( name "lostisland.p" size 15542 crc c93d1958 md5 f1783d3018e369fe915e919646ab845c sha1 56310e5ea2f0dc1e77c95717e7b5e988c9c0fff9 )
-	rom ( name "LostIsland.tzx" size 15766 crc b0682ddb md5 28ac9145502b4144b038821d63b419e4 sha1 b1bed07dd568166c87352c1700c8e3fb81a43a7b )
+	name "Car Race (19xx)(Ch. Zwerschke)[a]"
+	description "Car Race (19xx)(Ch. Zwerschke)[a]"
+	rom ( name "Car Race (19xx)(Ch. Zwerschke)[a].p" size 1705 crc dbd31778 md5 c10571748ec6bedf35d01d2b103545d3 sha1 58abdbc15d84aaef4cc1137f6b8f52930395d46d )
 )
+
 game (
-	name "Lunar Rescue (Mikro-Gen)"
-	description "Lunar Rescue (Mikro-Gen)"
-	manufacturer "K. J. Bezant"
-	rom ( name "lunarrescue.p" size 4657 crc 0ec491ce md5 62d3cd05d6ea6103cb47824c7316135f sha1 810fe42934480bc6967d058f91586cc558bf4bc5 )
-	rom ( name "LunarRescue.tzx" size 4885 crc b63d952a md5 9d99d03e0da02ab1601a4dbe89446bab sha1 620f51472b3313aa14bee80521e5654c05b4c5b6 )
+	name "Car-Pool (19xx)(-)"
+	description "Car-Pool (19xx)(-)"
+	rom ( name "Car-Pool (19xx)(-).p" size 14277 crc b544dc99 md5 890dd6fc3f4a05a94fcc8e3e082b97dc sha1 bb7c63ce203459437bb3bc6394f62ef3f8f3b1d0 )
 )
+
 game (
-	name "Machine Code Test Tool (F. O. Ainley)"
-	description "Machine Code Test Tool (F. O. Ainley)"
-	year 1982
-	manufacturer "F. O. Ainley"
-	rom ( name "machinecodetesttool.p" size 2823 crc 778f13a8 md5 440b350563fa9dd8ac48b7a3d01a27bd sha1 5063e60e26a804e8cb2f210349d9ccef375f3c2e )
-	rom ( name "MachineCodeTestTool.tzx" size 3047 crc e7fc10fc md5 fb5cd1e9564af7fcbda7227b19104342 sha1 9108f1176687353a4b9e0a0eff750478a863d5c2 )
+	name "Carpet (19xx)(-)"
+	description "Carpet (19xx)(-)"
+	rom ( name "Carpet (19xx)(-).p" size 1425 crc 3bcd1a6d md5 049442b933e7bc0c41c525d4f1221047 sha1 be50091a3e83fbdfcca4dca0942e26c34bc64e27 )
 )
+
 game (
-	name "Manufacturing Control (Timex)"
-	description "Manufacturing Control (Timex)"
-	year 1982
-	manufacturer "Timex"
-	rom ( name "manufacturingcontrol.p" size 14780 crc 10e493b2 md5 84384096921e088b18cc9e3eedb3b143 sha1 c603b553fc42d949fed9139cb58d0bde4f3c3d3e )
-	rom ( name "ManufacturingControl.tzx" size 15008 crc fec50d8e md5 38bcf567460a33edb8ff13034834100f sha1 694cfa2652b6134621f5b6a2a189af5b8f1e853b )
+	name "Casino 3 (19xx)(J.J. de Jong)(nl)"
+	description "Casino 3 (19xx)(J.J. de Jong)(nl)"
+	rom ( name "Casino 3 (19xx)(J.J. de Jong)(nl).p" size 2829 crc bef45ce8 md5 6b7a3f2a62965ed147a7d3fe667a5832 sha1 db7151f5f19b65cfe84838083e8f9a5f7ff9ee20 )
 )
+
 game (
-	name "Marine Rescue (International Publishing and Software Inc.)"
-	description "Marine Rescue (International Publishing and Software Inc.)"
-	year 1982
-	manufacturer "International Publishing & Software Inc."
-	rom ( name "marinerescue.p" size 10829 crc d91c71e8 md5 bf106cf05b1e4d7318df3f7c1a7c125c sha1 39af94024ccbbe9262bbf98b8841cb00d258c418 )
-	rom ( name "MarineRescue.tzx" size 11057 crc 60217181 md5 ca6ce91a6aea06ac28859c418daac227 sha1 c0fe4882d84b9fc7503004128975115b5cc355f2 )
+	name "Casino Quickpoor (19xx)(-)"
+	description "Casino Quickpoor (19xx)(-)"
+	rom ( name "Casino Quickpoor (19xx)(-).p" size 9174 crc 333bd25c md5 970aaa8185d4bbaee9e5bd3d668f5a8d sha1 e76976739ce8aa9833ff6a41debf7f07ea92e6b0 )
 )
+
 game (
-	name "Math Routines and Fit (Zeta Software)"
-	description "Math Routines and Fit (Zeta Software)"
-	manufacturer "Dr. Walter Diembeck"
-	rom ( name "mathroutinesandfit.p" size 15850 crc ef830293 md5 205efa1a71ba01038cd3bc523f1a9667 sha1 c1a6b8f1c9798fb57faea5ee52dc1bcacee68b1b )
-	rom ( name "MathRoutinesAndFit.tzx" size 16074 crc 2896de80 md5 ee3e759e69b64248f0e5bd1846d63a76 sha1 aa81c6329174cb096d5690cf4d6456b0e0dbdccc )
+	name "Casino Quickpoor (19xx)(-)[a]"
+	description "Casino Quickpoor (19xx)(-)[a]"
+	rom ( name "Casino Quickpoor (19xx)(-)[a].p" size 9207 crc b406726d md5 2a5b3e21c12be2ad7be418455f93d100 sha1 61f15fb8d87beac110e2dc2199b2e9a3991b0632 )
 )
+
 game (
-	name "Maths Invaders (Programs in Education)"
-	description "Maths Invaders (Programs in Education)"
-	rom ( name "mathsinvaders.p" size 7786 crc 27b974ec md5 0e79e0ceebc05771120adc45bebb8fb9 sha1 348d5786fd8b153ea7ef26e7eb0af63a273a9d18 )
-	rom ( name "MathsInvaders.tzx" size 8030 crc 19057596 md5 479d85ee6074fb7e7eccedb399dbc1f2 sha1 4e6e0fc96692a767de539ec97df4b06b30c5af70 )
+	name "Castles of Carmain, The (19xx)(John Wood)"
+	description "Castles of Carmain, The (19xx)(John Wood)"
+	rom ( name "Castles of Carmain, The (19xx)(John Wood).p" size 5512 crc f25d4e58 md5 e3740616ac0b1e3a76bd6434dc6d70c5 sha1 8d7acb8cb6fa5c08e18183094a2be70111e54902 )
 )
+
 game (
-	name "Mazogs (Bug Byte)"
-	description "Mazogs (Bug Byte)"
-	year 1982
-	manufacturer "Don Priestley"
-	rom ( name "mazogs.p" size 12831 crc 007463e5 md5 589a35248f7a9cb539f91b03427f9a3c sha1 dee47e0c7e717b9721e63078e1cfdce88ff9f725 )
-	rom ( name "Mazogs.tzx" size 13059 crc 4cb450b8 md5 421c3cdbe09cba807770d925bbb56dde sha1 edee5d84ed22c2cffa6b605a4caa998a8510da17 )
+	name "Castles of Carmain, The (19xx)(John Wood)[a]"
+	description "Castles of Carmain, The (19xx)(John Wood)[a]"
+	rom ( name "Castles of Carmain, The (19xx)(John Wood)[a].p" size 5490 crc 66a61c46 md5 f88b3392ed0774e7c2df6bc2cd0ed671 sha1 dd77e8fd75ad5a02e26c79f1e2f8d72866345c84 )
 )
+
 game (
-	name "Mazogs (Gladstone) (Gladstone Electronics)"
-	description "Mazogs (Gladstone) (Gladstone Electronics)"
-	manufacturer "Don Priestley"
-	rom ( name "mazogs(ge).p" size 12942 crc bdab60b2 md5 d8bbd02ade6ac94438547f255c04517b sha1 14ca73f2ae0d621ba17fbc5e0f0e8d9184184347 )
-	rom ( name "Mazogs(GE).tzx" size 13170 crc 5d7dd442 md5 cb162114851f80e1a4a820d4e7e4cc22 sha1 94e2da0938bd44f9c0392e2061e390e69d49d47b )
+	name "Catacombs (1981)(J.K. Greye Software)"
+	description "Catacombs (1981)(J.K. Greye Software)"
+	rom ( name "Catacombs (1981)(J.K. Greye Software).p" size 12506 crc 49525953 md5 5871e6e5b7af11b317503a1dc92e9364 sha1 57f0194272a9804d14cf4f77301d9365ce72037a )
 )
+
 game (
-	name "Mazogs (Monochrome) (Bug Byte)"
-	description "Mazogs (Monochrome) (Bug Byte)"
-	year 1981
-	manufacturer "Don Priestley"
-	rom ( name "mazogs.p" size 12831 crc 007463e5 md5 589a35248f7a9cb539f91b03427f9a3c sha1 dee47e0c7e717b9721e63078e1cfdce88ff9f725 )
-	rom ( name "Mazogs.tzx" size 13059 crc 4cb450b8 md5 421c3cdbe09cba807770d925bbb56dde sha1 edee5d84ed22c2cffa6b605a4caa998a8510da17 )
+	name "Catacombs (1981)(J.K. Greye Software)[a]"
+	description "Catacombs (1981)(J.K. Greye Software)[a]"
+	rom ( name "Catacombs (1981)(J.K. Greye Software)[a].p" size 12576 crc c6f0a98e md5 01e5499f0ae8985768b8ea487bbea715 sha1 7ce6814ffb4f444d81e79ea6f30483e3f9bcc6d0 )
 )
+
 game (
-	name "Mazogs (Softsync)"
-	description "Mazogs (Softsync)"
-	year 1982
-	manufacturer "Don Priestley"
-	rom ( name "mazogs(softsync).p" size 12831 crc 60b3c966 md5 acd2a6c8f4340c6f2553449225123cd8 sha1 a8e8494bee216f4054cdb2f34735177108305de8 )
-	rom ( name "Mazogs(Softsync).tzx" size 13059 crc 2c73fa3b md5 c89acd6ec795ffeef1d658836bb0dde3 sha1 56e5e86334cb633863fc2386ffda515ad8c58ea9 )
+	name "Catalogue (19xx)(-)"
+	description "Catalogue (19xx)(-)"
+	rom ( name "Catalogue (19xx)(-).p" size 1156 crc 45d68cdd md5 3480980a8dd3a91398d016ddf8d22e16 sha1 645dc091365627353f032970ad71914fae811967 )
 )
+
 game (
-	name "MCoder 11 (PSS)"
-	description "MCoder 11 (PSS)"
-	year 1983
-	manufacturer "PSS"
-	rom ( name "mcoder11.p" size 5713 crc 44b1bbe5 md5 7b5d8eaaaed4ba91ff36b3308126976f sha1 cd400d506c292dfd1946264d8d5518feceb8e0ba )
-	rom ( name "MCoder11.tzx" size 5941 crc 4c0ee232 md5 4e67fb609fa6b32e7b84c3c9713e468f sha1 e4d21864bfbba4e7584fb8d4817494eddebeba52 )
+	name "Catapult (19xx)(-)(nl)"
+	description "Catapult (19xx)(-)(nl)"
+	rom ( name "Catapult (19xx)(-)(nl).p" size 4499 crc a42d0d94 md5 1d6e11cc76c109068f98ec633aa59323 sha1 fbfc380cd7d03a714767669f7bef54614758b956 )
 )
+
 game (
-	name "MCoder (PSS)"
-	description "MCoder (PSS)"
-	year 1982
-	manufacturer "PSS"
-	rom ( name "mcoder.p" size 3558 crc 7297a09d md5 712640382c22590907acdf151c7c35f3 sha1 48e7bcfb62552fd617af3c4b903b3f52f759db3b )
-	rom ( name "MCoder.tzx" size 3786 crc 3aef6340 md5 3e6a131a6ff49dff552f0e8518686726 sha1 74d2103372c2d6e5d627c9deddba2ed948606c77 )
+	name "Caverns (19xx)(-)(nl)"
+	description "Caverns (19xx)(-)(nl)"
+	rom ( name "Caverns (19xx)(-)(nl).p" size 6854 crc c70e730b md5 a3c3ce411aecadd7e2498333d3305139 sha1 f8691513dd024211616ae0e95b5b50ab68eb84cb )
 )
+
 game (
-	name "Merchant of Venus (Crystal)"
-	description "Merchant of Venus (Crystal)"
-	year 1983
-	manufacturer "Crystal"
-	rom ( name "merchantofvenus.p" size 16161 crc 51cf1515 md5 f607c834c5f1405f7ff0f0e99af1e934 sha1 4be29a8df43bb849740910a055a8773e4d35a2fd )
-	rom ( name "MerchantOfVenus.tzx" size 16393 crc 5e4a029e md5 76409f6a8710a0231ffc4562a5217465 sha1 95f7628f548dcbfeb169fe3f12baa23e720b6f8c )
+	name "Caverns (19xx)(-)(nl)[a]"
+	description "Caverns (19xx)(-)(nl)[a]"
+	rom ( name "Caverns (19xx)(-)(nl)[a].p" size 7128 crc fc53628c md5 044f299a6283a8dba4558022abe26c55 sha1 11a366aba30b0f60f136f5d307d631c3fc3ad19f )
 )
+
 game (
-	name "Meteor Storm (dK'tronics)"
-	description "Meteor Storm (dK'tronics)"
-	year 1982
-	manufacturer "dK'tronics"
-	rom ( name "meteorstorm.p" size 5747 crc 8aed8ff8 md5 16a19477d2b25332dfd44117da71fa78 sha1 1c737a14c4bae0d2af32f28ed9dd2baa4d1dd792 )
+	name "Caverns of Mars (1983)(W. Labus - Frank Beer)(de)"
+	description "Caverns of Mars (1983)(W. Labus - Frank Beer)(de)"
+	rom ( name "Caverns of Mars (1983)(W. Labus - Frank Beer)(de).p" size 13936 crc 01820bed md5 e95061982ea1ede098063f96929a678d sha1 b59cefe5bd5e82c0d962d0c54f4c800c5be8a148 )
 )
+
 game (
-	name "Meteor Storm (Fast Master) (dK'tronics)"
-	description "Meteor Storm (Fast Master) (dK'tronics)"
-	year 1982
-	manufacturer "dK'tronics"
-	rom ( name "meteorstorm(fastmaster).p" size 5784 crc 83ae249c md5 0bbaafb1a7802dbbbbb03eb1852330e7 sha1 736654e354223e719629101bb94fdaf8a847220c )
-	rom ( name "MeteorStorm(FastMaster).tzx" size 6024 crc 35c2540e md5 4066b1dcfb69b1f9205ed0cb6b6bf35c sha1 e02a6983c28a40ccc70a3fa3edd1dc6dbf176354 )
+	name "Centipede (19xx)(Herosoft)(nl)"
+	description "Centipede (19xx)(Herosoft)(nl)"
+	rom ( name "Centipede (19xx)(Herosoft)(nl).p" size 10578 crc 743b2bc9 md5 f5fcf082e6fd2a65838c1b5f64bb74b0 sha1 06eb9f5bbf42b62026c455f8a4e8b5330dd8c363 )
 )
+
 game (
-	name "Micro Mouse goes de-bugging (Lothlorien)"
-	description "Micro Mouse goes de-bugging (Lothlorien)"
-	year 1983
-	manufacturer "M. C. Lothlorien"
-	rom ( name "micromouse.p" size 8487 crc 17365457 md5 d0603604ed0847e629eea1ec9e701457 sha1 c4510c08365bb8e873315f98fbbbbc067ec06612 )
-	rom ( name "MicroMouse.tzx" size 8713 crc db8110b5 md5 052bc1c42964e438a69feab1759a255c sha1 012a444ac366224d63daf2bc242ca30b58a0e33a )
+	name "Centipedes (19xx)(-)(de)"
+	description "Centipedes (19xx)(-)(de)"
+	rom ( name "Centipedes (19xx)(-)(de).p" size 4936 crc 5ac418a0 md5 a33e4a21c8bfcdd09ebdb91106be5d2e sha1 3f20691c12602d6554a5a0f4398556f3a964a718 )
 )
+
 game (
-	name "Mind vs. Machine (2-Bit Software)"
-	description "Mind vs. Machine (2-Bit Software)"
-	year 1982
-	manufacturer "2-Bit Software"
-	rom ( name "MindvsMachine.B.tzx" size 3168 crc c7ac234d md5 bb2ef658c6ffe1da45c34e32dd7a5161 sha1 5bf1942b1696ad670427a5119bac1cbddcac30f0 )
+	name "Chair (19xx)(-)"
+	description "Chair (19xx)(-)"
+	rom ( name "Chair (19xx)(-).p" size 1556 crc fdc9f312 md5 5cadd918c675668855ae65586b236721 sha1 135f02fb5c79f5cf3afe36aaeb0f978328d75431 )
 )
+
 game (
-	name "Miner Man"
-	description "Miner Man (2011) - 'Play through 60 levels of puzzles, mazes and traps. Each level will present the player with different amount of gems to collect. To collect the gems the player will have to work through the levels avoiding the traps and solving the puzzles.' (taken from the original game)"
-	rom ( name "MinerMan.p" size 15851 crc f84e2f0d md5 692985da7943b89cad06f4571b9a7b2f sha1 54db0c5305f89a629a19e5e107f34e65d2bfbd93 )
+	name "Character Effects (19xx)(-)"
+	description "Character Effects (19xx)(-)"
+	rom ( name "Character Effects (19xx)(-).p" size 1092 crc 133e9fe5 md5 36fe8bb9c5850eee51c9ad969d24f55a sha1 94f1d21b887b4c14d1ffa08f8bf05d6e8502a830 )
 )
+
 game (
-	name "Mixed Game Bag III (Timex)"
-	description "Mixed Game Bag III (Timex)"
-	year 1982
-	manufacturer "M. Orwin"
-	rom ( name "MixedGameBagIII.tzx" size 6939 crc 9115c144 md5 1aa50b1328afe02ce01d69fcee6ee746 sha1 9ad8a4c6321346b904995ac8e9aee31124eb5868 )
+	name "Charactersets Designprogram (19xx)(-)"
+	description "Charactersets Designprogram (19xx)(-)"
+	rom ( name "Charactersets Designprogram (19xx)(-).p" size 4972 crc 0240048c md5 89f2022595d936ae6835110669574675 sha1 2bf37c3cd9988f705e81ca745c8255f88840d173 )
 )
+
 game (
-	name "Money Analyzer 1 (Timex)"
-	description "Money Analyzer 1 (Timex)"
-	year 1982
-	manufacturer "T. J. Software"
-	rom ( name "MoneyAnalyzer1.tzx" size 2508 crc 8b0ecf6c md5 38b90377d5298596fd2d123f2e1bd9c2 sha1 5a223f431b06f01ccd7e30c31d462422409a3c69 )
+	name "Chase (19xx)(-)"
+	description "Chase (19xx)(-)"
+	rom ( name "Chase (19xx)(-).p" size 1864 crc c00648fc md5 082cb0504c4c3362122bc198bf460a38 sha1 62aa7762d85b25f74eeb76cda6b6210e8b327be4 )
 )
+
 game (
-	name "Moniteur Desassembleur (Direco International)"
-	description "Moniteur Desassembleur (Direco International)"
-	year 1982
-	rom ( name "moniteurdesassembleur.p" size 5593 crc 357448ff md5 5635d4860a5b03b9312ea12a87383631 sha1 6b32ff9ce4f9dab7e9e43df50c9dd8264d9cf5b9 )
-	rom ( name "MoniteurDesassembleur.tzx" size 5825 crc e548a0e6 md5 4b422022a5ed280d6bd1f6f74f7b56c5 sha1 f3433d201596f069dff1053a86fc2f293b8e4612 )
+	name "Checkbook (1982)(J. Gishen)"
+	description "Checkbook (1982)(J. Gishen)"
+	rom ( name "Checkbook (1982)(J. Gishen).p" size 2140 crc 8cd5e524 md5 cfed899b9d35e8b653328c18ff3391d2 sha1 f1858c5bbf8848f0e714848504fa0ad49917dadd )
 )
+
 game (
-	name "Monster Mine (Gem Software)"
-	description "Monster Mine (Gem Software)"
-	year 1982
-	manufacturer "Gem Software"
-	rom ( name "monstermine.p" size 10808 crc c0b1f76e md5 951905cd41aa8a43d7cece736a99099e sha1 f5063aff551446d25a9cbd3d7080e5d505d1f66a )
-	rom ( name "MonsterMine.tzx" size 11048 crc ac4bec18 md5 bba503301be95ea4fe4f9e3c45e867c1 sha1 bcbf2d46f2c8b547600f979882968d4a57c5b524 )
+	name "Checkbook Manager (19xx)(-)"
+	description "Checkbook Manager (19xx)(-)"
+	rom ( name "Checkbook Manager (19xx)(-).p" size 1951 crc 4cc51bd0 md5 106e2c0e9eed5e2c90858c89ca7ff395 sha1 a083013c6fd94236555187d8df075485091fe7fa )
 )
+
 game (
-	name "Morse Reader (JEP Electronics)"
-	description "Morse Reader (JEP Electronics)"
-	manufacturer "JEP Electronics"
-	rom ( name "morsereader.p" size 8827 crc 059ee1f6 md5 fffbf7d1aac3e3bf21f8895a5ea53194 sha1 51ce900cec1c55f91037989da1610dd6b73cbae6 )
-	rom ( name "MorseReader.tzx" size 9055 crc 9fce1af5 md5 f01f1d0b641939493ed663d9703baa5b sha1 debe28ec7e350d9b6431dc6fca6da97513232f02 )
+	name "Checkmate (19xx)(-)"
+	description "Checkmate (19xx)(-)"
+	rom ( name "Checkmate (19xx)(-).p" size 13658 crc 21821a77 md5 29a86079131bf78573c21d61506f5244 sha1 a591e991de38c5f194e88ba439445b1c2ab766b7 )
 )
+
 game (
-	name "Mothership (Sinclair Research)"
-	description "Mothership (Sinclair Research)"
-	year 1982
-	manufacturer "Alan Laity, Softsync"
-	rom ( name "mothership.p" size 9627 crc 7de56c4b md5 33404fcdbd84277061d678ebe4d6dbe3 sha1 55cd6d320281c29978170e22a8286803f0c72049 )
-	rom ( name "Mothership.tzx" size 9863 crc 526e7fa1 md5 bd8246e4a145f366bc9bf23bb45913c1 sha1 05fd66ec3eb2c22df673f2bdaa238faab8ae5fc2 )
+	name "Chess (19xx)(-)"
+	description "Chess (19xx)(-)"
+	rom ( name "Chess (19xx)(-).p" size 8303 crc 66e0f72e md5 8aed003be2b36794cd3f5410d3c80917 sha1 f3c2bcfa4cd41dafbf734bf25651cbea0c773f7e )
 )
+
 game (
-	name "Mothership (Softsync)"
-	description "Mothership (Softsync)"
-	year 1983
-	manufacturer "Alan Laity"
-	rom ( name "mothership(softsync).p" size 9627 crc 077d1fe8 md5 4b63a2614e5907b002264efea78a41e5 sha1 697ca1d242137e2207a98c70181d02a7895da64d )
-	rom ( name "Mothership(Softsync).tzx" size 9863 crc 28f60c02 md5 b065399ad89b9c5d000a60f7ac971154 sha1 63dec851b552ac48d167ce90deec768f0677d42f )
+	name "Chess (19xx)(-)[a2]"
+	description "Chess (19xx)(-)[a2]"
+	rom ( name "Chess (19xx)(-)[a2].p" size 941 crc 590d40ec md5 4ab43cb0e609895a0928ea7b25e7e74a sha1 6d6cb577211d0cfd1d9d0e1f85ea7bddbc0a3bf4 )
 )
+
 game (
-	name "Multifile (Gladstone) (Gladstone Electronics)"
-	description "Multifile (Gladstone) (Gladstone Electronics)"
-	year 1981
-	manufacturer "Bug Byte"
-	rom ( name "multifile(ge).p" size 5549 crc d71bf8bc md5 e4806a5d67124ada1f733f0e681cf66b sha1 bab72e5aae3ae98d0d4da03cba691b9e61e32fe6 )
-	rom ( name "Multifile(GE).tzx" size 5783 crc 18343751 md5 b05754895c071d02f191e4d7d588bf59 sha1 d72de512a1adc62cf2de299c2e1ff64ed630316b )
+	name "Chess (19xx)(-)[a]"
+	description "Chess (19xx)(-)[a]"
+	rom ( name "Chess (19xx)(-)[a].p" size 8381 crc b705b83d md5 712ec1e2918d9727b8ad85fb8a6bb6fa sha1 e7dc73301d8c9a94f035e17bf4ab2b81c1147357 )
 )
+
 game (
-	name "Multifile Plus (Gladstone Electronics)"
-	description "Multifile Plus (Gladstone Electronics)"
-	manufacturer "Bug Byte"
-	rom ( name "multifileplus(ge).p" size 7677 crc 6cb1f589 md5 dea427c0ddcdb0e27bdbfa199d903c8f sha1 e036fc55971244c9e2a3b157bd9f527b349dce17 )
-	rom ( name "MultifilePlus(GE).tzx" size 7921 crc 4952ff07 md5 80ff32332cb0bda770c476a519b0365a sha1 c2866c2c9430d5aec6ea4eb01d7f04c839b1b30c )
+	name "Chi-Square (19xx)(-)"
+	description "Chi-Square (19xx)(-)"
+	rom ( name "Chi-Square (19xx)(-).p" size 2081 crc 0ebe42ff md5 295771db8cb446b5853bec8dee6bebf8 sha1 4b696f79750e7ca188d5b5b72bd96403ac13aab0 )
 )
+
 game (
-	name "Multigraphics 2.3 (Bridge Software)"
-	description "Multigraphics 2.3 (Bridge Software)"
-	year 1981
-	manufacturer "Bridge Software"
-	rom ( name "multigraphics.p" size 14210 crc f55b43e1 md5 7000c83bd3b8b8ee761dffc603b7b90c sha1 256d229a11058bed6f608553fc1d9d081397ae89 )
-	rom ( name "Multigraphics.tzx" size 14452 crc 14dd97d3 md5 3b70eaa4b9c771feed049f6c1e0b798b sha1 7b7bead37db83539393b9bab71c15ed048608d85 )
+	name "Chopper (1980)(Tim Hartnell)[m Carlo Delhez]"
+	description "Chopper (1980)(Tim Hartnell)[m Carlo Delhez]"
+	rom ( name "Chopper (1980)(Tim Hartnell)[m Carlo Delhez].p" size 1958 crc c91321eb md5 bd76ad85b55df45813096df8d90e2a71 sha1 a5e4565a69eb25a1c61852f7f74737a0941e9c7c )
 )
+
 game (
-	name "Munchees (Quicksilva)"
-	description "Munchees (Quicksilva)"
-	year 1983
-	manufacturer "A. Laird"
-	rom ( name "munchees.p" size 7545 crc b9365fa1 md5 4d0347c0d394cdf1bbcb10d5553bb34b sha1 7c59c57a62eb0aa7750175020287b913e34aaa19 )
-	rom ( name "Munchees.tzx" size 7777 crc 4da90eed md5 b724025d7778e61dd088a66d0ba7b272 sha1 c64c8336f95030b957f3e6c3aed5be3a2237dbb1 )
+	name "City (19xx)(-)(nl)"
+	description "City (19xx)(-)(nl)"
+	rom ( name "City (19xx)(-)(nl).p" size 3283 crc 99eb10e6 md5 0b3c6a960c46393f07aa7e6d684d826b sha1 a4b6b318af870558bb8f9f1cfb063fafe2df2bf7 )
 )
+
 game (
-	name "Muncher (Silversoft)"
-	description "Muncher (Silversoft)"
-	year 1982
-	manufacturer "Silversoft"
-	rom ( name "muncher.p" size 5200 crc cadff742 md5 dba0e8079ab8f60c47b31bdff986e49e sha1 f9fcbbd7d5aac8a8c22bf7e73b87eccb18aedc00 )
-	rom ( name "Muncher.tzx" size 5430 crc 7334ad2a md5 2e1104b8d2d21f6c359477cc66366358 sha1 2d7edcfd205dfbdfe253967fa8dd25711964b00c )
+	name "City Bomb Run (19xx)(-)"
+	description "City Bomb Run (19xx)(-)"
+	rom ( name "City Bomb Run (19xx)(-).p" size 1253 crc 7213c74c md5 10b9a3d71fe101835691abee497e0a20 sha1 bb890e2d9d9bd859c336b9a96863920f0e702143 )
 )
+
 game (
-	name "Murgatroyds (Collins Computing)"
-	description "Murgatroyds (Collins Computing)"
-	year 1982
-	manufacturer "Collins Computing"
-	rom ( name "murgatroyds.p" size 7097 crc a0130eea md5 4b59af5f517ebeeaeb25db1a85883c5e sha1 6d309ccbe66964b30c9ed418ef8537efd07bc17e )
-	rom ( name "Murgatroyds.tzx" size 7315 crc d35af98d md5 40a6bb5e88b35f7309f76b55c808a7f2 sha1 e9b44dc8dce87e747c15c2bb24dc508f319ddc36 )
+	name "City Bomb Run (19xx)(-)[a]"
+	description "City Bomb Run (19xx)(-)[a]"
+	rom ( name "City Bomb Run (19xx)(-)[a].p" size 1392 crc a3ccfd8e md5 bca86a61a9ad8e8d353046c13ae7d8a2 sha1 eed5d7fd60c4deda19f6ac4f6db37c32013acfc9 )
 )
+
 game (
-	name "Music Composer (Memotronic)"
-	description "Music Composer (Memotronic)"
-	manufacturer "Frank Beer and Wolfgang Labus"
-	rom ( name "musiccomposer.p" size 5578 crc b0dcdcca md5 76133648609d8ab9b7b24a418e9ae215 sha1 70a99a384559e1d70e38b2ec5a6dfcac3cfe6ec0 )
-	rom ( name "MusicComposer.tzx" size 5822 crc d0cc5789 md5 8ab416356fb8de668546530c4ab0a890 sha1 bbf95991604eb52b8211d709736cdcde9ac4dc3b )
+	name "City Patrol (1982)(Macronics Systems)"
+	description "City Patrol (1982)(Macronics Systems)"
+	rom ( name "City Patrol (1982)(Macronics Systems).p" size 9198 crc e69fcf14 md5 f69f68161a8b15d6b29ab446c8d0d830 sha1 69e721cb5ebb53067352fa2d8b6d2d7ef350107e )
 )
+
 game (
-	name "Music Educator 1 (Timex)"
-	description "Music Educator 1 (Timex)"
-	year 1983
-	manufacturer "Tim Rossetti"
-	rom ( name "musiceducator1.p" size 14146 crc b7c34c96 md5 702e4b03957ef8a387a76013d1f1e932 sha1 457b9a66701a0edc6cb5b1c91d84758b64c3a074 )
-	rom ( name "MusicEducator1.tzx" size 14372 crc db66a8dd md5 f1fd3cf9b70bb1e730c0c73c75bf8129 sha1 0ee598ab50535505e8382f93d6f77f158d1e43e4 )
+	name "City Patrol (1982)(Macronics Systems)[a]"
+	description "City Patrol (1982)(Macronics Systems)[a]"
+	rom ( name "City Patrol (1982)(Macronics Systems)[a].p" size 7763 crc 1d4b3fa2 md5 362a95b657a41854f6b0540299e80164 sha1 03cc538b0ba3dd94086af1b002f3cb17db3d3179 )
 )
+
 game (
-	name "Namtir Raiders (Artic)"
-	description "Namtir Raiders (Artic)"
-	year 1982
-	manufacturer "J. Ritman"
-	rom ( name "namtirraiders.p" size 3740 crc 8ba3150e md5 28a7022c5386d46864fec0f0e9516a4f sha1 fb0367a015a4beb3cf6ee00853e84e430ceecc36 )
-	rom ( name "NamtirRaiders.tzx" size 3984 crc e65d10f3 md5 80d72c6b620d287e922279b2a5902e65 sha1 364dd09fac90173806cd1a643b594cb378156a55 )
+	name "Civilization (19xx)(-)[4K]"
+	description "Civilization (19xx)(-)[4K]"
+	rom ( name "Civilization (19xx)(-)[4K].p" size 3789 crc 56e2be24 md5 de5c1ea7d4c143c2884c46e5b8c7b360 sha1 86c171bd44492e3f269064535abf893aa14247a6 )
 )
+
 game (
-	name "Night Gunner (Digital Integration)"
-	description "Night Gunner (Digital Integration)"
-	year 1982
-	manufacturer "Digital Integration"
-	rom ( name "nightgunner.p" size 5113 crc 8fc7c658 md5 f15a54c0f92cc903b91ce8ed37e7cb88 sha1 9ec875318fa4e35087e65a9cf3b9def0080f3705 )
-	rom ( name "NightGunner.tzx" size 5333 crc ba8bea96 md5 cb630368c6f87f40c3d461f988f005fa sha1 ecd2c009311a97f40eae7102faf426e8572b6f96 )
+	name "Civilization (19xx)(-)[8K]"
+	description "Civilization (19xx)(-)[8K]"
+	rom ( name "Civilization (19xx)(-)[8K].p" size 7692 crc 5102853e md5 810a68980a00954338c388c5d3e48be8 sha1 f5ce857224352d864055cbe7f62fbf4f7c6e5bf6 )
 )
+
 game (
-	name "Night Gunner (Softsync)"
-	description "Night Gunner (Softsync)"
-	year 1982
-	manufacturer "Digital Integration"
-	rom ( name "nightgunner(softsync).p" size 5113 crc 77639e65 md5 32cbaf62810ec52668bb663029e893a5 sha1 f3b4ea9743015a0cb2c612a79322663a0e36a25a )
-	rom ( name "NightGunner(Softsync).tzx" size 5333 crc 422fb2ab md5 5fb5e7061c2c292259d4244b2b9847c1 sha1 9bd903833515016e2e6215c068b630223fc0138a )
+	name "Clock Frequency (1991)(Carlo Delhez)"
+	description "Clock Frequency (1991)(Carlo Delhez)"
+	rom ( name "Clock Frequency (1991)(Carlo Delhez).p" size 2019 crc 7ae746ec md5 e2cae2000a1a5858e07ef5ac4aa61882 sha1 8d27b0921f3cb20c378e375e410701bf09f45295 )
 )
+
 game (
-	name "Nightmare Park (Macronics)"
-	description "Nightmare Park (Macronics)"
-	year 1981
-	manufacturer "J. D. S. Cranston"
-	rom ( name "nightmarepark.p" size 11659 crc 28f39976 md5 ace96513fef192cd7197825120d9eb95 sha1 7b6344d8e2c62aa1dc1bebb64107dec51617b402 )
-	rom ( name "NightmarePark.tzx" size 11879 crc 53965b76 md5 42b898fee8207b3a73316056a7bf7eca sha1 86dbca70ae32e736a89c161c7e260e43576da971 )
+	name "Clou (19xx)(-)"
+	description "Clou (19xx)(-)"
+	rom ( name "Clou (19xx)(-).p" size 1754 crc 11b5a2fb md5 06dc9e1ea724a6af1ccd6a7d4131b257 sha1 441e28db8c126d135a778afe5d54eb3ef53d3272 )
 )
+
 game (
-	name "Noir Shapes"
-	description "Noir Shapes (2012) - Move the various shapes into a given space to complete each level, ensuring that none of the tiles overlap at any time. It may sound simple, but with limited room in which to arrange the tiles within things soon start to get claustrophobic..."
-	rom ( name "NoirShapes.p" size 15072 crc 20861b7a md5 b560973a9161f27e2929ce9a26a71fff sha1 5642ddd94d1c6649bc2e01ca112b7d76f376c826 )
+	name "CLR Test (19xx)(-)"
+	description "CLR Test (19xx)(-)"
+	rom ( name "CLR Test (19xx)(-).p" size 1228 crc 7a402cf7 md5 c2e551b5d4bf6937d2c14091a245f9e7 sha1 c3239fb706778203611edfb58716de47ac52687f )
 )
+
 game (
-	name "Octopussy (Peaksoft)"
-	description "Octopussy (Peaksoft)"
-	manufacturer "Peaksoft"
-	rom ( name "octopussy.p" size 6090 crc 62265923 md5 4c419dd9a3b3463d331e5c8c2f3d7e6b sha1 ca8c3a27854e51acb3abbb02c5ebb6ae40c628c0 )
-	rom ( name "Octopussy.tzx" size 6308 crc 9d408c0e md5 fa9f1e45071a0b907b6d8fdfc71f0430 sha1 745515410b88f840a33611b15c4e0a31e6b28611 )
+	name "Club Record (19xx)(-)"
+	description "Club Record (19xx)(-)"
+	rom ( name "Club Record (19xx)(-).p" size 6894 crc 0df4a885 md5 341e71f5ec1f360d0825edab90356619 sha1 6e5806ee3fa99cd5c477504508d77c61c1520696 )
 )
+
 game (
-	name "One Little Ghost"
-	description "One Little Ghost (2012) - Bob's interpretation of Namco's 1980 arcade game 'Pac-Man'."
-	rom ( name "OneLG.p" size 15884 crc c6b562c2 md5 3ed2b203e8ad7aefa659e11fa66fdc62 sha1 7bd65421239915dad4137206c0c7572f31c6ac5a )
+	name "Code Breaker (19xx)(-)"
+	description "Code Breaker (19xx)(-)"
+	rom ( name "Code Breaker (19xx)(-).p" size 2522 crc 6f12d38a md5 c8708dff462c6805f2e627e9fa9d87b3 sha1 0eb15eb99c372c8eaf0280af72eb7f084f34e437 )
 )
+
 game (
-	name "Othello (CDS Micro Systems)"
-	description "Othello (CDS Micro Systems)"
-	manufacturer "CDS Micro Systems"
-	rom ( name "othello.p" size 11655 crc 73457797 md5 ef70888041689cc60b9336201735f725 sha1 4dd7218297d9ef6cfb776decbd2f040a297e1c3e )
-	rom ( name "Othello.tzx" size 11885 crc 09d487fe md5 cfcb326e75dfa9a59a79e05491686dd6 sha1 47c8980d14972b59fab5098667b170169894515d )
+	name "Code Machine (19xx)(-)"
+	description "Code Machine (19xx)(-)"
+	rom ( name "Code Machine (19xx)(-).p" size 1956 crc 00094b48 md5 d1cdf7a2f5a856c4cd0a979091e5a343 sha1 066948bc015659cb56288ae7aeef5f8018b713a3 )
 )
+
 game (
-	name "Paint-Maze (Mikro-Gen)"
-	description "Paint-Maze (Mikro-Gen)"
-	manufacturer "Mikro-Gen"
-	rom ( name "PaintMaze.tzx" size 5086 crc 2eff4b27 md5 23dd48a06ff28c78e8a3f9bf26aa557e sha1 e8519c3eb5b772f13fe374c1c57a15d7d4791887 )
+	name "Codes (19xx)(-)"
+	description "Codes (19xx)(-)"
+	rom ( name "Codes (19xx)(-).p" size 1113 crc 1b9a79f4 md5 3e61c148a3afef598d92e307bdbeac85 sha1 09630cfc0c44010f61fb0d75c6162ff175db861c )
 )
+
 game (
-	name "Pandemic"
-	description "Pandemic (2014) - 'That is not dead which can eternal lie... in a petri dish' (with apologies to HP Lovecraft) -  The sequel 2010's VIRUS."
-	rom ( name "Pandemic.p" size 15934 crc 273220fa md5 4160c3e5a055e1258aeb500c7a60ffa7 sha1 28afa426e660186a1c1c56d74251b604e25bb2a1 )
+	name "Coin Game (19xx)(Ceran Software)(de)"
+	description "Coin Game (19xx)(Ceran Software)(de)"
+	rom ( name "Coin Game (19xx)(Ceran Software)(de).p" size 3476 crc cd8d2f15 md5 8d3c62762d49788007cec1af2eea71f4 sha1 727fd57e3508ee86601ae62cf65cf81ee0fd323f )
 )
+
 game (
-	name "Peloponnesian War (Lothlorien)"
-	description "Peloponnesian War (Lothlorien)"
-	year 1982
-	manufacturer "M. C. Lothlorien"
-	rom ( name "peloponnesianwar.p" size 16121 crc f44dec8b md5 1bc0299b676a7656670585fc0199772c sha1 a3f5b184568ac4ea26ae03f9e737e9fd1d4eac53 )
-	rom ( name "PeloponnesianWar.tzx" size 16341 crc f56e0c9d md5 7a8ab89f6173649c5bbc0a6a9bf4d62d sha1 94ebc1a99152a5441238ad242da19b4c9ccee699 )
+	name "Colditz Castle (19xx)(Logical Computers)"
+	description "Colditz Castle (19xx)(Logical Computers)"
+	rom ( name "Colditz Castle (19xx)(Logical Computers).p" size 10519 crc 680a4c2c md5 ea124b1897567e624339dde4de837df1 sha1 32ab9e7196024be160a810086703e8a4e611c7cf )
 )
+
 game (
-	name "Pengy (Fawkes Computing)"
-	description "Pengy (Fawkes Computing)"
-	year 1984
-	manufacturer "Fawkes Computing"
-	rom ( name "pengy.p" size 8564 crc f7e0304a md5 cdb3809c3f646129f7decba0dcc0c0ce sha1 19a0d22aca1f1580fac805b570a7bc3ea7ec4d2c )
-	rom ( name "Pengy.tzx" size 8782 crc 85894997 md5 bb2821339af5ebe2f6eb4ccc752f6a55 sha1 27606cf98e27ecc5a6da5da5e36ba5ab9c4fa038 )
+	name "Collectors Corner (19xx)(-)"
+	description "Collectors Corner (19xx)(-)"
+	rom ( name "Collectors Corner (19xx)(-).p" size 7481 crc 2acbcd0a md5 9715690d6192b385d842f96e33862ea5 sha1 c33ffbd0a2910c2c04f49e25a6a556ead4d9ba73 )
 )
+
 game (
-	name "Pilot (Colour inlay) (Hewson Consultants)"
-	description "Pilot (Colour inlay) (Hewson Consultants)"
-	year 1982
-	manufacturer "Hewson Consultants"
-	rom ( name "pilot.p" size 14899 crc 8dffd009 md5 68dc6d6b80d3c94e16d60cb5082a341f sha1 954dd9582e636990de568425b3602d3467c45d18 )
-	rom ( name "Pilot.tzx" size 15119 crc 775bafed md5 be91f4d73f8c368c0b5c55a33a836d28 sha1 8c4645159bcbec8144e875efeacb772d6609119d )
+	name "Colt (19xx)(Peet & Wil)(nl)"
+	description "Colt (19xx)(Peet & Wil)(nl)"
+	rom ( name "Colt (19xx)(Peet & Wil)(nl).p" size 3422 crc 51ce7a2e md5 81aae9852048d74f10564e41e1dfd5eb sha1 b9a73eb52d3f00defede15bc2ddce23e3ca163b2 )
 )
+
 game (
-	name "Pilot (Hewson Consultants)"
-	description "Pilot (Hewson Consultants)"
-	year 1982
-	manufacturer "Hewson Consultants"
-	rom ( name "pilot.p" size 14899 crc 8dffd009 md5 68dc6d6b80d3c94e16d60cb5082a341f sha1 954dd9582e636990de568425b3602d3467c45d18 )
-	rom ( name "Pilot.tzx" size 15119 crc 775bafed md5 be91f4d73f8c368c0b5c55a33a836d28 sha1 8c4645159bcbec8144e875efeacb772d6609119d )
+	name "Combat (19xx)(-)"
+	description "Combat (19xx)(-)"
+	rom ( name "Combat (19xx)(-).p" size 3862 crc 23d52c6b md5 e8c86ba7b430dd72e819e688d3187b6f sha1 254fe950344796714fcceb748a8e5f2b5e5beb58 )
 )
+
 game (
-	name "Pilot (New) (Hewson Consultants)"
-	description "Pilot (New) (Hewson Consultants)"
-	year 1982
-	manufacturer "Hewson Consultants"
-	rom ( name "pilot(new).p" size 13051 crc d9519a6e md5 8b5df07010240dcead0141109297547e sha1 8ecb69e390bd24941db252f592f059e327be0db6 )
-	rom ( name "Pilot(New).tzx" size 13271 crc 0bc60aad md5 b3b606add7070b8c774ff1af2b562732 sha1 42e19385766fe586291dee026b49b60f47a9df0f )
+	name "Combat Flight (1982)(G. Manuel)"
+	description "Combat Flight (1982)(G. Manuel)"
+	rom ( name "Combat Flight (1982)(G. Manuel).p" size 4516 crc c3d6cdab md5 de28f3f97e333bbefd8c347e1a354c1b sha1 dd925675cc095f6f2862c2d26f8a57af3f3cc57d )
 )
+
 game (
-	name "Pimania (Automata Cartography)"
-	description "Pimania (Automata Cartography)"
-	year 1982
-	manufacturer "Automata"
-	rom ( name "pimania.p" size 15773 crc 351eb08b md5 536e24e5b74ef6be13c44eaebebceea5 sha1 39f717b621452e6c853dc0e0318c01acb5ad45e6 )
-	rom ( name "Pimania.tzx" size 16003 crc 37cfb18d md5 5047a7041130a121e5d4e2d33e7ac1eb sha1 dd537d6ab72a749d1f6071d91748282e2ea2b89f )
+	name "Compac (19xx)(-)"
+	description "Compac (19xx)(-)"
+	rom ( name "Compac (19xx)(-).p" size 10074 crc dc199820 md5 6dbe4f4e1db7e544feab66aa4fd473f9 sha1 45acd4abb3534cc9d86945dc3e1db023a6908037 )
 )
+
 game (
-	name "Pinball (Timex)"
-	description "Pinball (Timex)"
-	year 1982
-	manufacturer "A. H. Laity"
-	rom ( name "pinball.p" size 4668 crc 40b6bef6 md5 1e2905fd9ab4f7f57e6a9d81ddfe2e7c sha1 26c5d56388ae2bdc5f9adc53aa670e427f3f5e68 )
-	rom ( name "Pinball.tzx" size 4898 crc f8452e21 md5 986cc07f307993d0f7a996caa18af0eb sha1 4ff5e7491088e5ebe4c67b4813baa943aaea5164 )
+	name "Compiler (19xx)(-)"
+	description "Compiler (19xx)(-)"
+	rom ( name "Compiler (19xx)(-).p" size 6980 crc 078105ae md5 b95e4cd201c22681bc9cc8e3d0bd36a1 sha1 1544f44c60c54a6f6d0918e9979915f78feaa2cb )
 )
+
 game (
-	name "Pioneer Trail (Quicksilva)"
-	description "Pioneer Trail (Quicksilva)"
-	year 1983
-	manufacturer "M.Stubbs"
-	rom ( name "pioneertrail.p" size 15462 crc e4ad892d md5 77f604b5f45dc443b41aefe41387f0f5 sha1 33fdc9772de2008cd98e5a55fe0013eaef752fe8 )
-	rom ( name "PioneerTrail.tzx" size 15682 crc ceb55f84 md5 3187c5eb7e83d9020e2aabf3f7ecb5eb sha1 1ff2a193ffda69d2ca542d63334399bcf2301390 )
+	name "Concentration (19xx)(-)"
+	description "Concentration (19xx)(-)"
+	rom ( name "Concentration (19xx)(-).p" size 2166 crc f41ea699 md5 1f6afd752e816af100a6f07f6c55bf1e sha1 9e46f7a0a4c769b68ed716ad6254ff5d84e9a3b8 )
 )
+
 game (
-	name "Planetoids (Macronics)"
-	description "Planetoids (Macronics)"
-	year 1981
-	manufacturer "Macronics"
-	rom ( name "planetoids.p" size 4909 crc 8a63863a md5 efdb0abdab99edbbf7b0c31281a17a8f sha1 9bca8cf12d888dbbe9b1d8f5a00e8f207cd0a346 )
-	rom ( name "Planetoids.tzx" size 5127 crc 02a6b2ad md5 8715626fa60ffa829018000d02dd3a1c sha1 270765be9b076e4eaa0704eece81137ad2c0ae10 )
+	name "Conquistador (19xx)(-)"
+	description "Conquistador (19xx)(-)"
+	rom ( name "Conquistador (19xx)(-).p" size 1594 crc 4d7dffbd md5 8166fcac765a68932e7b3862e4da1f0f sha1 6f1c26fd724d41aebe3fbf1eec86b2f00aac576e )
 )
+
 game (
-	name "Portfolio Analysis (Timex)"
-	description "Portfolio Analysis (Timex)"
-	year 1982
-	manufacturer "American Micro Products"
-	rom ( name "portfolioanalysis.p" size 15597 crc b540a618 md5 562cdb1a3e92927a8797312f03c448b6 sha1 26ebccff7160857f8490074a84bfd30c99aca883 )
-	rom ( name "PortfolioAnalysis.tzx" size 15819 crc d7ac34ed md5 0fd3b75c0d622131340a3c1bf3325edf sha1 e92da69a510bddb77ad5fab8e13f70d388ee5878 )
+	name "Copy (19xx)(-)"
+	description "Copy (19xx)(-)"
+	rom ( name "Copy (19xx)(-).p" size 787 crc 7cd0562f md5 5584b9e337e0bb7234004217b91d6633 sha1 fac94cba3a479d70a68cc7c663217601bef9d5e6 )
 )
+
 game (
-	name "Presidents (Timex)"
-	description "Presidents (Timex)"
-	year 1982
-	manufacturer "Timex"
-	rom ( name "presidents.p" size 5072 crc 61969b67 md5 6b8958911520b13ba8dcba0695d550e6 sha1 ba972c28536586a0c567357dbdcad2e362f45f91 )
-	rom ( name "Presidents.tzx" size 5300 crc 7bb539cf md5 7c4ccc1d49ef865bfd3a4e0babac9f4b sha1 e8ecee650bd89d88c7eb2fb9ec06eda5d5647caa )
+	name "Cosmax (19xx)(-)"
+	description "Cosmax (19xx)(-)"
+	rom ( name "Cosmax (19xx)(-).p" size 2147 crc ec9e991e md5 334ead5da156d9b80bd2d990883524b6 sha1 2e6297e0b3f34cb2929537e6cd2373c8c5f4493b )
 )
+
 game (
-	name "Print Shop (Cases Computer Simulations)"
-	description "Print Shop (Cases Computer Simulations)"
-	year 1983
-	manufacturer "Cases Computer Simulations"
-	rom ( name "printshop.p" size 14978 crc 5514b638 md5 cd8f4d73855eaef7ed7e81772a29ea3b sha1 cd58bee963702779034bfdbb17a22b8aeeb86c15 )
-	rom ( name "PrintShop.tzx" size 15212 crc da63a78f md5 5df01a04ff5ca4cf0f48939dd76a60fe sha1 6d911ea6f2e1df74f2547fb89c99f240a0e0272b )
+	name "Coupon Management (19xx)(-)"
+	description "Coupon Management (19xx)(-)"
+	rom ( name "Coupon Management (19xx)(-).p" size 15841 crc d610468c md5 bcc57fe50490a203215af9fae1a94bc4 sha1 9420126b2648805020622832c1533a415707f46b )
 )
+
 game (
-	name "Printer Programs (Nick Godwin)"
-	description "Printer Programs (Nick Godwin)"
-	year 1984
-	manufacturer "Nick Godwin"
-	rom ( name "PrinterPrograms.tzx" size 20668 crc 11d50d78 md5 dd1ccfe9d8243d306ebb0bda40e351a4 sha1 22a458e45d174f9053a5b96bcdf848fa2afc0e9e )
+	name "Coupon Management (19xx)(-)[a]"
+	description "Coupon Management (19xx)(-)[a]"
+	rom ( name "Coupon Management (19xx)(-)[a].p" size 15892 crc 708c7069 md5 b6959da3faa1ec1db685988be0d0f4b3 sha1 9471ff5296b13b9c6ed5c331c644ef8534067b7b )
 )
+
 game (
-	name "Privateer (Lothlorien)"
-	description "Privateer (Lothlorien)"
-	year 1982
-	manufacturer "M. C. Lothlorien"
-	rom ( name "privateer.p" size 12983 crc 8b4ce0e7 md5 81bd561dded0399d415f1e3c7b4d2419 sha1 b27dec9eaeb5f88581365fb6d5bd20c56e9bd6a9 )
-	rom ( name "Privateer.tzx" size 13217 crc 32e4f2d4 md5 7899a00015cc9b9b791c767d7c540c5e sha1 db608044f7c01b572406ade9481a6aea68995488 )
+	name "Crash (1981)(-)"
+	description "Crash (1981)(-)"
+	rom ( name "Crash (1981)(-).p" size 3428 crc 7aca281f md5 0041c4c80f8a7d4c2128fb038ef550e2 sha1 47274c5f2816597a82320c3b65da0faa9f58e0ac )
 )
+
 game (
-	name "Progmerge (ACS Software)"
-	description "Progmerge (ACS Software)"
-	year 1982
-	manufacturer "ACS Software"
-	rom ( name "progmerge.p" size 5279 crc d3fc7bf8 md5 951f8f1a0652936a3bb3f118c9bcc74e sha1 cde61a0ecb7a1e2f2531cc1743d2caeb746e47de )
-	rom ( name "Progmerge.tzx" size 5513 crc 13313bb9 md5 389d183a481034896e71e0c94603e729 sha1 fef5282a0e6a8937f22398c45187bb0e98e51b27 )
+	name "Crazy Kong (1983)(Ch. Zwerschke)"
+	description "Crazy Kong (1983)(Ch. Zwerschke)"
+	rom ( name "Crazy Kong (1983)(Ch. Zwerschke).p" size 6972 crc 730ba893 md5 63d144d3f5bc57acb67f386c06a26b5a sha1 730ecd352adfdaf59b6ddb3efb09bd4eeb1edb05 )
 )
+
 game (
-	name "Protector (Abacus)"
-	description "Protector (Abacus)"
-	year 1982
-	manufacturer "K. Flynn"
-	rom ( name "protector.p" size 7601 crc 571db599 md5 3c438049fff5dcc3247c530c9d39047e sha1 fa2bdbf6919ee3be7205f9a07db6a2ea1041e579 )
-	rom ( name "Protector.tzx" size 7835 crc 941c0480 md5 4d4c872b5934e61f8bb2064dbf7f122c sha1 750a926049abec9c67f6ade68fc029a068800dc6 )
+	name "Crazy Kong (1983)(Ch. Zwerschke)[a2]"
+	description "Crazy Kong (1983)(Ch. Zwerschke)[a2]"
+	rom ( name "Crazy Kong (1983)(Ch. Zwerschke)[a2].p" size 6956 crc 714298e9 md5 88a493a45d48286a0e52e9592983a65f sha1 63b68694600a4a8697c7bfdf2eff0a63ce85fd68 )
 )
+
 game (
-	name "Puckman (Hewson Consultants)"
-	description "Puckman (Hewson Consultants)"
-	year 1981
-	manufacturer "Hewson Consultants"
-	rom ( name "puckman.p" size 10535 crc 23e9839e md5 ca251287c8c980e758d4c497028a24d0 sha1 7571ebdbbd2308fff0653217fe599adb8e702b26 )
-	rom ( name "Puckman.tzx" size 10765 crc 2678c742 md5 46a91fb71da2119df0ce3ac027a7cbb3 sha1 c382093f64ac43318766c4c884854150a1775f2f )
+	name "Crazy Kong (1983)(Ch. Zwerschke)[a]"
+	description "Crazy Kong (1983)(Ch. Zwerschke)[a]"
+	rom ( name "Crazy Kong (1983)(Ch. Zwerschke)[a].p" size 6926 crc 47f8f81b md5 e8ea69720bf8114e8691d75dc4bb933a sha1 a01dbae6c8591a64ee03ca1adb83455958f3ed34 )
 )
+
 game (
-	name "Q Save (PSS)"
-	description "Q Save (PSS)"
-	manufacturer "PSS"
-	rom ( name "qsave.p" size 1547 crc a3edaab2 md5 48c37e545eaa01ef260e4b4799dc5992 sha1 fbdc2b3081b1e088ab05129ef8a5376e1378652d )
+	name "Creaded Demons Domain, The (19xx)(-)"
+	description "Creaded Demons Domain, The (19xx)(-)"
+	rom ( name "Creaded Demons Domain, The (19xx)(-).p" size 7506 crc 9f79feee md5 5b98948ebe3cebb0554883998402bb00 sha1 c3c2f5aa499d856e00748466d09f3e2f366eb70f )
 )
+
 game (
-	name "Q Save (Red) (PSS)"
-	description "Q Save (Red) (PSS)"
-	manufacturer "PSS"
-	rom ( name "qsave(red).p" size 1467 crc 7918413a md5 597c8a759af88ca64c2ad2462492887f sha1 46ee323c057848ab62d253662891eae847e449d8 )
-	rom ( name "QSave(Red).tzx" size 1693 crc 28bcfd44 md5 d6db4577ce639ce63b01d3ec351a5cf6 sha1 173946ba09a7b0f085b975d25ddfe6f431541186 )
+	name "Creaded Demons Domain, The (19xx)(-)[a]"
+	description "Creaded Demons Domain, The (19xx)(-)[a]"
+	rom ( name "Creaded Demons Domain, The (19xx)(-)[a].p" size 7516 crc 2ed248fd md5 ee47fa33638b02efef18b2a259b638f4 sha1 da86bcb220a7d76bce8a9559f204a5402bd68070 )
 )
+
 game (
-	name "QS Asteroids (Big picture, no text) (Quicksilva)"
-	description "QS Asteroids (Big picture, no text) (Quicksilva)"
-	year 1981
-	manufacturer "Quicksilva"
-	rom ( name "qsasteroids(bp2).p" size 3419 crc b88db752 md5 d5208b3c585a16897aa9488865faed2e sha1 f74fa3e6439f92a3491f2d6cf4c07961f40847f0 )
-	rom ( name "QSAsteroids(BP2).tzx" size 3641 crc c5fcf3db md5 df2760f0a630f8019d417946916fefeb sha1 b39c7484a5cec019727f037a37103e44b37741ec )
+	name "Cross Chase (2017-09-15)(Caruso, Fabrizio)[full][experimental]"
+	description "Cross Chase (2017-09-15)(Caruso, Fabrizio)[full][experimental]"
+	rom ( name "Cross Chase (2017-09-15)(Caruso, Fabrizio)[full][experimental].p" size 15571 crc 2c554fdc md5 e8d2c2351ee3432241e717e70a9e428d sha1 d43f685937633b9945bc58a36419e67f7e8f7634 )
 )
+
 game (
-	name "QS Asteroids (No characters) (Quicksilva)"
-	description "QS Asteroids (No characters) (Quicksilva)"
-	year 1982
-	manufacturer "Quicksilva"
-	rom ( name "qsasteroids(nc).p" size 3425 crc 64116f53 md5 cdbf8582fd0eb31c153708960714e98d sha1 52e3612464419dbe622c5c23fa50dce1fab9b4c3 )
-	rom ( name "QSAsteroids(NC).tzx" size 3647 crc 92df0bf9 md5 83a4ed182ca56c6cc560e1f017f536ce sha1 64a0e4aa51c42ddc49ba4a4a26f73fe4fef123fb )
+	name "Cross Chase (2017-09-15)(Caruso, Fabrizio)[minimal][experimental]"
+	description "Cross Chase (2017-09-15)(Caruso, Fabrizio)[minimal][experimental]"
+	rom ( name "Cross Chase (2017-09-15)(Caruso, Fabrizio)[minimal][experimental].p" size 10906 crc ba82801d md5 8b4fdff54ebece269e6ee27d41279b5d sha1 fe7c98073dc597de338a7f69106452a5f84b870f )
 )
+
 game (
-	name "QS Defenda (Big picture) (Quicksilva)"
-	description "QS Defenda (Big picture) (Quicksilva)"
-	year 1981
-	manufacturer "Quicksilva"
-	rom ( name "qsdefenda(bp).p" size 1749 crc 18409a9f md5 973e7fa1e1f0ebdfdfac2af2dcf15929 sha1 8e297aec1684fa43cdd5a1f2d8540bfb0b1b74dd )
-	rom ( name "QSDefenda(BP).tzx" size 1971 crc 15b06f98 md5 cc64ebd2a4e4bebc7033f975d33a0d4a sha1 eccd0670138ea0f14de3448536adddc1df5cd57f )
+	name "Cross Chase (2017-10-11)(Caruso, Fabrizio)[full]"
+	description "Cross Chase (2017-10-11)(Caruso, Fabrizio)[full]"
+	rom ( name "Cross Chase (2017-10-11)(Caruso, Fabrizio)[full].p" size 15887 crc d8713e62 md5 959b4d3e25a745ff3ac0ec6ddb54088c sha1 0f9eb7ebcade57ce3db89040e41301431789853d )
 )
+
 game (
-	name "QS Defenda (Number) (Quicksilva)"
-	description "QS Defenda (Number) (Quicksilva)"
-	year 1982
-	manufacturer "Quicksilva"
-	rom ( name "qsdefenda.p" size 2517 crc 91fc58b0 md5 cda9ab3ad5ec7dbffc54f03af34e09a0 sha1 b309d7eb02194221ed8aace44c17da53052555e6 )
-	rom ( name "QSDefenda.tzx" size 2739 crc f53682e9 md5 6b4adff2e0feaf1b8722f9025ff979ca sha1 db9f63deb748e232c16b4c8b769b143315d83540 )
+	name "Cross Chase (2017-10-11)(Caruso, Fabrizio)[light]"
+	description "Cross Chase (2017-10-11)(Caruso, Fabrizio)[light]"
+	rom ( name "Cross Chase (2017-10-11)(Caruso, Fabrizio)[light].p" size 11182 crc 1a844e97 md5 080cc071aa1ac0e48f93bf3764ed4335 sha1 21af60b55d1a9885a87ccd5d7d344c56da0f8cce )
 )
+
 game (
-	name "QS Defenda (Quicksilva)"
-	description "QS Defenda (Quicksilva)"
-	year 1982
-	manufacturer "Quicksilva"
-	rom ( name "qsdefenda.p" size 2517 crc 91fc58b0 md5 cda9ab3ad5ec7dbffc54f03af34e09a0 sha1 b309d7eb02194221ed8aace44c17da53052555e6 )
-	rom ( name "QSDefenda.tzx" size 2739 crc f53682e9 md5 6b4adff2e0feaf1b8722f9025ff979ca sha1 db9f63deb748e232c16b4c8b769b143315d83540 )
+	name "Cross Chase (2017-10-30)(Caruso, Fabrizio)[full]"
+	description "Cross Chase (2017-10-30)(Caruso, Fabrizio)[full]"
+	rom ( name "Cross Chase (2017-10-30)(Caruso, Fabrizio)[full].p" size 15856 crc a37f2570 md5 8d77d214a962308e28e0387e5415ef68 sha1 cbd087168e91636c55e0e33239de72fa872e0c74 )
 )
+
 game (
-	name "QS Invaders (Big picture) (Quicksilva)"
-	description "QS Invaders (Big picture) (Quicksilva)"
-	year 1981
-	manufacturer "Quicksilva"
-	rom ( name "qsinvaders(bp).p" size 7185 crc f855545e md5 72c039832c770144f6abbd7fcc1410d8 sha1 c2ab1cd34875dcd0f23206c5ce2f745169d047c0 )
-	rom ( name "QSInvaders(BP).tzx" size 7407 crc 05b21451 md5 ac31e8ef363def7fb56ebbab76f49db1 sha1 92b476abe309e02a9721ab2db8d927418060338e )
+	name "Cross Chase (2017-10-30)(Caruso, Fabrizio)[light]"
+	description "Cross Chase (2017-10-30)(Caruso, Fabrizio)[light]"
+	rom ( name "Cross Chase (2017-10-30)(Caruso, Fabrizio)[light].p" size 11065 crc 84722bfa md5 ce188917b96b4be2b6266de4521a1e2b sha1 1238a46f9f7b1d829778267c5e62791f246a27ee )
 )
+
 game (
-	name "QS Invaders (Number) (Quicksilva)"
-	description "QS Invaders (Number) (Quicksilva)"
-	year 1982
-	manufacturer "Quicksilva"
-	rom ( name "qsinvaders.p" size 7177 crc 81c099f2 md5 e3356d6fba598aa9fa70d4e8853f2c76 sha1 be764a893381a2b7ad55706dd7a60b1c0eba97f4 )
-	rom ( name "QSInvaders.tzx" size 7399 crc 6e8f0e11 md5 4c23b7f672ae9f4a12c24a54a485cda0 sha1 e9aa462b6d7edd1d2bcf20f37cf2f486ae61eff1 )
+	name "Cross Chase (2017-12-10)(Caruso, Fabrizio)"
+	description "Cross Chase (2017-12-10)(Caruso, Fabrizio)"
+	rom ( name "Cross Chase (2017-12-10)(Caruso, Fabrizio).p" size 15497 crc 4cc4481f md5 696bbff0e6f94ce8dd12cb35aa9d1cb8 sha1 8b589b9fb3714ad4785847338fb09948b6e27146 )
 )
+
 game (
-	name "QS Invaders (Number, Upside down) (Quicksilva)"
-	description "QS Invaders (Number, Upside down) (Quicksilva)"
-	year 1982
-	manufacturer "Quicksilva"
-	rom ( name "qsinvaders.p" size 7177 crc 81c099f2 md5 e3356d6fba598aa9fa70d4e8853f2c76 sha1 be764a893381a2b7ad55706dd7a60b1c0eba97f4 )
-	rom ( name "QSInvaders.tzx" size 7399 crc 6e8f0e11 md5 4c23b7f672ae9f4a12c24a54a485cda0 sha1 e9aa462b6d7edd1d2bcf20f37cf2f486ae61eff1 )
+	name "Cross Chase (2018-02-03)(Caruso, Fabrizio)[16K][full]"
+	description "Cross Chase (2018-02-03)(Caruso, Fabrizio)[16K][full]"
+	rom ( name "Cross Chase (2018-02-03)(Caruso, Fabrizio)[16K][full].p" size 14188 crc 292f192d md5 6e647e1749f50bcfe9a89ddb3d26b732 sha1 ac98ece2606c222d143d69013c208c5a4f3bf129 )
 )
+
 game (
-	name "QS Invaders (Quicksilva)"
-	description "QS Invaders (Quicksilva)"
-	year 1982
-	manufacturer "Quicksilva"
-	rom ( name "qsinvaders.p" size 7177 crc 81c099f2 md5 e3356d6fba598aa9fa70d4e8853f2c76 sha1 be764a893381a2b7ad55706dd7a60b1c0eba97f4 )
-	rom ( name "QSInvaders.tzx" size 7399 crc 6e8f0e11 md5 4c23b7f672ae9f4a12c24a54a485cda0 sha1 e9aa462b6d7edd1d2bcf20f37cf2f486ae61eff1 )
+	name "Cross Chase (2018-02-03)(Caruso, Fabrizio)[8K][tiny]"
+	description "Cross Chase (2018-02-03)(Caruso, Fabrizio)[8K][tiny]"
+	rom ( name "Cross Chase (2018-02-03)(Caruso, Fabrizio)[8K][tiny].p" size 7016 crc 278f90a1 md5 6b261ad5ba3859dd8f8803ffa6f2fe59 sha1 69868bd5241f2556a3db2c65040f69e8d6574a07 )
 )
+
 game (
-	name "QS Scramble (Number) (Quicksilva)"
-	description "QS Scramble (Number) (Quicksilva)"
-	year 1982
-	manufacturer "Quicksilva"
-	rom ( name "QSScramble(Alt).tzx" size 6320 crc 30847836 md5 09a4633a93747aeb1bca9e190aeaa14c sha1 7ee4b859c49ee81a670bd629e05ac27177dddb7d )
+	name "Cross Chase (2018-04-15)(Caruso, Fabrizio)[16K][full]"
+	description "Cross Chase (2018-04-15)(Caruso, Fabrizio)[16K][full]"
+	rom ( name "Cross Chase (2018-04-15)(Caruso, Fabrizio)[16K][full].p" size 14061 crc 25a64296 md5 a6ec2b071172bd16f0602120d5284f8e sha1 9aba69927044944df7b197a86df28d14077b8eb8 )
 )
+
 game (
-	name "Quack!"
-	description "Quack! (2014) - Bob's interpretation of the mobile game 'Flappy Bird'. Control a duck by tapping any key to make him fly up, and so avoid the oncoming pipes."
-	rom ( name "quack.p" size 8383 crc 01e8d775 md5 66afd32ec050cd1e4dbf657fd4f2089b sha1 d7e40348cc9181d2033c63e17e8fe07589e90c64 )
+	name "Cross Chase (2018-04-15)(Caruso, Fabrizio)[16K][full][turn-based]"
+	description "Cross Chase (2018-04-15)(Caruso, Fabrizio)[16K][full][turn-based]"
+	rom ( name "Cross Chase (2018-04-15)(Caruso, Fabrizio)[16K][full][turn-based].p" size 13910 crc 1582f16f md5 98eb11c375501cce0800fa047a5a0e97 sha1 0a0d32e109d80228f76226a20af5a0f5703c1320 )
 )
+
 game (
-	name "Ram Runner (Timex)"
-	description "Ram Runner (Timex)"
-	year 1982
-	manufacturer "Timex"
-	rom ( name "ramrunner.p" size 12985 crc 1caa4b3e md5 b18437b08fdeff0caca69ea2afae96eb sha1 998860f07b4c60a190883e5bbdfb3ae249c40f1c )
-	rom ( name "RamRunner.tzx" size 13213 crc 9ad7e13f md5 eef86dd226681e5e6cd3db6a7eb2766e sha1 c821a765c4045b8107ff273dac9d211baca717cd )
+	name "Cross Chase (2018-04-15)(Caruso, Fabrizio)[8K][tiny]"
+	description "Cross Chase (2018-04-15)(Caruso, Fabrizio)[8K][tiny]"
+	rom ( name "Cross Chase (2018-04-15)(Caruso, Fabrizio)[8K][tiny].p" size 6788 crc e0c3b701 md5 e92a03187dc3a2cd6be5053b03defe66 sha1 1cf0514ff8ba8c25c57b1fb1c682b4d3c8ae6d7f )
 )
+
 game (
-	name "Real Estate Investment Analysis (Timex)"
-	description "Real Estate Investment Analysis (Timex)"
-	year 1982
-	manufacturer "American Micro Products Inc."
-	rom ( name "realestateinvestmentanalysis.p" size 15825 crc edef9f40 md5 5767ad8d9e1ae3f9fedba17514a069e5 sha1 c75505864f9fe3d9842561ec9bde7a4d24cc9d57 )
-	rom ( name "RealEstateInvestmentAnalysis.tzx" size 16047 crc 8373ada1 md5 98459338d5e57be0f9e7721c4bcfd883 sha1 240481eb5e8b45ee3e7d240076819b8e2593c3f0 )
+	name "Cross Chase (2018-05-19)(Caruso, Fabrizio)[16K][full]"
+	description "Cross Chase (2018-05-19)(Caruso, Fabrizio)[16K][full]"
+	rom ( name "Cross Chase (2018-05-19)(Caruso, Fabrizio)[16K][full].p" size 13869 crc db808132 md5 1c531f75c4e11197cfbec1deb19fe2de sha1 8078492b4a8995024ff7161039632316252f7413 )
 )
+
 game (
-	name "Rebound"
-	description "Rebound (2014) - Bob's interpretation of a Breakout / Arkanoid game, with 32 unique levels, 16 ball directions, multiple balls, and power-ups."
-	rom ( name "Rebound.p" size 13897 crc 00721ae3 md5 81ef01732f2f2e4d7fa96fba5984665c sha1 6abc2d4de5bb40aac8f3703e5c33a9ce3a31be75 )
+	name "Cross Chase (2018-05-19)(Caruso, Fabrizio)[16K][full][turn-based]"
+	description "Cross Chase (2018-05-19)(Caruso, Fabrizio)[16K][full][turn-based]"
+	rom ( name "Cross Chase (2018-05-19)(Caruso, Fabrizio)[16K][full][turn-based].p" size 13651 crc c5148698 md5 0baa91bba05a94f4600bb515201cdb09 sha1 8735f7db13d05c3227e059fbe8ecc32ca243deb6 )
 )
+
 game (
-	name "Red Alert (Softsync)"
-	description "Red Alert (Softsync)"
-	year 1981
-	manufacturer "Quicksilva"
-	rom ( name "redalert.p" size 4004 crc e3f0e0c6 md5 3ee4de96ff92aa764d6a5af1978bf769 sha1 d95c77e1b695af04d6679cdab70ed2ab9caa8f2a )
-	rom ( name "RedAlert.tzx" size 4236 crc 16d48454 md5 4c5e219f57813a8838e43ba6ae791810 sha1 61a4719da9099699143e39713d08c13e381e9216 )
+	name "Cross Chase (2018-05-19)(Caruso, Fabrizio)[8K][tiny]"
+	description "Cross Chase (2018-05-19)(Caruso, Fabrizio)[8K][tiny]"
+	rom ( name "Cross Chase (2018-05-19)(Caruso, Fabrizio)[8K][tiny].p" size 6599 crc cb66e0f3 md5 75272818841673d2105d9fd7d3a5d6d8 sha1 c460da8cd390055b7a1e1cf38307d47a7036e899 )
 )
+
 game (
-	name "Rental Property Manager (Data-assette)"
-	description "Rental Property Manager (Data-assette)"
-	manufacturer "John Powers"
-	rom ( name "rentalpropertymanager.p" size 16109 crc 2316c873 md5 79e94ac3f50f837458eaf07ed4317951 sha1 79194cf5dfca47d67866257dbf2e2f31d8e79272 )
-	rom ( name "RentalPropertyManager.tzx" size 16339 crc 92f8aa70 md5 4b297d59dfa3fd14ee638b35d6f8bc99 sha1 378bb82167e1ee3a4f8ec8a69b2a3612cd2b2810 )
+	name "Cross Chase (2018-07-19)(Caruso, Fabrizio)[16K]"
+	description "Cross Chase (2018-07-19)(Caruso, Fabrizio)[16K]"
+	rom ( name "Cross Chase (2018-07-19)(Caruso, Fabrizio)[16K].p" size 13374 crc 5a0f93f5 md5 09946f086034dc8d6fee3aa1575474b6 sha1 893d46633d716d9e2787e3ae6d2f57bc9f63e2cc )
 )
+
 game (
-	name "Reversi (Artic)"
-	description "Reversi (Artic)"
-	year 1982
-	manufacturer "T. Hughes"
-	rom ( name "reversi(artic).p" size 14726 crc 613dd959 md5 5529e75702832f4c17874d81e49833a2 sha1 89e9591ff6720a374c30a1be117e5b9720fcea98 )
-	rom ( name "Reversi(Artic).tzx" size 14952 crc d5796e37 md5 708f70b98133de0290338c974ae50509 sha1 516f08ceefe2997e183e6f47e774fda4b81d7be3 )
+	name "Cross Chase (2018-07-19)(Caruso, Fabrizio)[16K][turn-based]"
+	description "Cross Chase (2018-07-19)(Caruso, Fabrizio)[16K][turn-based]"
+	rom ( name "Cross Chase (2018-07-19)(Caruso, Fabrizio)[16K][turn-based].p" size 13248 crc d04cbdb9 md5 2a14fa22e8df441ed27021fe1d50ea4e sha1 8630141244fcae47b70123e844952e8256df676d )
 )
+
 game (
-	name "Reversi also known as Othello (Sinclair Research)"
-	description "Reversi also known as Othello (Sinclair Research)"
-	year 1982
-	manufacturer "Moi/Games of Skill Ltd"
-	rom ( name "reversi.p" size 6222 crc 9317d6cf md5 496aeef5f2cea222a7223625f990c8f4 sha1 df86a5e30d5e38f37a3ab4e2975515e38bddbb82 )
-	rom ( name "Reversi.tzx" size 6452 crc 01930d80 md5 e33b1e6b4508f5eff9d7f0c873b0c94d sha1 0b09a2d44f3fb3243da9cc46ff161bffe6d8021b )
+	name "Cross Chase (2018-08-04)(Caruso, Fabrizio)[16K]"
+	description "Cross Chase (2018-08-04)(Caruso, Fabrizio)[16K]"
+	rom ( name "Cross Chase (2018-08-04)(Caruso, Fabrizio)[16K].p" size 13057 crc f9032661 md5 29b05acad2deccac93b8d41ab7b09434 sha1 4bc0a67ca89db4b15f77692b5c1a1a35420088de )
 )
+
 game (
-	name "Robbers of the Lost Tomb (Timeworks)"
-	description "Robbers of the Lost Tomb (Timeworks)"
-	year 1982
-	manufacturer "Timeworks"
-	rom ( name "robbersofthelosttomb.p" size 12141 crc 79fcfb44 md5 02209f4889c543a0a43d451743708328 sha1 345fa829ad2f082291c236ec5826aed0e864d8ba )
-	rom ( name "RobbersOfTheLostTomb.tzx" size 12365 crc 700a0975 md5 7d90a419cc9fc490f597993effb7d068 sha1 4e78f00d3529accfdde236c2ef24e43106b5d8d4 )
+	name "Cross Chase (2018-08-04)(Caruso, Fabrizio)[16K][turn-based]"
+	description "Cross Chase (2018-08-04)(Caruso, Fabrizio)[16K][turn-based]"
+	rom ( name "Cross Chase (2018-08-04)(Caruso, Fabrizio)[16K][turn-based].p" size 12952 crc 46050298 md5 24793fece1eb09c019d8cab336809a7b sha1 334aa21d9f2a7c9207f50746062e0a760610079e )
 )
+
 game (
-	name "Rocket Man (Software Farm)"
-	description "Rocket Man (Software Farm)"
-	year 1984
-	manufacturer "Software Farm"
-	rom ( name "rocketman.p" size 15327 crc 93fdefb0 md5 2a2606484cf8bbc5bfdfece4b1ab657b sha1 c9bde797ab35e89fe71fe595857b5d1d1d2740fc )
-	rom ( name "RocketMan.tzx" size 15561 crc e34adca9 md5 4ef97704d962703ca65309098356d20b sha1 024909ddf04e7efb22c4e84781aea9ce8e20a877 )
+	name "Cross Chase (2018-10-29)(Caruso, Fabrizio)[16K]"
+	description "Cross Chase (2018-10-29)(Caruso, Fabrizio)[16K]"
+	rom ( name "Cross Chase (2018-10-29)(Caruso, Fabrizio)[16K].p" size 12680 crc 38be81f6 md5 72d51f29c431478365b80f7e24d166e2 sha1 e8bd82f046b79e7d379e47ae1dd4dc7ca8561953 )
 )
+
 game (
-	name "Roman Empire (Lothlorien)"
-	description "Roman Empire (Lothlorien)"
-	year 1982
-	manufacturer "M. C. Lothlorien"
-	rom ( name "romanempire.p" size 15108 crc 19ebf247 md5 5c3babff0601a703a4ee3549d7608422 sha1 3629f81c9dff99b9d9bb84ee392f3c3ec345916f )
-	rom ( name "RomanEmpire.tzx" size 15328 crc 5eeef590 md5 a0b4632b0bc95998b687af11df7c769b sha1 38225146a420b541cd425e420b5c21c794fd7486 )
+	name "Cross Chase (2018-10-29)(Caruso, Fabrizio)[16K][turn-based]"
+	description "Cross Chase (2018-10-29)(Caruso, Fabrizio)[16K][turn-based]"
+	rom ( name "Cross Chase (2018-10-29)(Caruso, Fabrizio)[16K][turn-based].p" size 12600 crc 92a51e84 md5 7c70787ffcd42837e8ba4ac0ddc25357 sha1 9331b469270dd8800bb6a44f2728152c136f6660 )
 )
+
 game (
-	name "RPN Calculator (Zeta Software)"
-	description "RPN Calculator (Zeta Software)"
-	year 1982
-	manufacturer "Dr. Walter Diembeck"
-	rom ( name "rpncalculator.p" size 8282 crc fd66ef0e md5 df81ab32f89accd286bf7cac114db2a4 sha1 cd9f8d264af05fee79132004522eb5049f250650 )
-	rom ( name "RPNCalculator.tzx" size 8504 crc 1609ef0d md5 6943fdf8fb6e3d76ee3c9d119d3cd441 sha1 a6283859ffc5d6390b55803129777fe32b74d627 )
+	name "Cross Chase (2019-09-26)(Caruso, Fabrizio)[16K][light]"
+	description "Cross Chase (2019-09-26)(Caruso, Fabrizio)[16K][light]"
+	rom ( name "Cross Chase (2019-09-26)(Caruso, Fabrizio)[16K][light].p" size 9868 crc 02f5cc62 md5 9b401a5f2f9eee28ee7f68a62ee8ce9d sha1 02bdcec4243f4c93baeb2fca2dba783e1a565944 )
 )
+
 game (
-	name "Rubik Cube (Alt) (CDS Micro Systems)"
-	description "Rubik Cube (Alt) (CDS Micro Systems)"
-	year 1982
-	manufacturer "CDS Micro Systems"
-	rom ( name "rubikcube(alt).p" size 14375 crc c163a924 md5 12bcc34945162beb2b494198aea60e23 sha1 8075d277091b180ee535f253daeaf7cd39135069 )
-	rom ( name "RubikCube(Alt).tzx" size 14601 crc 11d010a0 md5 a514d66d19792684ad2f5f8987bb9448 sha1 7996ca3bb737847719bdfc0663483d0906d74282 )
+	name "Cross Chase (2019-09-26)(Caruso, Fabrizio)[32K][full]"
+	description "Cross Chase (2019-09-26)(Caruso, Fabrizio)[32K][full]"
+	rom ( name "Cross Chase (2019-09-26)(Caruso, Fabrizio)[32K][full].p" size 14289 crc ea322a91 md5 3402d652dfb7bbc1398ac306e4d0290c sha1 c019214d8a9e963771bbfad94a45a987cf7a0d30 )
 )
+
 game (
-	name "Rubik Cube (Brown inlay) (CDS Micro Systems)"
-	description "Rubik Cube (Brown inlay) (CDS Micro Systems)"
-	year 1982
-	manufacturer "CDS Micro Systems"
-	rom ( name "rubikcube.p" size 15158 crc 8ae261a2 md5 d70593b633e0e6a88a7e919f6f4c95c2 sha1 31426d332e594597879a9c42b259436445e96e4e )
-	rom ( name "RubikCube.tzx" size 15384 crc 580179a6 md5 724cdc2b86991f8710876579f9a16559 sha1 9b1b7f10e2ebfc90b3653dc10ec0ffd0d5a5c552 )
+	name "Cross Chase (2019-10-10)(Caruso, Fabrizio)[16K][full]"
+	description "Cross Chase (2019-10-10)(Caruso, Fabrizio)[16K][full]"
+	rom ( name "Cross Chase (2019-10-10)(Caruso, Fabrizio)[16K][full].p" size 12949 crc 5b513c37 md5 145b3b83c166a6e491e195fa20454ea9 sha1 086485fe5334516448b7af5e1a22314decd49c2e )
 )
+
 game (
-	name "Sabotage (Sinclair Research)"
-	description "Sabotage (Sinclair Research)"
-	year 1982
-	manufacturer "Macronics"
-	rom ( name "sabotage.p" size 8852 crc 682b39a0 md5 93a3ac8c7c759d72848470e7bf1595fc sha1 43467cef8ef83457ad6bac424ddd89ab885fed3c )
-	rom ( name "Sabotage.tzx" size 9070 crc 0120fe03 md5 6becdebc9329742a817e1d0068716ded sha1 4d123b512a757fe2e0bfd7ddee111322d8238d9f )
+	name "Cross Chase (2019-10-10)(Caruso, Fabrizio)[16K][full][turn-based]"
+	description "Cross Chase (2019-10-10)(Caruso, Fabrizio)[16K][full][turn-based]"
+	rom ( name "Cross Chase (2019-10-10)(Caruso, Fabrizio)[16K][full][turn-based].p" size 13099 crc d4d5f2ae md5 4f0981a14158f3f866bf681a8e791a5d sha1 faf55d9479028d9fcd799bae7bd7817f9ecc5e3b )
 )
+
 game (
-	name "Salvo (Orbyte Software)"
-	description "Salvo (Orbyte Software)"
-	manufacturer "A & M Productions"
-	rom ( name "salvo.p" size 15284 crc 202f1a9b md5 009acfc6e76e528f40cc693753e73251 sha1 3bd88ac1e2a1dfca98ad495346e0c65d9936a1a0 )
-	rom ( name "Salvo.tzx" size 15510 crc d9303929 md5 a28b801ff835cd8dccddacf23ed8db1f sha1 706ddd40ffc24ad4fffcef7d8f77889a6a1c1a19 )
+	name "Cross Chase (2019-10-10)(Caruso, Fabrizio)[16K][light]"
+	description "Cross Chase (2019-10-10)(Caruso, Fabrizio)[16K][light]"
+	rom ( name "Cross Chase (2019-10-10)(Caruso, Fabrizio)[16K][light].p" size 9868 crc 5e7bcd86 md5 cf01085d9b0e7951dfa7e1c39950124f sha1 2844308d8f87f2c7743771e8d4d1b0252a3f6ad5 )
 )
+
 game (
-	name "Samurai Warrior (Lothlorien)"
-	description "Samurai Warrior (Lothlorien)"
-	year 1982
-	manufacturer "M. C. Lothlorien"
-	rom ( name "samuraiwarrior.p" size 15261 crc 6804e38d md5 e268d6c175c8359bc23491aa237c0aa5 sha1 24ac5226d3e646254f00f3ccad7abfde618b346c )
-	rom ( name "SamuraiWarrior.tzx" size 15481 crc 68f13fb0 md5 4e59f61c5a39bf5f8b372ba40a009b07 sha1 a6d7b88718f8ef85e300cb1ba696544a6cb1efcf )
+	name "Cross Chase (2019-10-10)(Caruso, Fabrizio)[32K][full]"
+	description "Cross Chase (2019-10-10)(Caruso, Fabrizio)[32K][full]"
+	rom ( name "Cross Chase (2019-10-10)(Caruso, Fabrizio)[32K][full].p" size 14287 crc a1e98db1 md5 e070cd87d24c5f03d5da06dc097fc3d3 sha1 178401289bda9611d90a0c75047c6943450f7e8b )
 )
+
 game (
-	name "Scramble (Colour inlay) (Mikro-Gen)"
-	description "Scramble (Colour inlay) (Mikro-Gen)"
-	manufacturer "Mikro-Gen"
-	rom ( name "scramble(ci).p" size 4455 crc bfc4a5e6 md5 f9ba0ffc3497e3fd978a6894fcf28547 sha1 6add38b04de58597b939f24f35613b6a1b8e2eb5 )
-	rom ( name "Scramble(CI).tzx" size 4693 crc 0ef260a9 md5 de5f9bb0623c40822463ca512f959d06 sha1 338ba99e7d814653800311cd67be49fca764a822 )
+	name "Cross Chase (2019-10-10)(Caruso, Fabrizio)[32K][full][turn-based]"
+	description "Cross Chase (2019-10-10)(Caruso, Fabrizio)[32K][full][turn-based]"
+	rom ( name "Cross Chase (2019-10-10)(Caruso, Fabrizio)[32K][full][turn-based].p" size 14205 crc 98c9fe6b md5 15d89b928cb8be888937152253ea1594 sha1 ed613c091908baa19f33e1cc96fa24fa854f97d0 )
 )
+
 game (
-	name "Scramble (Mikro-Gen)"
-	description "Scramble (Mikro-Gen)"
-	manufacturer "Mikro-Gen"
-	rom ( name "scramble.p" size 4455 crc 6ca59ceb md5 1cace2e4cea14d6f96913f3ed7d7204f sha1 bd6ff916c9a18ea0eda7d21b061670231643e308 )
-	rom ( name "Scramble.tzx" size 4693 crc dd9359a4 md5 8f50b50f065ff824c39209c4680bf2aa sha1 84760e3b08c0e5686c9ace4b23dff5b6187da367 )
+	name "Cross Chase (2019-10-12)(Caruso, Fabrizio)[16K][full][QAOPM]"
+	description "Cross Chase (2019-10-12)(Caruso, Fabrizio)[16K][full][QAOPM]"
+	rom ( name "Cross Chase (2019-10-12)(Caruso, Fabrizio)[16K][full][QAOPM].p" size 12944 crc 1dd15b95 md5 febff37d0ec66a5c8a8df345ca2574fa sha1 cacd1945c1b44c738252d2e2438147336ce6f2ab )
 )
+
 game (
-	name "Screen Kit 1 (Picturesque)"
-	description "Screen Kit 1 (Picturesque)"
-	manufacturer "Picturesque"
-	rom ( name "screenkit1.p" size 1841 crc fe229e5d md5 3dab82c0980eeca3b0f22016ed6dcd16 sha1 84abe2d096d68e01573fe1aea3c3a0646c62e6f5 )
-	rom ( name "ScreenKit1.tzx" size 2081 crc 88368931 md5 ec8d98cec4ac5b718d7ab4c188a99a01 sha1 78351cb1c27587935242bf9bb0f512d07b902625 )
+	name "Cross Chase (2019-10-12)(Caruso, Fabrizio)[16K][full][turn-based][QAOPM]"
+	description "Cross Chase (2019-10-12)(Caruso, Fabrizio)[16K][full][turn-based][QAOPM]"
+	rom ( name "Cross Chase (2019-10-12)(Caruso, Fabrizio)[16K][full][turn-based][QAOPM].p" size 13098 crc 52cee7f9 md5 8bd935aeadc5a9148262df26bb20b8e1 sha1 8bb683470aafe51d7074766bc776c0814376cbd2 )
 )
+
 game (
-	name "Sea Wolf (Newer) (Stephen Hartley Computing)"
-	description "Sea Wolf (Newer) (Stephen Hartley Computing)"
-	year 1983
-	manufacturer "I. R. Bird"
-	rom ( name "seawolf(newer).p" size 9502 crc 3d713295 md5 a437d3a2d8ae59c77cca90bfb572ecd7 sha1 c75d950618d084f3cf1a0903a696d0a9bb8b6121 )
-	rom ( name "SeaWolf(Newer).tzx" size 9732 crc 9e1b515b md5 c71a018235cc635882535a19a256ce7a sha1 b55b9b06c9805d2253335d4f61a6ae43bbe9ffe4 )
+	name "Cross Chase (2019-10-12)(Caruso, Fabrizio)[16K][light][QAOPM]"
+	description "Cross Chase (2019-10-12)(Caruso, Fabrizio)[16K][light][QAOPM]"
+	rom ( name "Cross Chase (2019-10-12)(Caruso, Fabrizio)[16K][light][QAOPM].p" size 9864 crc 49cbaa97 md5 3d12bb097b93645bf3514319d4cfcfbc sha1 6b06cc365bab8038d840448a1b5d907485dea31a )
 )
+
 game (
-	name "Sea Wolf (Stephen Hartley Computing)"
-	description "Sea Wolf (Stephen Hartley Computing)"
-	year 1983
-	manufacturer "I. R. Bird"
-	rom ( name "seawolf.p" size 9502 crc 7156979a md5 394000d5a21f5320b63c1145e30f119f sha1 1c221622620508cdd921e0d84c34042fca87d1cc )
-	rom ( name "SeaWolf.tzx" size 9732 crc d23cf454 md5 0fceb5b1ae6ed2721d95f2343f6cdf37 sha1 f0275fe3bc08875e643be9431615b7a7c5ba64ab )
+	name "Cross Chase (2019-10-12)(Caruso, Fabrizio)[32K][full][QAOPM]"
+	description "Cross Chase (2019-10-12)(Caruso, Fabrizio)[32K][full][QAOPM]"
+	rom ( name "Cross Chase (2019-10-12)(Caruso, Fabrizio)[32K][full][QAOPM].p" size 14283 crc 9b36d393 md5 77a781cf61b861b8c3263dadb1142f0c sha1 92cf1cd8dd3155ba0db0fcbb471045e68714f123 )
 )
+
 game (
-	name "Similes Countdown (AVC Software)"
-	description "Similes Countdown (AVC Software)"
-	year 1981
-	manufacturer "K. Jammer and S. Brown"
-	rom ( name "similescountdown.p" size 9899 crc f2f2b554 md5 adce97d888ca6665a5071a5df2759364 sha1 4d0117466c37df6b4fafdc3eff7f75f3aea3aed1 )
-	rom ( name "SimilesCountdown.tzx" size 10151 crc fbbcdef4 md5 e270304c53d20e65b47ef69bd0fefdc8 sha1 7cd764fcbd90d455fb2d31ceec7cda10b08ec8cd )
+	name "Cross Chase (2019-10-12)(Caruso, Fabrizio)[32K][full][turn-based][QAOPM]"
+	description "Cross Chase (2019-10-12)(Caruso, Fabrizio)[32K][full][turn-based][QAOPM]"
+	rom ( name "Cross Chase (2019-10-12)(Caruso, Fabrizio)[32K][full][turn-based][QAOPM].p" size 14203 crc 5c2c8fa9 md5 79b36acd24d917fd088396fe8dd53101 sha1 c61d7f03ef01168e3c2d22a641bf4f967a5493c1 )
 )
+
 game (
-	name "Space Intruders (Hewson Consultants)"
-	description "Space Intruders (Hewson Consultants)"
-	year 1981
-	manufacturer "Hewson Consultants"
-	rom ( name "spaceintruders.p" size 3764 crc 074dc33e md5 6919edc03f14fc6772c089af461624d6 sha1 dfed85eafde74afb2c3237003d73e7fa3fe69837 )
-	rom ( name "SpaceIntruders.tzx" size 4010 crc 88b1156f md5 f15a15be576dc7efdcfd8bdf87faaadf sha1 8aaf24a56fe3cc999ce32ae795ce0bbd7983838f )
+	name "Cross Chase (2020-04-02)(Caruso, Fabrizio)[16K][full]"
+	description "Cross Chase (2020-04-02)(Caruso, Fabrizio)[16K][full]"
+	rom ( name "Cross Chase (2020-04-02)(Caruso, Fabrizio)[16K][full].p" size 12595 crc 7b834949 md5 0bf2442fcde79f0439ceaf3e2f72edcf sha1 013cfa72bb7aa6dd429e1da1b099588c0232a783 )
 )
+
 game (
-	name "Space Invaders 3K (Macronics)"
-	description "Space Invaders 3K (Macronics)"
-	year 1981
-	manufacturer "Macronics"
-	rom ( name "spaceinvaders3k.p" size 2854 crc f1273575 md5 dd982a212278df38fa34c19b19db4484 sha1 653dd0ba53d7005005fff184ee8d556cb6982a23 )
-	rom ( name "SpaceInvaders3K.tzx" size 3074 crc 69729abd md5 753f7387213896a0dae8e09a4974d2a2 sha1 00bea09a8d43cfd35cb2fb44eff623692811d2a9 )
+	name "Cross Chase (2020-04-02)(Caruso, Fabrizio)[16K][full][turn-based]"
+	description "Cross Chase (2020-04-02)(Caruso, Fabrizio)[16K][full][turn-based]"
+	rom ( name "Cross Chase (2020-04-02)(Caruso, Fabrizio)[16K][full][turn-based].p" size 12759 crc 49dbbd8a md5 fa7ee6add8486cd8bd2cc51ac436cdd5 sha1 1f7e63d29d5c11248aed7e9a48f0b528867bae58 )
 )
+
 game (
-	name "Space Invaders (dK'tronics)"
-	description "Space Invaders (dK'tronics)"
-	year 1981
-	manufacturer "dK'tronics"
-	rom ( name "spaceinvaders(dk).p" size 6645 crc 4c0edb0a md5 7bb4a934ddc0746167e6fac17f71cae4 sha1 1392c3c2ba459fbc67edb18fd96fd617fd8ad167 )
-	rom ( name "SpaceInvaders(dk).tzx" size 6889 crc 720bf20c md5 3d25c73ac6e5c6f48081eb86a5d0e0b3 sha1 e9d543b4f96bbda648c1488a06d2538ed3da3001 )
+	name "Cross Chase (2020-04-02)(Caruso, Fabrizio)[16K][light][wrx]"
+	description "Cross Chase (2020-04-02)(Caruso, Fabrizio)[16K][light][wrx]"
+	rom ( name "Cross Chase (2020-04-02)(Caruso, Fabrizio)[16K][light][wrx].p" size 9803 crc 3acc0203 md5 a01272af70a6afce291a923438545bc2 sha1 a58c9796595abb4d97be26d9bacb8437b54009e5 )
 )
+
 game (
-	name "Space Invaders (Mikro-Gen)"
-	description "Space Invaders (Mikro-Gen)"
-	manufacturer "Mikro-Gen"
-	rom ( name "spaceinvaders.p" size 2664 crc e39a90be md5 cce844a181612ad7e32209e73ce42b9c sha1 795cc3740caee56e9af16a52b557d93b968d0cde )
-	rom ( name "SpaceInvaders.tzx" size 2896 crc a345e8db md5 f835a9b2d5dce454a2ddc4caf8175505 sha1 4536f0d2a465a71891803b23d29bc8c54c1b874f )
+	name "Cross Chase (2020-04-02)(Caruso, Fabrizio)[32K][full][wrx]"
+	description "Cross Chase (2020-04-02)(Caruso, Fabrizio)[32K][full][wrx]"
+	rom ( name "Cross Chase (2020-04-02)(Caruso, Fabrizio)[32K][full][wrx].p" size 14206 crc 64f3a6fb md5 2100fc8af93d1023ec23afe96881903a sha1 ae1dd49a17fd55831997ab124db0af250b527ff2 )
 )
+
 game (
-	name "Space Man Apollo (ICT)"
-	description "Space Man Apollo (ICT)"
-	year 1984
-	manufacturer "Iain Thomson"
-	rom ( name "spacemanapollo.p" size 15647 crc 1adf5140 md5 0e91bcac7314fb7d95db8d86cb4920f4 sha1 fd98b6596b28bc0ecda1f3b7aaef526809d3a38e )
-	rom ( name "SpacemanApollo.tzx" size 15875 crc 0fc40716 md5 17291434ca3e09aed13b243f95498b0b sha1 68861a48e02a2d65b717012df38600d96986df97 )
+	name "Cross Chase (2020-04-02)(Caruso, Fabrizio)[32K][full][wrx][turn-based]"
+	description "Cross Chase (2020-04-02)(Caruso, Fabrizio)[32K][full][wrx][turn-based]"
+	rom ( name "Cross Chase (2020-04-02)(Caruso, Fabrizio)[32K][full][wrx][turn-based].p" size 14124 crc 8d42d97a md5 67674f45514eaf03694d7b1f8968efe6 sha1 baf9d202df247f4efeda1c6b299b82de8d0a68e6 )
 )
+
 game (
-	name "Space Mission (Gem Software)"
-	description "Space Mission (Gem Software)"
-	year 1982
-	manufacturer "Gem Software"
-	rom ( name "spacemission.p" size 13365 crc 97df84e4 md5 be00529ebf59e65659d1d658976fa738 sha1 1071d74d173d8f325894f0dbac851e60a15e38b2 )
-	rom ( name "SpaceMission.tzx" size 13607 crc 0dacab8d md5 35ac87605be32557ce38bfbf61f3dbaa sha1 bd92c04a311a49e5846e35528d692ee5e6eb2bcf )
+	name "Cross Chase (2021-05-13)(Caruso, Fabrizio)[16K]"
+	description "Cross Chase (2021-05-13)(Caruso, Fabrizio)[16K]"
+	rom ( name "Cross Chase (2021-05-13)(Caruso, Fabrizio)[16K].p" size 13004 crc 1bb43d25 md5 9749e7c56c5da61f0585d0e0bf5af12d sha1 ff1d46e5544c54d9ba50fec9ebf8cb8e0397455f )
 )
+
 game (
-	name "Space Trek (Micromega)"
-	description "Space Trek (Micromega)"
-	manufacturer "Micromega"
-	rom ( name "spacetrek.p" size 15395 crc 8c8545b1 md5 eb1db83f22e599c4a8927bdf043d2677 sha1 ff8a32ee7197f3ef632f2cf231cb0ca7cbf1defc )
-	rom ( name "SpaceTrek.tzx" size 15619 crc 081b0787 md5 7a2a66e12f7983634ff1ca0b9b795ded sha1 0e20ed7812a34ad507ec1c1dc23536641c4b9993 )
+	name "Cross Chase (2021-05-13)(Caruso, Fabrizio)[32K][wrx][turn-based]"
+	description "Cross Chase (2021-05-13)(Caruso, Fabrizio)[32K][wrx][turn-based]"
+	rom ( name "Cross Chase (2021-05-13)(Caruso, Fabrizio)[32K][wrx][turn-based].p" size 13277 crc 4d3ba905 md5 0e5eab81e876803a937c9d1ea5aa8c51 sha1 9cfa1cc0b60a70f092255022b86da01583fe7b38 )
 )
+
 game (
-	name "Spacetrek (JRS Software)"
-	description "Spacetrek (JRS Software)"
-	manufacturer "JRS Software"
-	rom ( name "spacetrek(jrs).p" size 332 crc c2f526df md5 a3b4c8c194ffd9b3df6ab21f57bcc6cc sha1 6b5c61147a38082825fc71a003937e5f07f59f02 )
-	rom ( name "Spacetrek(JRS).tzx" size 550 crc d62cc02f md5 17aaf306f2269d03004c5866d47af928 sha1 1b0c8177a41aea9aa40f5698280c86e505151349 )
+	name "Cross Horde (2021-04-16)(Caruso, Fabrizio)[32K][wrx]"
+	description "Cross Horde (2021-04-16)(Caruso, Fabrizio)[32K][wrx]"
+	rom ( name "Cross Horde (2021-04-16)(Caruso, Fabrizio)[32K][wrx].p" size 11714 crc 9c341e6c md5 12f909bdf90c2614d82f20d979219e32 sha1 0da9957392796fd8bbda1d02347e8e7aa2f81a1a )
 )
+
 game (
-	name "Spelling Bee (Timex)"
-	description "Spelling Bee (Timex)"
-	year 1983
-	manufacturer "Russell Klein"
-	rom ( name "SpellingBee.tzx" size 48415 crc a5987f22 md5 75f46b5eac8f50943ebe3c185da8a98b sha1 d992d921483b59b85ae68bdfa6e44d1c9c5068cc )
+	name "Cross Horde (2021-04-25)(Caruso, Fabrizio)[32K][wrx]"
+	description "Cross Horde (2021-04-25)(Caruso, Fabrizio)[32K][wrx]"
+	rom ( name "Cross Horde (2021-04-25)(Caruso, Fabrizio)[32K][wrx].p" size 12007 crc 87b4ce37 md5 cfe57e3b31138244867dfc590ede95a8 sha1 7f4085c997d30eb92cb1fc6aedcb74d1fde4f6b8 )
 )
+
 game (
-	name "Star Trek (Bug Byte)"
-	description "Star Trek (Bug Byte)"
-	year 1982
-	manufacturer "Bug Byte"
-	rom ( name "startrek.p" size 10018 crc a3004740 md5 33bacef251164137a75e7b9a7164ada0 sha1 7a890295c0b822938db6e8dc70bb68d669bf9051 )
-	rom ( name "StarTrek.tzx" size 10250 crc c8107516 md5 db8fba7fba8544b74b63c53519163be7 sha1 3e0f7d137f9572f756ba9edc5c6835fa9367be81 )
+	name "Cross Horde v1.0 (2021-05-01)(Caruso, Fabrizio)[32K][wrx]"
+	description "Cross Horde v1.0 (2021-05-01)(Caruso, Fabrizio)[32K][wrx]"
+	rom ( name "Cross Horde v1.0 (2021-05-01)(Caruso, Fabrizio)[32K][wrx].p" size 11958 crc ca0e2966 md5 63876fc027c900d12a5664ee9aebb6f4 sha1 b0b47d950ff39b941c531c37b484aedf35c12852 )
 )
+
 game (
-	name "Star Trek (Macronics)"
-	description "Star Trek (Macronics)"
-	year 1981
-	manufacturer "Macronics"
-	rom ( name "startrek(macronics).p" size 15869 crc e33d9286 md5 dac4c635719e0a8a0b7d55cc18f2e6a6 sha1 2f7d41853aa556ee5197a54e03e405286884343d )
-	rom ( name "StarTrek(Macronics).tzx" size 16091 crc 171e0b56 md5 9f7ef6572bf3d71c53b3ef64053a0715 sha1 5a25a295fc011e37b8941634ad32746b9d626d48 )
+	name "Cross Snake v1.0 (2020-12-12)(Caruso, Fabrizio)[32K]"
+	description "Cross Snake v1.0 (2020-12-12)(Caruso, Fabrizio)[32K]"
+	rom ( name "Cross Snake v1.0 (2020-12-12)(Caruso, Fabrizio)[32K].p" size 14272 crc 8e1e95e0 md5 d6c6e9126caa8543a9e4327d1862e286 sha1 0766df7ea1f84a202d879356e17fdc69d3aed632 )
 )
+
 game (
-	name "Star Trek (Typed Inlay) (Bug Byte)"
-	description "Star Trek (Typed Inlay) (Bug Byte)"
-	year 1981
-	manufacturer "Bug Byte"
-	rom ( name "startrek(typed).p" size 10018 crc 2749661e md5 9e9f60d7e165323899d49206285d9c3a sha1 f289f9958df4c2a7f811e36920fa4b7c74bc505c )
-	rom ( name "StarTrek(Typed).tzx" size 10250 crc 4c595448 md5 c7d23895712792195672678584e5d250 sha1 d6286120a5acc82d974f76e381f3382fe0c55be8 )
+	name "Cross Snake v2.0 (2020-12-31)(Caruso, Fabrizio)[32K][wrx]"
+	description "Cross Snake v2.0 (2020-12-31)(Caruso, Fabrizio)[32K][wrx]"
+	rom ( name "Cross Snake v2.0 (2020-12-31)(Caruso, Fabrizio)[32K][wrx].p" size 13961 crc 71460258 md5 a51ca1e70124ea35697d70ca0797ae8d sha1 99d9d5974adb902579514812a4eb70fc9fe299ff )
 )
+
 game (
-	name "Starquest (International Publishing and Software Inc.)"
-	description "Starquest (International Publishing and Software Inc.)"
-	year 1982
-	manufacturer "Pixel"
-	rom ( name "Starquest(IPS).tzx" size 17893 crc 0375bd08 md5 7237e3d312cdecfa235a945cd88b3aef sha1 fa7a242596852d6aa1c2ff15142ea2f1ed6d4b1f )
+	name "Cruzia (19xx)(-)"
+	description "Cruzia (19xx)(-)"
+	rom ( name "Cruzia (19xx)(-).p" size 1870 crc e02d29bf md5 d0f1ad5f49a7b037657cc6b8b88626d6 sha1 ea8a586bf307d3b267bc6db60494320b6c93b731 )
 )
+
 game (
-	name "Starquest (Pixel Productions)"
-	description "Starquest (Pixel Productions)"
-	year 1982
-	manufacturer "Pixel"
-	rom ( name "Starquest.2.Starquest.tzx" size 16209 crc 85bfc2b5 md5 7602a6da23e1e058b4ef39ac1b1d29cd sha1 f0d5783909ca9a5954ecd71854f4f9aaa57d6619 )
-	rom ( name "starquest.p" size 15989 crc fb070bd6 md5 73407dfbdae230f813ee47ee62747a4f sha1 6171f22250e4bfaf347b85f1e0cfeca5312dddae )
+	name "Cube (19xx)(-)"
+	description "Cube (19xx)(-)"
+	rom ( name "Cube (19xx)(-).p" size 2603 crc d8d185b6 md5 0961fb36d038b67f4e7bd34ada889d4a sha1 c35735858d7e5fc511af94ac2b05eee17aec4cdd )
 )
+
 game (
-	name "States and Capitals (Timex)"
-	description "States and Capitals (Timex)"
-	year 1982
-	manufacturer "Timex"
-	rom ( name "statesandcapitals.p" size 11310 crc d0be9818 md5 bedb20f535283c3d59eb0990a07690af sha1 509778144c3918ce04f64a5d723d17f7cacd9719 )
-	rom ( name "StatesAndCapitals.tzx" size 11538 crc c70fa5a4 md5 a2fad8976a643ea58281ae9c6276123a sha1 99551d3bb7ad39b7f55be16973af29dc7425e9e3 )
+	name "Cube (19xx)(John S. Heaney)"
+	description "Cube (19xx)(John S. Heaney)"
+	rom ( name "Cube (19xx)(John S. Heaney).p" size 13490 crc e74060ab md5 5396db1edfdb6bf3629b529a4ecb72fb sha1 6fa83678beab1ef60561fea8ebc35f686ddbd4c3 )
 )
+
 game (
-	name "Statistics (Timex)"
-	description "Statistics (Timex)"
-	year 1982
-	manufacturer "R. Daniel"
-	rom ( name "Statistics.tzx" size 4852 crc 22eb02c8 md5 0eb9db5c0720be88d236a198c94797d4 sha1 494389e8ad0a8c8adb4a7fa17c91464a78d555e2 )
+	name "Curse of the Aztec Tomb (19xx)(-)"
+	description "Curse of the Aztec Tomb (19xx)(-)"
+	rom ( name "Curse of the Aztec Tomb (19xx)(-).p" size 9631 crc 2e32d014 md5 76646da1dd909f105e524b56f3cbbc71 sha1 8a9bb8268ddfb01af4fb5f7c37f23a70da85a3a3 )
 )
+
 game (
-	name "Statistics (Zeta Software)"
-	description "Statistics (Zeta Software)"
-	manufacturer "Dr. Walter Diembeck"
-	rom ( name "statistics(zeta).p" size 13376 crc 9204f603 md5 f82de91f3b217e98a74152e96ab3856b sha1 5df7ca4145a22cc7f730aac13fe8835c40669321 )
-	rom ( name "Statistics(Zeta).tzx" size 13600 crc c0b4f14a md5 2b944e3bf6f17648919c3591b7b9905a sha1 7f13b230064429ab366f0816b43d683085d0bf62 )
+	name "Curse of the Aztec Tomb (19xx)(-)[a]"
+	description "Curse of the Aztec Tomb (19xx)(-)[a]"
+	rom ( name "Curse of the Aztec Tomb (19xx)(-)[a].p" size 9666 crc 430a5a0c md5 469695ca315b2a2b4283cea5df9abf7c sha1 1b9a0ff61520440b71cf1e830f7b89f712093d0b )
 )
+
 game (
-	name "Stock Car (Informatique Service)"
-	description "Stock Car (Informatique Service)"
-	year 1984
-	rom ( name "stockcar.p" size 8216 crc 41224d6b md5 c7549cd5dfc22bd438a16d6ffeb29b18 sha1 e70d50de2f51597bc74a50bdb25a34bf6b059888 )
-	rom ( name "StockCar.tzx" size 8450 crc fedbbc78 md5 cd54361859d4d5ae1e4290c8c5db8063 sha1 3604d2ff3b9de27e45cb691131b98be09ba3c65b )
+	name "Dallas (1982)(CCS)"
+	description "Dallas (1982)(CCS)"
+	rom ( name "Dallas (1982)(CCS).p" size 15646 crc a1137af3 md5 65e79c139aa7703e84efc9e21898786c sha1 9aaafdd543695439b73f45eb0e511ed73e09f56e )
 )
+
 game (
-	name "Stock Market Tech. Analysis 1 (Timex)"
-	description "Stock Market Tech. Analysis 1 (Timex)"
-	year 1982
-	manufacturer "T. H. Nooter"
-	rom ( name "stockmarkettechanalysis1.p" size 16177 crc 0ee43e40 md5 23d4292a790d7120376375574118136b sha1 6d8fe3f2bf6b8171af5a30ec199f6ec5f8c31c30 )
-	rom ( name "StockMarketTechAnalysis1.tzx" size 16405 crc 40a9b729 md5 bb445169bd552aa1beff7b3221856965 sha1 0d23879da55a4e5cbd7a8b482d010fdcb21e06f6 )
+	name "Dammen (1983)(M. Meerman Design)(nl)"
+	description "Dammen (1983)(M. Meerman Design)(nl)"
+	rom ( name "Dammen (1983)(M. Meerman Design)(nl).p" size 5760 crc 79d4c557 md5 052ae491f66d88b43f9077ddd2df1aa9 sha1 48f776f42ed54062ae3d7bd4b877bf6ba4ba62d5 )
 )
+
 game (
-	name "Stock-Market (Video Software)"
-	description "Stock-Market (Video Software)"
-	year 1981
-	manufacturer "Video Software"
-	rom ( name "StockMarket.A.tzx" size 11978 crc 440cc0e5 md5 cad4ab9c37b2db19ee7950cdfbe71490 sha1 849c2761901e9210f101500e5603d38b90e55a8c )
-	rom ( name "stockmarket.p" size 11738 crc d6f22d69 md5 3c4e77adf07396603240c9225499245d sha1 a71ff5fcc069c95e0e0ca480e78a724ea73fcf00 )
+	name "Dammen (1983)(M. Meerman Design)(nl)[a]"
+	description "Dammen (1983)(M. Meerman Design)(nl)[a]"
+	rom ( name "Dammen (1983)(M. Meerman Design)(nl)[a].p" size 5791 crc 4750fd39 md5 c70fcd3a9c6f36d7f3c1b6969a7fd6f3 sha1 6da78fd4c2a31a74ab16bad4ce3a70f5fa67c2f2 )
 )
+
 game (
-	name "Strategy Football (Timex)"
-	description "Strategy Football (Timex)"
-	year 1983
-	manufacturer "Gerald Bennett"
-	rom ( name "strategyfootball.p" size 15249 crc 903db439 md5 23b460ac48b647e5f5d2029a62c3a27a sha1 51e03ad187ae202e999e2b391e9fe82d4a301d5a )
-	rom ( name "StrategyFootball.tzx" size 15469 crc 432f9356 md5 9ce1d8687fa6ec86c44ceb48f5f0c4bd sha1 4add01b5f9e3ddf8f19a686ad91385d4dece1bbd )
+	name "Dammen (19xx)(-)(nl)[16K]"
+	description "Dammen (19xx)(-)(nl)[16K]"
+	rom ( name "Dammen (19xx)(-)(nl)[16K].p" size 7631 crc 302069e4 md5 8e1b308975f32b7c76ac1097d5858684 sha1 d457b8b0cf7010a11328092ed729bf97e40be79a )
 )
+
 game (
-	name "Subspace Striker (International Publishing and Software Inc.)"
-	description "Subspace Striker (International Publishing and Software Inc.)"
-	year 1982
-	manufacturer "Pixel"
-	rom ( name "SubspaceStriker(IPS).tzx" size 17446 crc b3c93f34 md5 7d123fe1a0f6430b7a8492483e2feeb6 sha1 4a0d2d26033bfb0b0d67248b8b2ae1fa5f423dc4 )
+	name "Damnation Alley (19xx)(H. Oudekerk)"
+	description "Damnation Alley (19xx)(H. Oudekerk)"
+	rom ( name "Damnation Alley (19xx)(H. Oudekerk).p" size 11460 crc 922629a5 md5 5aab90e05b52002573cfdf9790ddccb7 sha1 a2f2e1b269ffc9669b1ca44a8be7d8d4957cd5e8 )
 )
+
 game (
-	name "Super Chess (CP Software)"
-	description "Super Chess (CP Software)"
-	year 1982
-	manufacturer "CP Software"
-	rom ( name "superchess.p" size 16060 crc 650317b6 md5 abfb385e22165912beadca3377e4a6b2 sha1 324f41e92e9c6d5ea06792238b9374eb2340919f )
-	rom ( name "SuperChess.tzx" size 16296 crc dad51d68 md5 50316e46482e309565e8bb584190f3ed sha1 ce79c0b548bb98118e1725c82396887e01aea430 )
+	name "Damnation Alley (19xx)(H. Oudekerk)[a]"
+	description "Damnation Alley (19xx)(H. Oudekerk)[a]"
+	rom ( name "Damnation Alley (19xx)(H. Oudekerk)[a].p" size 10730 crc 05c2e385 md5 3a73b1e58d84305cc47eabf32ce405c9 sha1 4d5b2a00df27571440f56cf9c983f8fa6e31f604 )
 )
+
 game (
-	name "Super Chess (Softsync)"
-	description "Super Chess (Softsync)"
-	year 1982
-	manufacturer "CP Software"
-	rom ( name "superchess(softsync).p" size 16060 crc 026568f8 md5 3834752bc2c52e38631f234a1390810b sha1 a91df04216af0ce22b85c6a9bfa8c523e97b7da2 )
-	rom ( name "SuperChess(Softsync).tzx" size 16296 crc bdb36226 md5 5cfb66aefd5c74f85443d1a89d420410 sha1 5dda6654a11c6f0afa5dcb9d7f128667359a6954 )
+	name "Damper (1982)(Quicksilva)"
+	description "Damper (1982)(Quicksilva)"
+	rom ( name "Damper (1982)(Quicksilva).p" size 7686 crc f6f27471 md5 42036bf2a6ce8f69f5bc31b0b41797c8 sha1 ba7d54fe1433d28c5ca2f85b3cd657f74b3f70f5 )
 )
+
 game (
-	name "Super Invaders (Bridge Software)"
-	description "Super Invaders (Bridge Software)"
-	year 1982
-	manufacturer "Bridge Software"
-	rom ( name "superinvaders.p" size 12317 crc 94f95161 md5 4f2f2556ab2020046b3b864e1ffdf218 sha1 5bf9ccc9a39a47095143f0506aa778a1be11c341 )
-	rom ( name "SuperInvaders.tzx" size 12541 crc f662bd98 md5 b4bf9dff58752eb60ffd48d6af234720 sha1 3d8c7a7f290d9c792ea7263957dcdaa14cd02c93 )
+	name "Damper (1982)(Quicksilva)[a]"
+	description "Damper (1982)(Quicksilva)[a]"
+	rom ( name "Damper (1982)(Quicksilva)[a].p" size 7665 crc d8e9c8d1 md5 bb8dbcfc93b3021b383774fcbc1827d1 sha1 4436fbe2130456c0d5eae8f32612d3f455bf61a3 )
 )
+
 game (
-	name "Super Invasion (Softsync)"
-	description "Super Invasion (Softsync)"
-	year 1981
-	manufacturer "Beam Software"
-	rom ( name "superinvasion.p" size 896 crc 54df2bd2 md5 c65906f94fc9cef39c32bbdf56cd1b20 sha1 3c6a9ce5d9785c2a51802a21e666b01af73e0c8e )
-	rom ( name "SuperInvasion.tzx" size 1124 crc cc59f451 md5 dd3904d9a8d535358bebc9affcf11854 sha1 447855ab4bd695a574a93ff9fab09d65258438a5 )
+	name "Damsel and the Beast, The (1981)(-)"
+	description "Damsel and the Beast, The (1981)(-)"
+	rom ( name "Damsel and the Beast, The (1981)(-).p" size 11110 crc b6b4a6c2 md5 646a9d1c3529186ff7d5ee143f54a351 sha1 63de99dcd3824a28ea8eb87daf4129ccd97b442e )
 )
+
 game (
-	name "Super Math (Timex)"
-	description "Super Math (Timex)"
-	year 1982
-	manufacturer "Timex"
-	rom ( name "supermath.p" size 8075 crc 1f288f07 md5 5d4125044a0954ea23754d036920a1e7 sha1 4373cf521b219edb88a527454e97080a27344a72 )
-	rom ( name "SuperMath.tzx" size 8299 crc 21eb7b78 md5 1278409cd4aef861297f630f88665c5f sha1 3f30feead9537bf39da7d83175a5a0cc3dcf0a72 )
+	name "Damsel and the Beast, The (1981)(-)[a]"
+	description "Damsel and the Beast, The (1981)(-)[a]"
+	rom ( name "Damsel and the Beast, The (1981)(-)[a].p" size 11145 crc 0750f3b7 md5 eb139d146685afe70fe5c2f17f1b309f sha1 5b6c54c5df8d74f4de9c31e018848f98c532df09 )
 )
+
 game (
-	name "Super Nine (Romik Software)"
-	description "Super Nine (Romik Software)"
-	year 1982
-	manufacturer "Romik Software"
-	rom ( name "SuperNine.tzx" size 6872 crc e8b39d87 md5 5c6a25cd318de3f362261214003c32f1 sha1 5d3cb094e65d4bd9c412f4b6fc18afcc768e6f41 )
+	name "Dan's Revenge (1986)(Steven Mc Donald)"
+	description "Dan's Revenge (1986)(Steven Mc Donald)"
+	rom ( name "Dan's Revenge (1986)(Steven Mc Donald).p" size 10965 crc 607f4c36 md5 bdfe311871fe75500cc35c2f71fbc139 sha1 0b3409917ff6e5761d5b4d1c372ead8a0b58c08e )
 )
+
 game (
-	name "Super Programs 8 (ICL)"
-	description "Super Programs 8 (ICL)"
-	year 1982
-	manufacturer "ICL"
-	rom ( name "superprograms8(icl).p" size 14974 crc b7e6c5f1 md5 9ae1c2a5dd3976372cf9a9d712ae20f5 sha1 8cf3626e7b7289ce5fe14f4b5d15d3ddb71bd0ef )
-	rom ( name "SuperPrograms8(ICL).tzx" size 15192 crc 2532389a md5 2f2fff60323980089b85d19fdb34f21c sha1 a40650a76c57edc7a0431117fe9d9e5c4f47bb6b )
+	name "Danger UXB (19xx)(-)"
+	description "Danger UXB (19xx)(-)"
+	rom ( name "Danger UXB (19xx)(-).p" size 8205 crc 42995434 md5 a6060e9e28b48f71bce16e09b34b7bdc sha1 6e9747023b0da52cf0e1137c86a05ddcb5ab4a9d )
 )
+
 game (
-	name "Super Programs 8 (Sinclair Black) (ICL)"
-	description "Super Programs 8 (Sinclair Black) (ICL)"
-	year 1982
-	manufacturer "ICL"
-	rom ( name "superprograms8(icl).p" size 14974 crc b7e6c5f1 md5 9ae1c2a5dd3976372cf9a9d712ae20f5 sha1 8cf3626e7b7289ce5fe14f4b5d15d3ddb71bd0ef )
-	rom ( name "SuperPrograms8(ICL).tzx" size 15192 crc 2532389a md5 2f2fff60323980089b85d19fdb34f21c sha1 a40650a76c57edc7a0431117fe9d9e5c4f47bb6b )
+	name "Danger UXB (19xx)(-)[a]"
+	description "Danger UXB (19xx)(-)[a]"
+	rom ( name "Danger UXB (19xx)(-)[a].p" size 8240 crc ee6dc1c5 md5 54263ab4291936cc07bbfa38c68a398b sha1 493e82b4898b2e4aa0efddae6ed88610b52e1911 )
 )
+
 game (
-	name "Super Programs 8 (Sinclair Research)"
-	description "Super Programs 8 (Sinclair Research)"
-	year 1982
-	manufacturer "ICL"
-	rom ( name "superprograms8.p" size 14974 crc b876fa33 md5 6d3374dc7edbfd66f4d48b6140c17c11 sha1 cc2aa503a948d62d0a40fb29d0c628a5e4ea3632 )
-	rom ( name "SuperPrograms8.tzx" size 15192 crc 2aa20758 md5 545c084c45b5188079167da9f1acb304 sha1 de665ebe1949e077934ed6f0961d525f274f3d6e )
+	name "Dateiverwaltung (19xx)(-)(de)"
+	description "Dateiverwaltung (19xx)(-)(de)"
+	rom ( name "Dateiverwaltung (19xx)(-)(de).p" size 2749 crc 20594379 md5 3cbee4b2a39106735fd79152b323eaaf sha1 d2a349e0ee836ba19ec9a9f9b12c71c28cead9ba )
 )
+
 game (
-	name "Super Scramble (Software Farm)"
-	description "Super Scramble (Software Farm)"
-	year 1982
-	manufacturer "Software Farm"
-	rom ( name "superscramble.p" size 9068 crc 29c5c5d5 md5 8846ef2a3955e7637f72b13d0a8405b2 sha1 ab1e6fae6ba522c9cc9363ddb75c35a794ffdfd2 )
-	rom ( name "SuperScramble.tzx" size 9312 crc 5f11c06c md5 579e55d4adf1d3ee050bfb59abab6167 sha1 aa22bb6ff4c10b8279f2c1e568db7b9ae5158ca6 )
+	name "Days of Our Lives (1980)(Tim Hartnell)"
+	description "Days of Our Lives (1980)(Tim Hartnell)"
+	rom ( name "Days of Our Lives (1980)(Tim Hartnell).p" size 1862 crc ab22185a md5 b6ebe7f33e81b1eb1295978801209f16 sha1 6510aa8b415d4f98f39263573b1e226959bf7ddf )
 )
+
 game (
-	name "Supermaze (Timex)"
-	description "Supermaze (Timex)"
-	year 1982
-	manufacturer "Greg Harvey"
-	rom ( name "supermaze.p" size 16170 crc c58f309b md5 2684494519118b0c23b94ab177ed694e sha1 b36c2eaff62752137c75855e7686a90c58127906 )
-	rom ( name "Supermaze.tzx" size 16394 crc 6e93ce7f md5 225ef6ba2e2b9788dbeba444b5fc60ed sha1 f85d7522e9cd2bf3cbdc3c05493423d7afad482b )
+	name "DC-S Dakota (19xx)(Alpha Software)(nl)"
+	description "DC-S Dakota (19xx)(Alpha Software)(nl)"
+	rom ( name "DC-S Dakota (19xx)(Alpha Software)(nl).p" size 14442 crc 0f24f21a md5 5042fe24c8ec272147d81fc4211e2911 sha1 5865cae7a83b7b8ccc4bce6daf29c1e172de89aa )
 )
+
 game (
-	name "Tables Countdown (AVC Software)"
-	description "Tables Countdown (AVC Software)"
-	year 1981
-	manufacturer "K. Jammer and C. Deeson"
-	rom ( name "tablescountdown.p" size 8947 crc e3b0d8d8 md5 b71d10dcec0d99531fb8d2fb777751a0 sha1 1713feb2d1fbdf6d3712e10e2f0291a6bce813c4 )
-	rom ( name "TablesCountdown.tzx" size 9197 crc 59bd7de7 md5 8fec27b406d4041d3fb99784f7318f08 sha1 71d4f85478e2eb9016bab2fd0fac0107a7fccdea )
+	name "Death Caves (19xx)(Stephen Ives)"
+	description "Death Caves (19xx)(Stephen Ives)"
+	rom ( name "Death Caves (19xx)(Stephen Ives).p" size 4119 crc b2e4c5e4 md5 de3c2a3e06418eaad37eeaa5dcae9146 sha1 0c5b6a72faea65868d926929a38eb9b1069288ea )
 )
+
 game (
-	name "Tai (PSS)"
-	description "Tai (PSS)"
-	year 1982
-	manufacturer "PSS"
-	rom ( name "tai.p" size 14015 crc c7869e9e md5 17e769ceca4301beafb8c1547e62a326 sha1 7a44314234cffd9fff42c90a46be0db954e63352 )
-	rom ( name "Tai.tzx" size 14237 crc 3a1351f8 md5 2d7f98eca4bd7efe614ca55b6eb4fde3 sha1 fd0a3ceac8ce8540e13c7e6af6f547a2feff5d8a )
+	name "Death Duel (19xx)(-)"
+	description "Death Duel (19xx)(-)"
+	rom ( name "Death Duel (19xx)(-).p" size 3558 crc c0a1069c md5 7b2850e1e382b21c6c0e40c9fe3b5df3 sha1 889548612fe6d3883c7129e65db3143730c141e7 )
 )
+
 game (
-	name "Talkback (M. W. F. Ringrose)"
-	description "Talkback (M. W. F. Ringrose)"
-	year 1983
-	manufacturer "M. W. F. Ringrose"
-	rom ( name "Talkback.tzx" size 12740 crc 36724d18 md5 6caa20b159f6e66bec947d4a901862dd sha1 6b32ff6dd4930ad62cadb59b3c4ecdb6eb4a2654 )
+	name "Deathrider (1995)(Matt Barber)"
+	description "Deathrider (1995)(Matt Barber)"
+	rom ( name "Deathrider (1995)(Matt Barber).p" size 8639 crc 2dffab9b md5 16fcb32e73be78036987d792338e1ac2 sha1 4dd0de399cfa062191f0a8e8acf53c34323e0ee6 )
 )
+
 game (
-	name "Tapebook 50 1K (Control Technology)"
-	description "Tapebook 50 1K (Control Technology)"
-	manufacturer "Control Technology"
-	rom ( name "TapeBook50.tzx" size 37005 crc d882bccd md5 05b0b6c39c1a331e9d4592944f5fcf03 sha1 0d1b30d4d024147c9489d56e0519f9f60bf75cbd )
+	name "Declaraties Scout in 1983 (1983)(-)(nl)"
+	description "Declaraties Scout in 1983 (1983)(-)(nl)"
+	rom ( name "Declaraties Scout in 1983 (1983)(-)(nl).p" size 12714 crc ebd8017d md5 0f388b98630d7fca709cbcc02a5f0a0e sha1 9487f404fcff6025304118ceec7db08f9103d95b )
 )
+
 game (
-	name "Tarot (Timex)"
-	description "Tarot (Timex)"
-	year 1983
-	manufacturer "Computer Phood"
-	rom ( name "Tarot.tzx" size 29510 crc 5c63c324 md5 35525dae43101ab654360464227dfc37 sha1 81f1ab607044fd2b44c1163a0cb317dc1727d0a4 )
+	name "Deep Space (19xx)(-)"
+	description "Deep Space (19xx)(-)"
+	rom ( name "Deep Space (19xx)(-).p" size 6636 crc 94920678 md5 7cda17ddd96899f75c2ed6139f082f74 sha1 e0650e21202036f90fa62db121f8d31b697f9f7f )
 )
+
 game (
-	name "Tasword (Tasman Software)"
-	description "Tasword (Tasman Software)"
-	year 1982
-	manufacturer "Tasman Software"
-	rom ( name "tasword.p" size 5339 crc d2cd3934 md5 dd0169e3a06413005f30670f959d56d4 sha1 9dd68379eb1079ceb6b3a106cbc9839a2df9ad30 )
-	rom ( name "Tasword.tzx" size 5569 crc 9b77040a md5 321945f0628d33e073ae1c306d2ead5a sha1 100be588ad785f012f513e8043c323348b5e44ed )
+	name "Defence Command (19xx)(-)"
+	description "Defence Command (19xx)(-)"
+	rom ( name "Defence Command (19xx)(-).p" size 4815 crc ea5bcce7 md5 510363d8eac061288f93f21cc6eb3b76 sha1 0be6ba117b421d3781a2dbc3b6ea849f6818411e )
 )
+
 game (
-	name "Tempest (Mikro-Gen)"
-	description "Tempest (Mikro-Gen)"
-	manufacturer "S. P. Kelly"
-	rom ( name "tempest.p" size 3291 crc f760afba md5 44309dc8b4e242a1e08dfad3f4d590ba sha1 8e4c160df4ec5905f38a922e8e1403d984c92fe4 )
-	rom ( name "Tempest.tzx" size 3521 crc 5cca0ded md5 09bdea36a433f0a3f5fe8b8bcc8e0aa3 sha1 a4cfd1f82d0e4d255ae3b54a54f30a6cb96ce4f9 )
+	name "Defence Force (19xx)(Greg Jarvis)"
+	description "Defence Force (19xx)(Greg Jarvis)"
+	rom ( name "Defence Force (19xx)(Greg Jarvis).p" size 6979 crc 2b0acba8 md5 0a1b771cd12d4daa2198b1b25deb1b6c sha1 7d2dd986e8488b86b71b31e6361f47b5eac5fabd )
 )
+
 game (
-	name "Ten 1K Games (Computer Rentals)"
-	description "Ten 1K Games (Computer Rentals)"
-	year 1983
-	manufacturer "Mike Biddell, Tom Davies [5,6], Robert Vance[7,8]"
-	rom ( name "Ten1KGames.tzx" size 7545 crc c724fd4a md5 60cccfa8c4852f55d0eeda74524c0ca0 sha1 589c68041f90a46fb8c18118c0889c6b8f91f0ca )
+	name "Defenda (19xx)(-)"
+	description "Defenda (19xx)(-)"
+	rom ( name "Defenda (19xx)(-).p" size 1749 crc 68d7bfd0 md5 4c290d76fad6bef9d568f8ee0ad0fca8 sha1 06500bde44ea24082d6b46053c918c6425399359 )
 )
+
 game (
-	name "The Budgeter (Timex)"
-	description "The Budgeter (Timex)"
-	year 1982
-	manufacturer "Timex"
-	rom ( name "budgeterthe.p" size 7421 crc 8d3b6fc8 md5 f8f70240fd3ce11eda2d349f26d760d9 sha1 c2d31635238b2d581c1d8e4c7ed0565933275b1d )
-	rom ( name "BudgeterThe.tzx" size 7653 crc 5ea30258 md5 ab5775378af88aaf6fd6b6e653f00318 sha1 936a4bdf69507c24b8a634c94065548a3757fac9 )
+	name "Demolition (1982)(Phipps Associates)"
+	description "Demolition (1982)(Phipps Associates)"
+	rom ( name "Demolition (1982)(Phipps Associates).p" size 3601 crc 59fd5916 md5 44c61ea1186f9c79497e863bdb0d6088 sha1 f2b7683f0477c983af8951473a8db25068eb3fa4 )
 )
+
 game (
-	name "The Carpooler (Timex)"
-	description "The Carpooler (Timex)"
-	manufacturer "Timex"
-	rom ( name "carpoolerthe.p" size 14277 crc 0d8abcac md5 068be6e28af97837ffbb6d292930b6d7 sha1 992b08b7fc5bc7d0d891459fbcebb078ba9d2649 )
-	rom ( name "CarpoolerThe.tzx" size 14507 crc d8258cef md5 9f1a67808e8506b0df3c66bf00568caf sha1 cafbb78bf77f88c0ffb29e6c2a92666899149c8e )
+	name "Denkspel (19xx)(-)(de)"
+	description "Denkspel (19xx)(-)(de)"
+	rom ( name "Denkspel (19xx)(-)(de).p" size 2737 crc 49e610ad md5 7621781b85fc2c1d0d35ecf57d6492e5 sha1 06dd6be91a6ffc2016642efef40e50f93584101f )
 )
+
 game (
-	name "The Challenger 1 (Timex)"
-	description "The Challenger 1 (Timex)"
-	year 1982
-	manufacturer "R. Fowkes"
-	rom ( name "Challenger1The.tzx" size 4178 crc a01b37e4 md5 ca1d005637983ed5618c1bfd4b9bb08d sha1 5b9809a27911e43d8fb882a60da3752fe202bc27 )
+	name "Depreciation (19xx)(-)"
+	description "Depreciation (19xx)(-)"
+	rom ( name "Depreciation (19xx)(-).p" size 2034 crc 405c64d7 md5 f73f8b9cc7994558bb6da05363891639 sha1 5743c7fe05ef15d3930e563f808558ab4268da94 )
 )
+
 game (
-	name "The Checkbook Manager (Timex)"
-	description "The Checkbook Manager (Timex)"
-	year 1982
-	manufacturer "John Heaney"
-	rom ( name "checkbookmanagerthe.p" size 13483 crc b9446d9b md5 6e610dca9691a1fc82c89a5ba4a4574d sha1 5a12849ce4be86742c393306023fbf2fb081ca6a )
-	rom ( name "CheckbookManagerThe.tzx" size 13713 crc b32eaa12 md5 59cd50185f32789958737b3eac99c64b sha1 d1b150fee25332715af8115604d8063e5a71b77d )
+	name "Depreciation (19xx)(-)[a]"
+	description "Depreciation (19xx)(-)[a]"
+	rom ( name "Depreciation (19xx)(-)[a].p" size 2065 crc 0cc966b5 md5 ed3e685ff9b62b6f75b9aafca30f2bc3 sha1 d95326874979566b444c50faa22bc32bebd378de )
 )
+
 game (
-	name "The Coupon Manager (Timex)"
-	description "The Coupon Manager (Timex)"
-	year 1982
-	manufacturer "Timex"
-	rom ( name "couponmanagerthe.p" size 15892 crc d4803e75 md5 ae154df5fad396df2c60a12ff7275328 sha1 e6f50fcc128863cd06428a20a731b0cdb1b76379 )
+	name "Detective (19xx)(A. Watney)"
+	description "Detective (19xx)(A. Watney)"
+	rom ( name "Detective (19xx)(A. Watney).p" size 9667 crc b16c9753 md5 7f54374bae8cc53f4d5ab620c826a4c9 sha1 4f67f9e3964291c50693b2ec2bbc16993793b714 )
 )
+
 game (
-	name "The Cube Game (Timex)"
-	description "The Cube Game (Timex)"
-	year 1982
-	manufacturer "John Heaney"
-	rom ( name "cubegamethe.p" size 13490 crc 5b814ea8 md5 46141c523cf55f37ad18594d434c118e sha1 c30033cd7773cf740f517b3e5c8fd7b1bfe593da )
-	rom ( name "CubeGameThe.tzx" size 13714 crc c87bea16 md5 e7e0b000b8fce72a25f358b4b5f2478e sha1 dbf04e07ff5ed808df032c66191f79d0c96488a5 )
+	name "Detective (19xx)(A. Watney)[a]"
+	description "Detective (19xx)(A. Watney)[a]"
+	rom ( name "Detective (19xx)(A. Watney)[a].p" size 9701 crc 59ead00f md5 c7349442b89b7b29605c94e665d9f757 sha1 c11b6eca29e4a42b02e8ff888ebabc69116d2f8e )
 )
+
 game (
-	name "The Damsel and the Beast (Bug Byte)"
-	description "The Damsel and the Beast (Bug Byte)"
-	year 1981
-	manufacturer "Bug Byte"
-	rom ( name "damselandthebeastthe.p" size 10200 crc e572e012 md5 a4ba6fb14be2c6841565dffc496d8c18 sha1 15033d3454985a1ce45289bb33296791ab3332aa )
-	rom ( name "DamselAndTheBeastThe.tzx" size 10464 crc b34252c8 md5 d055c7009157dcf01dc9689d414dbafa sha1 574392a27b8328ec82121e1c666e2c3411f34342 )
+	name "Detector (19xx)(-)(nl)"
+	description "Detector (19xx)(-)(nl)"
+	rom ( name "Detector (19xx)(-)(nl).p" size 3134 crc 593ae881 md5 8b2f19bf4831e6e14bca11f774f87685 sha1 4990221e7113e6516aeca9e2222d00386a01a2e7 )
 )
+
 game (
-	name "The Electronic Checkbook (Timeworks)"
-	description "The Electronic Checkbook (Timeworks)"
-	year 1982
-	manufacturer "Timeworks"
-	rom ( name "electroniccheckbookthe.p" size 16162 crc 75097784 md5 cdd6ea720f382f5dc8f2c971a53e3e2f sha1 a2ace5b2b1bf45c5dbd0ebf2cbd47934dc668787 )
-	rom ( name "ElectronicCheckbookThe.tzx" size 16382 crc bc3ed36d md5 c0f35b0fcef5474812364c0ea6cdcf2e sha1 3791720c3974c31c322b9d1e6a6281de6e6bcfcd )
+	name "Dice, The (19xx)(-)"
+	description "Dice, The (19xx)(-)"
+	rom ( name "Dice, The (19xx)(-).p" size 282 crc 4b3bb0d8 md5 df03aba350d47276666377e8bfebaa20 sha1 58545c301c09ba38cd1fdde8a660cb85f59449be )
 )
+
 game (
-	name "The Fast One (Campbell Systems)"
-	description "The Fast One (Campbell Systems)"
-	manufacturer "Campbell Systems"
-	rom ( name "FastOne(Green).tzx" size 9837 crc 3c57d2f2 md5 24bfe29d78ac664aa6b367ef983c590d sha1 c31f2892ea9145cdab6ef5f21cd126ab9d079036 )
+	name "Dictator (1983)(Herosoft)(nl)"
+	description "Dictator (1983)(Herosoft)(nl)"
+	rom ( name "Dictator (1983)(Herosoft)(nl).p" size 15335 crc 0106686e md5 223d726327be612bca0f918e91580031 sha1 e9bc5ccb3a9493c8d1489be8203e01361719105a )
 )
+
 game (
-	name "The Flight Simulator (Timex)"
-	description "The Flight Simulator (Timex)"
-	year 1982
-	manufacturer "Psion"
-	rom ( name "flightsimulation.p" size 13627 crc 7b1bb76a md5 7279ffb7409871741475587b3f707e70 sha1 f80f7b67fb2a629fa1492f67756ea2078e6d28d7 )
-	rom ( name "FlightSimulation.tzx" size 13855 crc 945da3c1 md5 cad45e8938878607ed1a6ca38f08c3c5 sha1 de020d7531c0904a8a152193e7b3d5203e5c1017 )
+	name "Digger (19xx)(-)[16K]"
+	description "Digger (19xx)(-)[16K]"
+	rom ( name "Digger (19xx)(-)[16K].p" size 4556 crc cbef09d7 md5 4e4a8d2254986b5a1bf5dd4b256d4fd0 sha1 d5c16fe0127608ebd48e6748753483d6ffffe754 )
 )
+
 game (
-	name "The Gambler (Timex)"
-	description "The Gambler (Timex)"
-	year 1982
-	manufacturer "Timex"
-	rom ( name "GamblerThe.tzx" size 19202 crc e05a3062 md5 ea6c404af8fc06091341e038643a85a6 sha1 61da0728b3850a4235d13b1a71e7bb0e339fac63 )
+	name "Digger (19xx)(-)[a][16K]"
+	description "Digger (19xx)(-)[a][16K]"
+	rom ( name "Digger (19xx)(-)[a][16K].p" size 4620 crc fee61073 md5 899e72b730e881f2428e680b1561006c sha1 aa47bde6517313cc8f7df5358eabdaa43130bb09 )
 )
+
 game (
-	name "The Gauntlet (Colourmatic)"
-	description "The Gauntlet (Colourmatic)"
-	year 1982
-	manufacturer "Colourmatic"
-	rom ( name "gauntletthe.p" size 14411 crc ae7d6fec md5 b0f5118cdb2d11510ae8a9f6cd735225 sha1 4b1ad35595a0ddd772a3facc1f0c57499030d69a )
-	rom ( name "GauntletThe.tzx" size 14643 crc 7de2e0a3 md5 90c561d24d267dd43e349eed180fe51d sha1 49e714e58e9725925b28f8e17d90c708961064b5 )
+	name "Digger (19xx)(M. Patron)(de)"
+	description "Digger (19xx)(M. Patron)(de)"
+	rom ( name "Digger (19xx)(M. Patron)(de).p" size 15821 crc 99bb1141 md5 c1ea7483074ba5bc2c44645b57a369b5 sha1 e5c8b49998ef0f7aa311d5eab03982bc678caeea )
 )
+
 game (
-	name "The Gauntlet (PSS) (PSS)"
-	description "The Gauntlet (PSS) (PSS)"
-	year 1984
-	manufacturer "Colourmatic"
-	rom ( name "gauntletthe(pss).p" size 14561 crc f8f47bbf md5 c0f5783184d967260c7d8e4a0b027850 sha1 27b343c7b034563ff4c5218ae6ffa8e190b7313f )
-	rom ( name "GauntletThe(PSS).tzx" size 14793 crc 076726dd md5 f4ad5284a8d7eca0e7e7e564131b3b6b sha1 3756c65ac420104c97a01317cdf156c2f412a2df )
+	name "Diversen 1 (19xx)(-)(nl)"
+	description "Diversen 1 (19xx)(-)(nl)"
+	rom ( name "Diversen 1 (19xx)(-)(nl).p" size 11430 crc db388d75 md5 ef4aa46f0b159751ccebb6811fbddad1 sha1 080da122f9036e9234b7f5ab2ebf68518066a6bc )
 )
+
 game (
-	name "The Home Asset Manager (Timex)"
-	description "The Home Asset Manager (Timex)"
-	year 1982
-	manufacturer "Timex"
-	rom ( name "homeassetmanagerthe.p" size 14886 crc 20b3e57e md5 9b8cb2a6f3192db3dd54c6de1ab895dc sha1 2bfd33290ac86115bbd77e00ca1617f3aab588ea )
-	rom ( name "HomeAssetManagerThe.tzx" size 15112 crc fd728104 md5 9ead11c52ed50477589a292313faa4b9 sha1 e19508787e6ede4ec4323df540dd7516b49b295d )
+	name "Diversen 2 (19xx)(-)(nl)"
+	description "Diversen 2 (19xx)(-)(nl)"
+	rom ( name "Diversen 2 (19xx)(-)(nl).p" size 11280 crc aaadd6b9 md5 ea1189a0971c9134f587690e90616edd sha1 2b5b9661b01768d28a7f41a47a5a8b66dcb1e151 )
 )
+
 game (
-	name "The Home Improvement Planner (Timex)"
-	description "The Home Improvement Planner (Timex)"
-	year 1982
-	manufacturer "K. Frink"
-	rom ( name "homeimprovementplannerthe.p" size 15647 crc f3a473a6 md5 d966246149ab479d02fe07debb61fcd5 sha1 3536d7cd6538e0ce71b00cb9d8166303114d769d )
-	rom ( name "HomeImprovementPlannerThe.tzx" size 15871 crc 4e4df58c md5 15d4996825631a65404bcbebb7358e09 sha1 45e98db0f02643a37ed71b86a85042a331b9aac1 )
+	name "Dodge It (19xx)(S. Fawkes)"
+	description "Dodge It (19xx)(S. Fawkes)"
+	rom ( name "Dodge It (19xx)(S. Fawkes).p" size 8084 crc b191c7f6 md5 df9d38ae441adbc9e819f89733c209ea sha1 fa8bb5ba0cad05c0056068e18ba331ff439afdf9 )
 )
+
 game (
-	name "The IRA Planner (Timex)"
-	description "The IRA Planner (Timex)"
-	year 1982
-	manufacturer "Vincent H. Chase"
-	rom ( name "IRAPlannerThe.tzx" size 16247 crc ad9f1b1c md5 73d76e80fe78e640708645b14e6dac88 sha1 74f585b9673b45307f59019f5d03e324ffedfb8c )
+	name "Dodgem (19xx)(Logical Computers)"
+	description "Dodgem (19xx)(Logical Computers)"
+	rom ( name "Dodgem (19xx)(Logical Computers).p" size 5642 crc 98be2c40 md5 a4693446e94a27085ba39893b3e71725 sha1 80db4a494edcc111c68295173193cd4897497dee )
 )
+
 game (
-	name "The Knight's Quest (Phipps Associates)"
-	description "The Knight's Quest (Phipps Associates)"
-	year 1983
-	manufacturer "Mike Farley"
-	rom ( name "KnightsQuest.tzx" size 52909 crc 2bcedb3f md5 bb390c8d2bd1ced32c6e0a739daecdb3 sha1 ce182bf32766964ca43066727475eadbaa6a8d1a )
+	name "Dodgems (19xx)(-)"
+	description "Dodgems (19xx)(-)"
+	rom ( name "Dodgems (19xx)(-).p" size 3686 crc 0326bcb4 md5 f699e6fc7698c5b9abeb07be1a623413 sha1 5e2015b2724f142260e65234887b4ab093b4392a )
 )
+
 game (
-	name "The List Manager (Timex)"
-	description "The List Manager (Timex)"
-	year 1982
-	manufacturer "Timex"
-	rom ( name "ListManagerThe.tzx" size 29918 crc 9df64f46 md5 7994115109d17648490efb35403448b0 sha1 f3fed91b2947d49a6d85c26797f46366ba614769 )
+	name "Dogs (19xx)(-)"
+	description "Dogs (19xx)(-)"
+	rom ( name "Dogs (19xx)(-).p" size 1252 crc 874c4f1e md5 88a19721601e32fb5bf7225ab8ee5a47 sha1 078844156d5e40b79a5ea39177b60d2035098cef )
 )
+
 game (
-	name "The Loan/Mortgage Amortizer (Timex)"
-	description "The Loan/Mortgage Amortizer (Timex)"
-	year 1982
-	manufacturer "T. J. Software"
-	rom ( name "loanmortgageamortizerthe.p" size 10332 crc 08257da4 md5 418e25313141160cd04d7ac8693b5784 sha1 731aaa3f99ed2aa3f71d86858037f37c4b7af86b )
-	rom ( name "LoanMortgageAmortizerThe.tzx" size 10564 crc 8fd28637 md5 b0bf87937e33697f07d9b3d62d436e36 sha1 60988beeefb18dd293f49a3f91c6487d6245a554 )
+	name "Dominoes (19xx)(M. Moll)"
+	description "Dominoes (19xx)(M. Moll)"
+	rom ( name "Dominoes (19xx)(M. Moll).p" size 15994 crc bd1a76bb md5 d731d57425cf4bbc33a20e9016203ddd sha1 85bb40394753e9a9a4a550872b538ea42cc8b0c7 )
 )
+
 game (
-	name "The Oracle's Cave (Doric Computer Systems)"
-	description "The Oracle's Cave (Doric Computer Systems)"
-	year 1981
-	manufacturer "C. T. Dorrel"
-	rom ( name "oraclescavethe.p" size 15953 crc 6135daad md5 01f7597a8eecf63967921a7dc63ff23e sha1 9358857b5b1be76ee495a089e07cd61bc44c6f48 )
-	rom ( name "OraclesCaveThe.tzx" size 16181 crc dea5489a md5 e148ddc58ccce3fc4f32be9b8abc2b63 sha1 752bb718f14e0a7e9da87fa958ccd0e366813a34 )
+	name "Dominos (19xx)(-)"
+	description "Dominos (19xx)(-)"
+	rom ( name "Dominos (19xx)(-).p" size 1834 crc 13ff6a55 md5 6ae2e811d1adca45660c7dbf8e77da98 sha1 93e57fd7d83c1dcd7dc80006c3a7209f340ff079 )
 )
+
 game (
-	name "The Stamp Collector (Timex)"
-	description "The Stamp Collector (Timex)"
-	year 1982
-	manufacturer "Timex"
-	rom ( name "stampcollectorthe.p" size 14449 crc 2a38e112 md5 9329dee03b6620d5000dd3ffc9643068 sha1 69daaab88aec472f12910bb0c3b56c188b5c05ad )
-	rom ( name "StampCollectorThe.tzx" size 14675 crc 702011b4 md5 a207294c88268520101a8b277fc1b882 sha1 e44f8118a5ef3c7ffc55a46d476cdb0f516179ce )
+	name "Donner Rakete (19xx)(-)"
+	description "Donner Rakete (19xx)(-)"
+	rom ( name "Donner Rakete (19xx)(-).p" size 1236 crc a9bce3e1 md5 d8a62e83248998639a2436f30d8f4826 sha1 62e3accf9fa5917d5b2e63136822fdd553f5ee32 )
 )
+
 game (
-	name "The Starter (Timex)"
-	description "The Starter (Timex)"
-	year 1981
-	manufacturer "Sinclair"
-	rom ( name "Starter.tzx" size 2613 crc 00cb3c24 md5 d4de1b915c3a27215ae0bf6bfc60aa91 sha1 c2be276cf0f988df20707105f0fb5d6380d8e357 )
+	name "Doolhof (19xx)(-)(de)"
+	description "Doolhof (19xx)(-)(de)"
+	rom ( name "Doolhof (19xx)(-)(de).p" size 2155 crc b2ccb3f4 md5 542191269d312226ca38a1fa785d639c sha1 0965fbb35606988043444cb911e7f334e2540424 )
 )
+
 game (
-	name "The Stock Option Analyzer (Timex)"
-	description "The Stock Option Analyzer (Timex)"
-	year 1982
-	manufacturer "Timex"
-	rom ( name "stockoptionanalyzerthe.p" size 5533 crc 6a11fef8 md5 5172731b04549ea7e6fd487fcf0b2497 sha1 1fd0599c4cb2f3ec072d2f858f844eaac0b3ca12 )
-	rom ( name "StockOptionAnalyzerThe.tzx" size 5763 crc b829c9c3 md5 78ded4a1d1170ea521dff3ac3f302cca sha1 7691ee6f0ac6a103168684ac3cde78ec128c5e68 )
+	name "Doolhof (19xx)(-)(nl)"
+	description "Doolhof (19xx)(-)(nl)"
+	rom ( name "Doolhof (19xx)(-)(nl).p" size 3096 crc d88e9d3c md5 2a5f5c4eb46b927b0f5bfc556e399b66 sha1 13c3fd636a14f60084edee3461f685f123146d65 )
 )
+
 game (
-	name "Tomb of Dracula (Colour Inlay) (Felix Software)"
-	description "Tomb of Dracula (Colour Inlay) (Felix Software)"
-	year 1982
-	manufacturer "Felix Software"
-	rom ( name "tombofdracula.p" size 14523 crc d7ebcd59 md5 547c42491c4ea4d99fd0386644cb3394 sha1 2228c845e69487db3cb302d4af27e2c03181d3b5 )
-	rom ( name "TombOfDracula.tzx" size 14743 crc ef2a3f64 md5 d1e99f6b365c888e93c405e7a37a529a sha1 e883c6e1992ddd67a82e66709211d024b563aa36 )
+	name "Doolhof (19xx)(-)(nl)[different]"
+	description "Doolhof (19xx)(-)(nl)[different]"
+	rom ( name "Doolhof (19xx)(-)(nl)[different].p" size 2999 crc 7ce4edd6 md5 4a08610a870456d0831f3991b768ea8a sha1 61429bcf826ef511f39f4f02b3962d7b5724fc34 )
 )
+
 game (
-	name "Tomb of Dracula (Moviedrome Video)"
-	description "Tomb of Dracula (Moviedrome Video)"
-	manufacturer "Moviedrome Video"
-	rom ( name "tombofdracula.p" size 14523 crc d7ebcd59 md5 547c42491c4ea4d99fd0386644cb3394 sha1 2228c845e69487db3cb302d4af27e2c03181d3b5 )
-	rom ( name "TombOfDracula.tzx" size 14743 crc ef2a3f64 md5 d1e99f6b365c888e93c405e7a37a529a sha1 e883c6e1992ddd67a82e66709211d024b563aa36 )
+	name "Doortje Stoot (19xx)(J. Bankras)"
+	description "Doortje Stoot (19xx)(J. Bankras)"
+	rom ( name "Doortje Stoot (19xx)(J. Bankras).p" size 9756 crc b8449d57 md5 15990bb79e2baba7e8f90eb9efd3948f sha1 1b07326b806b64627a8647b0020535893671af97 )
 )
+
 game (
-	name "Toolkit (Artic)"
-	description "Toolkit (Artic)"
-	manufacturer "Artic"
-	rom ( name "toolkit(artic).p" size 3582 crc d331e275 md5 19c29072c4cf201f0c6d80a34c487e1a sha1 1076da4a02f3e667d86ef0d40e644103768e71ed )
-	rom ( name "Toolkit(Artic).tzx" size 3802 crc 4743b221 md5 7b527b5afdb2c55d5a0135b6faa68f98 sha1 049169deb7c4c760d79dd66fdf49172d5a77d776 )
-	rom ( name "toolkit.p" size 3600 crc 28c28dc8 md5 75b1355e07ad2a2055d86809c1d12256 sha1 7a4132458d5d3be2502c736b560dae0a84e9dc91 )
-	rom ( name "Toolkit.tzx" size 3820 crc c015038b md5 ee928acdd0608e4095d31d8245038271 sha1 422fadbdf7cfc0da1e6fdfd101f1d613581ed884 )
+	name "Doorzakken (19xx)(-)(nl)"
+	description "Doorzakken (19xx)(-)(nl)"
+	rom ( name "Doorzakken (19xx)(-)(nl).p" size 2486 crc efc795a5 md5 e2fb6f3e1aad56eace94e20650340274 sha1 ac128edb32c003f4be577ec5e58bdb0284800dbd )
 )
+
 game (
-	name "Toolkit (JRS Software)"
-	description "Toolkit (JRS Software)"
-	year 1982
-	manufacturer "Paul Holmes"
-	rom ( name "toolkit(jrs).p" size 2094 crc 9de785fd md5 ddfabe0545708752dc9947c12b0691dd sha1 45c020c2381e691e42385d005e496a7032c72b0e )
-	rom ( name "Toolkit(JRS).tzx" size 2318 crc 5c378f0f md5 c16ab5e0f0a83c954596a61278865a60 sha1 2121e140989dc586810bec4e1399de1007924286 )
+	name "Dot Game Board (19xx)(-)"
+	description "Dot Game Board (19xx)(-)"
+	rom ( name "Dot Game Board (19xx)(-).p" size 1146 crc bc310baa md5 6aec02163ec53973fbcda223566f3e9a sha1 0ba2fcd45a3a50b128ad0473168c412fb3bdb6f9 )
 )
+
 game (
-	name "Toolkit (Sinclair Research)"
-	description "Toolkit (Sinclair Research)"
-	manufacturer "Artic"
-	rom ( name "toolkit.p" size 3600 crc 28c28dc8 md5 75b1355e07ad2a2055d86809c1d12256 sha1 7a4132458d5d3be2502c736b560dae0a84e9dc91 )
-	rom ( name "Toolkit.tzx" size 3820 crc c015038b md5 ee928acdd0608e4095d31d8245038271 sha1 422fadbdf7cfc0da1e6fdfd101f1d613581ed884 )
+	name "Dots (1983)(Sinclair User)[16K]"
+	description "Dots (1983)(Sinclair User)[16K]"
+	rom ( name "Dots (1983)(Sinclair User)[16K].p" size 2648 crc 53981145 md5 82ffb764f46866f3b13e437292275dc5 sha1 b7678a584bd95a9c6e31252af32d59ac2820ff5e )
 )
+
 game (
-	name "Trace (Texgate)"
-	description "Trace (Texgate)"
-	year 1983
-	manufacturer "Texgate"
-	rom ( name "trace.p" size 3248 crc 347a23e2 md5 588baf432b5f22295d6e8347b8e12f9b sha1 5b5fb4641de0cecee592944b7991cad5514c3f69 )
-	rom ( name "Trace.tzx" size 3474 crc b43432d2 md5 ba0bc19769d99d42e22475e2ca5c5d76 sha1 68ea27c33ee7b25628862ebd51bf07b716aa0d57 )
+	name "Dots (19xx)(-)"
+	description "Dots (19xx)(-)"
+	rom ( name "Dots (19xx)(-).p" size 935 crc 18e7149b md5 69dd645d6e6519ebf09677c7d9c5a835 sha1 a4c3e24ed1625fee12f2dc30b34d664923494f93 )
 )
+
 game (
-	name "Trader (Flap-fronted box) (Pixel Productions)"
-	description "Trader (Flap-fronted box) (Pixel Productions)"
-	year 1982
-	manufacturer "Pixel"
-	rom ( name "Trader.tzx" size 49461 crc 41c24497 md5 80943bb4b68ad15508c1028f2b59ad15 sha1 37fd173296fb68815ca87544977b354c44a54d9e )
+	name "Dots Print (19xx)(-)"
+	description "Dots Print (19xx)(-)"
+	rom ( name "Dots Print (19xx)(-).p" size 1081 crc 8e0ea28f md5 8d87ab3dc1dbf8b1eb598b244cbb6d20 sha1 0a506b6221a3632838635c2006a597a9c9eaa3d0 )
 )
+
 game (
-	name "Trader (Pixel Productions)"
-	description "Trader (Pixel Productions)"
-	year 1982
-	manufacturer "Pixel"
-	rom ( name "Trader(Jewel).tzx" size 49639 crc 01e4ec2a md5 f0837cbfe6ac9168b3264aac3c21857d sha1 0082993bf62f04b69581990f052786daeea5620c )
+	name "Double Inversion (1982)(N.L. Martino)"
+	description "Double Inversion (1982)(N.L. Martino)"
+	rom ( name "Double Inversion (1982)(N.L. Martino).p" size 16209 crc 85f28fbd md5 f7752be52a17bf506b565bac2008fbb6 sha1 7c21ced848525821be7e758761993e277175b4b3 )
 )
+
 game (
-	name "Trader (Quicksilva)"
-	description "Trader (Quicksilva)"
-	year 1982
-	manufacturer "Pixel"
-	rom ( name "Trader.tzx" size 49461 crc 41c24497 md5 80943bb4b68ad15508c1028f2b59ad15 sha1 37fd173296fb68815ca87544977b354c44a54d9e )
+	name "Dracula (19xx)(S. Earl)"
+	description "Dracula (19xx)(S. Earl)"
+	rom ( name "Dracula (19xx)(S. Earl).p" size 4231 crc 093b68e0 md5 a5d7aa05eff1f1f8339b3cb60a39a5a3 sha1 d2c869601f17304b935642f881dc77f54da03a64 )
 )
+
 game (
-	name "Traffic (Loriciels)"
-	description "Traffic (Loriciels)"
-	year 1984
-	manufacturer "M Bouat"
-	rom ( name "traffic.p" size 6800 crc b40d7fa0 md5 66919861847fb1dae81487de697b1c74 sha1 0d91bd4b6f1abaec8882b2b360e144ef2a523137 )
-	rom ( name "Traffic.tzx" size 7030 crc be09c247 md5 2f644a8598a84813fdc38bbab38d080f sha1 44626d460f9c918c4bc9e0611737b50215c73a3c )
+	name "Dragon Curve Generator (1987)(SMC)"
+	description "Dragon Curve Generator (1987)(SMC)"
+	rom ( name "Dragon Curve Generator (1987)(SMC).p" size 7845 crc 02baa272 md5 204bd0b3799a0eef285313332efda73a sha1 e5400527599f9c7c1ee7eafe6f22e43464d860d9 )
 )
+
 game (
-	name "Tutor (German) (Artic)"
-	description "Tutor (German) (Artic)"
-	year 1983
-	manufacturer "S. and J. Mitchell"
-	rom ( name "tutorgerman.p" size 13643 crc 1812f460 md5 a0c9d577d010f7d36f52f0e46fafca4c sha1 e0a880b515f960cf65e76ea4eacaed3326f7ea1c )
-	rom ( name "TutorGerman.tzx" size 13869 crc 44ddecba md5 c14b69f2223528031a15c8ec638ad941 sha1 058f24ef7be7494a90cd9799cd68b07e78169b95 )
+	name "Draw & Store in String (19xx)(-)"
+	description "Draw & Store in String (19xx)(-)"
+	rom ( name "Draw & Store in String (19xx)(-).p" size 7234 crc 73fc9508 md5 c0e7136f655b148454b07e579efd9919 sha1 1e4a0c90b717d7c6a8878107433071a56764ebe5 )
 )
+
 game (
-	name "Tutor (Spanish) (Artic)"
-	description "Tutor (Spanish) (Artic)"
-	year 1983
-	manufacturer "S. and J. Mitchell"
-	rom ( name "tutorspanish.p" size 14993 crc 822e1b3e md5 38d6e26acb7d0f937ac92deade6ecfb1 sha1 88a4e1152cc0a92a3539a21c11a8ac227915b529 )
-	rom ( name "TutorSpanish.tzx" size 15219 crc 4d62869a md5 02068afec8b6f9c2875acf822951af83 sha1 e12aabea86ff2542821bd04cdf6e2868f1d3f5d7 )
+	name "Drunken (19xx)(-)"
+	description "Drunken (19xx)(-)"
+	rom ( name "Drunken (19xx)(-).p" size 1145 crc d4d2bf91 md5 b82c9a06f255045d9c06881af6120a2c sha1 dbcbefbc600daf9b09dc72375f9bf47be1480542 )
 )
+
 game (
-	name "Tyrannosaure Rex labyrinthe en trois dimensions (Informatique Service)"
-	description "Tyrannosaure Rex labyrinthe en trois dimensions (Informatique Service)"
-	year 1982
-	manufacturer "Informatique Service Logiciels"
-	rom ( name "tyrannosaurerex.p" size 11506 crc b4ba768a md5 1319f6e2e899b6611fc24443ef13cd9b sha1 7c5172140b9f208b40357c28f348dca23f8ae1a8 )
-	rom ( name "TyrannosaureRex.tzx" size 11728 crc 5300e4d1 md5 5660c77dbaaae1c8e4fe7f18380b03f6 sha1 cb0caa82180a19407cd5e850ca88ca33e12b8efc )
+	name "Duck Shoot (19xx)(-)"
+	description "Duck Shoot (19xx)(-)"
+	rom ( name "Duck Shoot (19xx)(-).p" size 2380 crc 6d58794c md5 f42911560c495d54afb2f5b7611018e1 sha1 dcc827fcba1e03cdbde46524fc63aa7f2f981f59 )
 )
+
 game (
-	name "Tyrant of Athens (Lothlorien)"
-	description "Tyrant of Athens (Lothlorien)"
-	year 1982
-	manufacturer "M. C. Lothlorien"
-	rom ( name "tyrantofathens.p" size 12848 crc 00039ed3 md5 40c8cfd3ebeb9510f04115b34be32097 sha1 347c589d6d9a22794f863d6e61be0ce8c31ec485 )
-	rom ( name "TyrantOfAthens.tzx" size 13068 crc fc3fd4f8 md5 c3f5e5d0f379fe1529a27596a8d5b13f sha1 882b644962f09d68bc813563478d773c3a07115b )
+	name "Duell (19xx)(-)(de)"
+	description "Duell (19xx)(-)(de)"
+	rom ( name "Duell (19xx)(-)(de).p" size 9175 crc 271949b5 md5 6c43377f098d9d340f59988f83ad129f sha1 3b1b562f64f3ae60f47a155f0cde28816f90f34c )
 )
+
 game (
-	name "U-Bend"
-	description "U-Bend (2015) - Bob's interpretation of a Pipe-Mania game, with 36 unique levels."
-	rom ( name "UBend.p" size 14905 crc c537e261 md5 1d648c9042117e6cc47e9293d66aec0c sha1 17c49e4ac9179ed0d08c18c671f3db5343bad3cc )
+	name "Dump (19xx)(-)(nl)"
+	description "Dump (19xx)(-)(nl)"
+	rom ( name "Dump (19xx)(-)(nl).p" size 2497 crc b4591925 md5 9bcc7f87b699af43ed8e471dd929675c sha1 807ed4bff723b7d9c12e0ed8adf44b4cbc7fd733 )
 )
+
 game (
-	name "UDG (dK'tronics)"
-	description "UDG (dK'tronics)"
-	year 1981
-	manufacturer "dK'tronics"
-	rom ( name "udg.p" size 7928 crc a4259b70 md5 e9fdd20a2bb40d5b1d6d356e1b34793a sha1 7c2656d8cbd5427f5e464a5108f82ec84c539706 )
-	rom ( name "UDG.tzx" size 8150 crc 66a2453f md5 76f87a79206c9fc82e5127b7e94c2d6f sha1 0fefc639d3c9a6c2ed2a5d994f94ee0691e0dca5 )
+	name "Dungeon of Ymir - Custom Mazes Designer (19xx)(-)"
+	description "Dungeon of Ymir - Custom Mazes Designer (19xx)(-)"
+	rom ( name "Dungeon of Ymir - Custom Mazes Designer (19xx)(-).p" size 4913 crc 3ee0ac35 md5 872b935560748cbd12b8b75c244a9400 sha1 f09ee91c80f08790e3c7db64a4d53ee29d4cbd37 )
 )
+
 game (
-	name "UFO (Protek)"
-	description "UFO (Protek)"
-	year 1983
-	manufacturer "Protek"
-	rom ( name "ufo.p" size 5158 crc 4e3f3226 md5 318f5420747069feb32f65e008b84a61 sha1 f4e7a1691ad0af71b26a9d1bcc36e3155814100a )
-	rom ( name "UFO.tzx" size 5380 crc 6b8cbcec md5 eac2815189bdb98a886b8f6739b4f188 sha1 f9bd4f690cb67fa718154cb9f07d63e8103a8c4f )
+	name "Dungeons (19xx)(-)"
+	description "Dungeons (19xx)(-)"
+	rom ( name "Dungeons (19xx)(-).p" size 3133 crc a0f2ab5b md5 aa9f74c7914568b11700b366daa9d24f sha1 717e904d11c791f97b52153d4bee04d20e155ec9 )
 )
+
 game (
-	name "UFO + 3D Maze (Babtech)"
-	description "UFO + 3D Maze (Babtech)"
-	year 1982
-	manufacturer "Babtech"
-	rom ( name "UFOAnd3DMaze.tzx" size 13279 crc cc63dfdf md5 90efa80ff6a2bd4ca39af581f1cb43a4 sha1 07a8d839b7202b3846fd8f1f84025000fb222f58 )
+	name "Editor (19xx)(-)"
+	description "Editor (19xx)(-)"
+	rom ( name "Editor (19xx)(-).p" size 3282 crc d7c8af73 md5 af89900e8bd87fcef99a84f4457da66d sha1 6807719f4e2ce8690aa310a43ec3ab391287fb7d )
 )
+
 game (
-	name "Variance Analyzer (Zeta Software)"
-	description "Variance Analyzer (Zeta Software)"
-	manufacturer "Dr. Walter Diembeck"
-	rom ( name "varianceanalyzer.p" size 8185 crc 73023b9a md5 72fbc8622939ac385b41dc3355b6d4c9 sha1 01535d36d01908855e4530c3077c6b774e893ce8 )
-	rom ( name "VarianceAnalyzer.tzx" size 8407 crc 90a5774a md5 5237031b0a92f415c5ac347d60fd5d3e sha1 a429c8165b8be52791c99e5da26a84758a4c508b )
+	name "Editor 16 (1983)(Robert & Gerald Pearson)"
+	description "Editor 16 (1983)(Robert & Gerald Pearson)"
+	rom ( name "Editor 16 (1983)(Robert & Gerald Pearson).p" size 12388 crc cd9139f7 md5 2dec40f51c9a35ad8d6f2285703b08d3 sha1 fedce8849be5c30d70f99317acb594b4c4696394 )
 )
+
 game (
-	name "Vector Mathematics (W. H. Smith)"
-	description "Vector Mathematics (W. H. Smith)"
-	year 1982
-	manufacturer "ICL"
-	rom ( name "vectormathematics.p" size 11849 crc a13c22de md5 7f44adcd2eab5fa11a948bad8677e102 sha1 8a75f82fd30681bf8d557e03babc165c0f64567c )
-	rom ( name "VectorMathematics.tzx" size 12101 crc c33b86ba md5 4ce4bf8556a215e4d1528e0adc8de3c9 sha1 b82230bcc7f57f7b1f12720d82440031135be44b )
+	name "Eeuwige Kalender (1982)(Rob Lechanteur)(nl)"
+	description "Eeuwige Kalender (1982)(Rob Lechanteur)(nl)"
+	rom ( name "Eeuwige Kalender (1982)(Rob Lechanteur)(nl).p" size 4806 crc ff37e3c7 md5 310400f2fa612edec5d7a9a1659ade97 sha1 4e26396d79bdc2d7007ff18d52d83595972240ec )
 )
+
 game (
-	name "Video Graffiti (AGF Hardware)"
-	description "Video Graffiti (AGF Hardware)"
-	year 1982
-	manufacturer "AGF Hardware"
-	rom ( name "videograffiti.p" size 5033 crc 4b37557f md5 521067db79cb6f937b5cf2e2d0662f15 sha1 45996efa5157865159c613ca49dc1f54402e3c7b )
-	rom ( name "VideoGraffiti.tzx" size 5263 crc dd2ecb00 md5 7ea6fb6995eae21a6731a7c61f7fe91c sha1 cf2e6cee862cc503be44bf2e6621a2e8d005c521 )
+	name "Egg (19xx)(-)"
+	description "Egg (19xx)(-)"
+	rom ( name "Egg (19xx)(-).p" size 2295 crc e5524347 md5 bce2ef3c8d31aa78a0dd80c43bd3c4fd sha1 8e4e5c6f9dc15c44cd87681a419050daf3c09561 )
 )
+
 game (
-	name "Video-Ad (Video Software)"
-	description "Video-Ad (Video Software)"
-	year 1981
-	manufacturer "Video Software"
-	rom ( name "VideoAd.A.tzx" size 15281 crc 42136adc md5 baef4c10ef4e5d71498c31e5d2197f64 sha1 c2409cd598ce050d622eb8850e21d74d709060eb )
-	rom ( name "videoad.p" size 15049 crc abc19f74 md5 209beec2010448bb63643842df41793d sha1 beebc6bc78805b1bb6328d518aab9cff70b2a3a2 )
+	name "Egyptian Quiz (1983)(J.J. Castillos)"
+	description "Egyptian Quiz (1983)(J.J. Castillos)"
+	rom ( name "Egyptian Quiz (1983)(J.J. Castillos).p" size 14203 crc b35b53bb md5 207499488a5befe0614ba7ecd914e9d3 sha1 7292193244c565f25447afa4d34d11d6e91e2c9c )
 )
+
 game (
-	name "Video-Map (Video Software)"
-	description "Video-Map (Video Software)"
-	year 1981
-	manufacturer "Video Software"
-	rom ( name "VideoMap.A.tzx" size 15713 crc b76622dc md5 86528f5577970284c231b5048ad5f669 sha1 86d292def89f2cd01bdf677f50abdb18002507a6 )
-	rom ( name "videomap.p" size 15479 crc f37cc7c7 md5 ca144229c898e0fbedf4c974ced0fe56 sha1 3791b93f30fe410716efdb3d9d345ff803973d28 )
+	name "Einarminger Bandit (19xx)(-)(de)"
+	description "Einarminger Bandit (19xx)(-)(de)"
+	rom ( name "Einarminger Bandit (19xx)(-)(de).p" size 5191 crc 1567abbd md5 c9846773f727fbe7d27ee3fdba8f0bd2 sha1 0397f1a78dbbab4bb9fc42ab4ee2f64797c1cfcd )
 )
+
 game (
-	name "Video-Plan (Video Software)"
-	description "Video-Plan (Video Software)"
-	manufacturer "Video Software"
-	rom ( name "VideoPlan.A.tzx" size 15425 crc 849e21dc md5 23e1f6eed1029f7433286c3682ccff69 sha1 fffa47475a0634fc9859212e5a309603d922d258 )
-	rom ( name "videoplan.p" size 15189 crc fd242331 md5 260e9496c1bd1cb40a6095f04e0bbec2 sha1 2cb0a66c7aa506061fe621a53ee0bc7f143b9988 )
+	name "Elefants (19xx)(-)(nl)"
+	description "Elefants (19xx)(-)(nl)"
+	rom ( name "Elefants (19xx)(-)(nl).p" size 7461 crc 339e1155 md5 cea5ee4182051edabf464d2b5c0ae9c4 sha1 0f7f43c9d0f47223c7c30fe0fecff9cec1108132 )
 )
+
 game (
-	name "Video-View (Video Software)"
-	description "Video-View (Video Software)"
-	manufacturer "Video Software"
-	rom ( name "videoview.p" size 13859 crc 53eca8e2 md5 e02361e6a92651a25ca5f0f5cac3c408 sha1 bdc28fc5964960f3159a8bd08db7b3ded64eca98 )
-	rom ( name "VideoView.tzx" size 14095 crc f5fdb04b md5 fd38379fc882828484b0a1e7fac02a4d sha1 abadd8bd7a829c778d6fbf1d4f394025cd1b7c58 )
+	name "Eliza (19xx)(-)"
+	description "Eliza (19xx)(-)"
+	rom ( name "Eliza (19xx)(-).p" size 10152 crc c5340724 md5 44f678fc294d3c531e5ca5631ad21096 sha1 64b564177fa25d3ac2fc49d0c3964577e08e7155 )
 )
+
 game (
-	name "Viewtext (U.S. release) (Bug Byte)"
-	description "Viewtext (U.S. release) (Bug Byte)"
-	year 1981
-	manufacturer "Bug Byte"
-	rom ( name "viewtext(us).p" size 12535 crc 4a6de687 md5 a9edbdb5e0f43efc83bd3233ed8122ea sha1 9c9999f8daeffd8d6f9f4234548c665c0d2d18a5 )
-	rom ( name "Viewtext(US).tzx" size 12767 crc 83f14397 md5 7ab7ff7c1b3baebcfdb31632abe00646 sha1 eb0996ddb294a42c133b0c301958bdaa3b5f4a1a )
+	name "Endlos Schlange (19xx)(-)(de)"
+	description "Endlos Schlange (19xx)(-)(de)"
+	rom ( name "Endlos Schlange (19xx)(-)(de).p" size 2600 crc ed14c7ea md5 7da7b7447ed4c9172be430916cb542ba sha1 2754828cae864328bc09121bdad493823f33c84b )
 )
+
 game (
-	name "Virus"
-	description "Virus (2010) - A very playable and extremely polished top-down shoot'em up, making the most of the machine's limitations."
-	rom ( name "virus.p" size 16164 crc 9495a62e md5 2ee3b625a6481026c9d00a7da43c8fd1 sha1 0f7a62fa0d575d595857aafdefc78b33a207be91 )
+	name "Enigma Coder (19xx)(-)"
+	description "Enigma Coder (19xx)(-)"
+	rom ( name "Enigma Coder (19xx)(-).p" size 2485 crc c9577501 md5 bb9670c1a170fba279de64eb74af8fb4 sha1 6dd172f8463db0bb2901ceafea7f76acb39f3e37 )
 )
+
 game (
-	name "Volcanic Dungeon (Carnell)"
-	description "Volcanic Dungeon (Carnell)"
-	year 1982
-	manufacturer "Carnell Software"
-	rom ( name "volcanicdungeon.p" size 16234 crc bdcc9896 md5 801e5cd018f555198867d3f989033b24 sha1 503c8cfd4994440a3662fbce25d46b000887056a )
-	rom ( name "VolcanicDungeon.tzx" size 16482 crc c6f44894 md5 60210e10f6d239cddaffe65b6a3911c8 sha1 6275899b3b7849a97ca8ea869d2bc5806522ae9a )
+	name "Escape (19xx)(-)"
+	description "Escape (19xx)(-)"
+	rom ( name "Escape (19xx)(-).p" size 8825 crc e855a285 md5 846f2a2f6408598fcc1d40f8d76e1ba6 sha1 5a34af4a280b9f442c5f948ce0ba20798963cb69 )
 )
+
 game (
-	name "VU-CALC (Sinclair Research)"
-	description "VU-CALC (Sinclair Research)"
-	year 1982
-	manufacturer "Psion"
-	rom ( name "vu-calc.p" size 5551 crc 85195a78 md5 5b833077456f266abbf68ca295a60ee1 sha1 19280c9645a23ffbd53818889c4899bd00d29d29 )
-	rom ( name "VU-CALC.tzx" size 5781 crc 221479df md5 cb3925e52d2afa1c3f93cbafeb2443fe sha1 50275ce9c48f4f3533899a00c5291bdade4a1efe )
+	name "Escape (19xx)(Derf Software)(nl)"
+	description "Escape (19xx)(Derf Software)(nl)"
+	rom ( name "Escape (19xx)(Derf Software)(nl).p" size 4343 crc 0992b39d md5 0fc5765c499f467f9cce47f10e645b9e sha1 e26a1b161eb543e3736ca8b6c3c9f75e2f471fd4 )
 )
+
 game (
-	name "VU-CALC (Timex)"
-	description "VU-CALC (Timex)"
-	year 1982
-	manufacturer "Psion"
-	rom ( name "vu-calc(timex).p" size 5549 crc 294a26c8 md5 5df9f5bb28e55cd1bb0e8eae025c38bc sha1 ce80bfee2434761babbfb0aa2b204b2cdb70c76c )
-	rom ( name "VU-CALC(Timex).tzx" size 5779 crc 3db82474 md5 ac03e37dc2013d571c352ad8fa3ee69d sha1 d1533151dfecf9614c55551e0d6bbab85bce9c3c )
+	name "Escapes (19xx)(-)"
+	description "Escapes (19xx)(-)"
+	rom ( name "Escapes (19xx)(-).p" size 3240 crc 9a799dbe md5 f16cac34cb3891547dfa6bfe70fa523b sha1 c31fa95627219ad98e8c119712ecb68bb7e777f3 )
 )
+
 game (
-	name "Warlord (Lothlorien)"
-	description "Warlord (Lothlorien)"
-	year 1982
-	manufacturer "M. C. Lothlorien"
-	rom ( name "warlord.p" size 15659 crc 5b5b6fbb md5 0d8e945e8cdf72f737d2848cb35ef853 sha1 e8fe374088097adb86b658e54a4bc05208627ae5 )
-	rom ( name "Warlord.tzx" size 15879 crc 9bff8537 md5 1f8271889f8e1f381c60707a0d10621b sha1 dee7757fc095d4de68efcd4147777e0cbbad8424 )
+	name "Escher Boys (19xx)(-)(nl)"
+	description "Escher Boys (19xx)(-)(nl)"
+	rom ( name "Escher Boys (19xx)(-)(nl).p" size 12558 crc 58c7b78d md5 f704b0886f8595105c8cb93cec679fda sha1 05a2337947aa760eddd8b95b18151e35082926ea )
 )
+
 game (
-	name "Winged Avenger (Work Force)"
-	description "Winged Avenger (Work Force)"
-	year 1982
-	manufacturer "Work Force"
-	rom ( name "wingedavenger.p" size 3760 crc ec61facb md5 abb4ab208952c4f184769683545b68e8 sha1 ef6259d87f68c3882aecb6bd47ef0b99a6dbe2a9 )
-	rom ( name "WingedAvenger.tzx" size 4004 crc 18536d36 md5 8d6e49676509ae0666cf832b8be958b1 sha1 b3ecbf77bb7d691bd1b973ede3774bf3a54a1494 )
+	name "European Countries and Capitals (19xx)(-)"
+	description "European Countries and Capitals (19xx)(-)"
+	rom ( name "European Countries and Capitals (19xx)(-).p" size 10607 crc fac6de46 md5 b585b6a1f42dfb53bc7769e3b6fc448f sha1 df1664680d61000fb5ed6d4fd7e43b463962c12a )
 )
+
 game (
-	name "Word Processor (Alan's Recordings)"
-	description "Word Processor (Alan's Recordings)"
-	manufacturer "Alan D. Went"
-	rom ( name "WordProcessor.A.tzx" size 12384 crc c1f41d1c md5 668f2df5ba976dda0e79405a1c3b0353 sha1 4f2e76139efb5a07b443c5495636bcbb42489241 )
+	name "Executie (19xx)(-)"
+	description "Executie (19xx)(-)"
+	rom ( name "Executie (19xx)(-).p" size 2772 crc fd0851db md5 a755306a73062ed09a27b569a3854f40 sha1 a0ccf6d66c8fbca620d0b0a89ae9396181a0cc3a )
 )
+
 game (
-	name "Word Test (Mindware)"
-	description "Word Test (Mindware)"
-	year 1982
-	manufacturer "Christopher Jones"
-	rom ( name "WordTest.1.WordTest.tzx" size 1133 crc e12825a4 md5 1d78c945fe6ed7c191f0016e26c4961b sha1 a17549ce398aa7c4955e6a691fd27dbce089db4a )
-	rom ( name "wordtest.p" size 901 crc be88df61 md5 338af799286fee95ca3f1131a2c00bac sha1 fbbe0822184c0a4594c5932358edcfbe3df4e7be )
+	name "Expert System (19xx)(Chris Maylor)"
+	description "Expert System (19xx)(Chris Maylor)"
+	rom ( name "Expert System (19xx)(Chris Maylor).p" size 4256 crc dee4eede md5 61d745d107b53e30650930bc798d5bb6 sha1 dc652b83485cb8d2b599d8db99388aa05b7f1d1e )
 )
+
 game (
-	name "World Cup Football (Test your knowledge of) (M. A. Smith)"
-	description "World Cup Football (Test your knowledge of) (M. A. Smith)"
-	year 1982
-	manufacturer "M. A. Smith"
-	rom ( name "worldcupfootball.p" size 10439 crc 5647eb5e md5 c08c7f4881310b8e3ad0c336ca996965 sha1 80b894c252d6185362018b1405d4868484cd0198 )
-	rom ( name "WorldCupFootball.tzx" size 10657 crc 685d01ce md5 f603bc86bbd22e511e7628a9209c3838 sha1 d081ccd8b759a2866bff5676a112481bb73d5f88 )
+	name "Fairway (1983)(Fontana Publishing)"
+	description "Fairway (1983)(Fontana Publishing)"
+	rom ( name "Fairway (1983)(Fontana Publishing).p" size 3495 crc 3d5235f7 md5 01cef1b6a399a8782ca819b115f572aa sha1 06a09aa3f289bbe079f3bab3111924fe32a03251 )
 )
+
 game (
-	name "Zac-Man (Macronics)"
-	description "Zac-Man (Macronics)"
-	manufacturer "Macronics"
-	rom ( name "zacman.p" size 6881 crc 261a596b md5 cd301f8807f261d005a0f5e0a5f8e1b3 sha1 1c8cb9858647e86a3be82467a6da6a04a4a40d15 )
-	rom ( name "ZacMan.tzx" size 7111 crc 76fca436 md5 c33deb5191e85bcaa942a92f184236c7 sha1 e4271947dfab4c3eeb64a5927cda4d25445a0e53 )
+	name "Fallen Comrades (19xx)(-)"
+	description "Fallen Comrades (19xx)(-)"
+	rom ( name "Fallen Comrades (19xx)(-).p" size 2120 crc c7dfbcb7 md5 359654aad3992298b986d0caadaf3a17 sha1 38cb409d8efb332e17f3e46b23d542f53252d191 )
 )
+
 game (
-	name "Zaraks (Computer Rentals)"
-	description "Zaraks (Computer Rentals)"
-	year 1983
-	manufacturer "Richard Taylor"
-	rom ( name "zaraks.p" size 3695 crc 733e3147 md5 f41780fbd2b777457afbdbacf838c2fb sha1 46a79fa15abf021d05e323b36629dcab80e84e72 )
-	rom ( name "Zaraks.tzx" size 3923 crc 4466c390 md5 46d8771cf8578edcf534505127a3735d sha1 d4d0575f849ed626a6d2b02cc3d64660980694c5 )
+	name "Familie Rekening (19xx)(Peet Penninkhoff)(nl)"
+	description "Familie Rekening (19xx)(Peet Penninkhoff)(nl)"
+	rom ( name "Familie Rekening (19xx)(Peet Penninkhoff)(nl).p" size 15573 crc 7522c633 md5 5b997ce06841fb7576c315b918b89073 sha1 1d5849cf0b3c394cf92d663647428b904da39d84 )
 )
+
 game (
-	name "Zombies/Sword of Peace (Artic)"
-	description "Zombies/Sword of Peace (Artic)"
-	manufacturer "Artic"
-	rom ( name "ZombiesSwordOfPeace.tzx" size 12404 crc 45500520 md5 cf95266460228f0be0ec5cd944051fca sha1 519d3115b5ceb75b61dff442a927be851fb0ca96 )
+	name "Family Quiz (19xx)(-)"
+	description "Family Quiz (19xx)(-)"
+	rom ( name "Family Quiz (19xx)(-).p" size 15954 crc 480278f0 md5 93075977c5fa0cb7c3c1e03ebabe6fc6 sha1 a09d963050d3238cb49ffa4c78ddd438cfa360e8 )
 )
+
 game (
-	name "Zuckman (Black inlay) (DJL Software)"
-	description "Zuckman (Black inlay) (DJL Software)"
-	year 1982
-	manufacturer "DJL Software"
-	rom ( name "zuckman(alt).p" size 9939 crc a57caafa md5 b57a30d83b200790bccf55ef9959aaa0 sha1 bf63e2441fcfad7c72c8e8bded65f9d3704d85ed )
-	rom ( name "Zuckman(Alt).tzx" size 10169 crc 886fa5b4 md5 82570cafb6bae5e05cf474c69c5abf8b sha1 87f7870077134b24dfc9bab9e406762bd7ff6d04 )
+	name "Farmer (1983)(CCS)"
+	description "Farmer (1983)(CCS)"
+	rom ( name "Farmer (1983)(CCS).p" size 15691 crc beacaabc md5 763d70c02a78589e958e915cc0535fe5 sha1 4733ff16d71a61a56a32d610f611896fc6194db2 )
 )
+
 game (
-	name "Zuckman (White inlay) (DJL Software)"
-	description "Zuckman (White inlay) (DJL Software)"
-	year 1982
-	manufacturer "DJL Software"
-	rom ( name "zuckman.p" size 9939 crc e518a2bd md5 4d40c31b628fca5ed079f992e8ae2d24 sha1 30720d6d3af16aed257832988218f8ec3f002765 )
-	rom ( name "Zuckman.tzx" size 10169 crc c80badf3 md5 5b98d152d8a4ead841a65716f68f7dd6 sha1 e212c3315d69861422dee61af487f6729568520a )
+	name "Fast One X, The (19xx)(-)"
+	description "Fast One X, The (19xx)(-)"
+	rom ( name "Fast One X, The (19xx)(-).p" size 4820 crc 8b833d66 md5 285d87711372fabfc1bd889423d48ed0 sha1 46c9e374144aca634a8abf0cfc465f1592bba11e )
 )
+
 game (
-	name "ZX Action Pack (Axis)"
-	description "ZX Action Pack (Axis)"
-	year 1982
-	manufacturer "Axis"
-	rom ( name "ZXActionPack.tzx" size 4677 crc f5f95245 md5 7e8c4e96f560ce731ae5d167009cc947 sha1 a97dbf23ee4788951617cc26e8bbd2987d3a4cd6 )
+	name "Fast One, The (19xx)(-)"
+	description "Fast One, The (19xx)(-)"
+	rom ( name "Fast One, The (19xx)(-).p" size 4606 crc 64552d8d md5 577550a16bf18563e9e960052a692701 sha1 916e811e75edf0dbd1f1471e9bdc590dded48ccd )
 )
+
 game (
-	name "ZX Assembler (Artic)"
-	description "ZX Assembler (Artic)"
-	manufacturer "D. P. Aknai and M. Streeton"
-	rom ( name "zxassembler.p" size 7330 crc 95a485d6 md5 20f54f3a1f15fc2956937ee10582b1f2 sha1 8e2526bdb2aa5000ff2d814a009cec5259d46ded )
-	rom ( name "ZXAssembler.tzx" size 7564 crc 99c7faec md5 7cfc5b8a15f9a4dea3f1ce6d27e6ff31 sha1 7fe0c1c9dfbdff0e3f1c4274e09a19eb3ac88a59 )
+	name "Fast Print (19xx)(-)"
+	description "Fast Print (19xx)(-)"
+	rom ( name "Fast Print (19xx)(-).p" size 1591 crc d0b2bda7 md5 038a2c589acbbe6059dcadeb586fffdc sha1 874a6d855a4d96d59251b8910d903030d79cb11c )
 )
+
 game (
-	name "ZX Assembler (International Publishing and Software Inc.)"
-	description "ZX Assembler (International Publishing and Software Inc.)"
-	year 1982
-	manufacturer "D. P. Aknai and M. Streeton (Artic)"
-	rom ( name "zxassembler.p" size 7330 crc 95a485d6 md5 20f54f3a1f15fc2956937ee10582b1f2 sha1 8e2526bdb2aa5000ff2d814a009cec5259d46ded )
-	rom ( name "ZXAssembler.tzx" size 7564 crc 99c7faec md5 7cfc5b8a15f9a4dea3f1ce6d27e6ff31 sha1 7fe0c1c9dfbdff0e3f1c4274e09a19eb3ac88a59 )
+	name "Ferry (1982)(Sinclair User)[16K]"
+	description "Ferry (1982)(Sinclair User)[16K]"
+	rom ( name "Ferry (1982)(Sinclair User)[16K].p" size 2286 crc cbf75a64 md5 b4b67cf28342458fb8682058fe2531f6 sha1 7e3cdc3c70b2dfd1477b914e05465e90e2814f01 )
 )
+
 game (
-	name "ZX Assembler (Mono cover) (International Publishing and Software Inc.)"
-	description "ZX Assembler (Mono cover) (International Publishing and Software Inc.)"
-	year 1982
-	manufacturer "D. P. Aknai and M. Streeton"
-	rom ( name "zxassembler(mono).p" size 7330 crc 95a485d6 md5 20f54f3a1f15fc2956937ee10582b1f2 sha1 8e2526bdb2aa5000ff2d814a009cec5259d46ded )
-	rom ( name "ZXAssembler(Mono).tzx" size 7564 crc 99c7faec md5 7cfc5b8a15f9a4dea3f1ce6d27e6ff31 sha1 7fe0c1c9dfbdff0e3f1c4274e09a19eb3ac88a59 )
+	name "Ferry Boat (19xx)(-)"
+	description "Ferry Boat (19xx)(-)"
+	rom ( name "Ferry Boat (19xx)(-).p" size 5737 crc 7f118b5f md5 dc834bc8d97534df4ac08508bcf036cb sha1 bc1f3ad6f2be05213393cf3393cd6915ed677ebf )
 )
+
 game (
-	name "ZX Assembleur (French) (Artic)"
-	description "ZX Assembleur (French) (Artic)"
-	year 1982
-	manufacturer "D. P. Aknai and M. Streeton"
-	rom ( name "zxassembleur.p" size 8963 crc d0d72bdc md5 b085ecfb9d97d32fc9eeb0fe94a8629e sha1 1fe43e6c0e7dd3c33bff97b7246fb5172d5aa892 )
-	rom ( name "ZXAssembleur.tzx" size 9197 crc aa532026 md5 7b58c9bfe54c57cb8080441bea91e7ec sha1 02a75242aabfbfa1d233b134df53727d5b8f597b )
+	name "Fietser (19xx)(-)"
+	description "Fietser (19xx)(-)"
+	rom ( name "Fietser (19xx)(-).p" size 2798 crc 6cf4f740 md5 6c674b593d2adcdeda57f83e2b6a8e89 sha1 bd20aa7a33cef28001e6f4232b55900ef45d615d )
 )
+
 game (
-	name "ZX Asteroids (Electric Pencil Company)"
-	description "ZX Asteroids (Electric Pencil Company)"
-	year 1982
-	manufacturer "Robert J. Wray"
-	rom ( name "zxasteroids.p" size 6054 crc bc47cff8 md5 57b3ec022dec0b1796aa7c6fadcd8f35 sha1 98e75c5767925cd515a10b88f731181caa84b337 )
-	rom ( name "ZXAsteroids.tzx" size 6280 crc c92d5c86 md5 f3e15eefe198558ffb618f9b005aa063 sha1 bc223f7b59f8ba07d7faf1da62f5a408034c568c )
+	name "Filters (19xx)(-)"
+	description "Filters (19xx)(-)"
+	rom ( name "Filters (19xx)(-).p" size 4686 crc 5150aa8f md5 2661f541dc012e39f0cc836c931750f6 sha1 90064842d8a6203556e210b621b744508b34eabc )
 )
+
 game (
-	name "ZX Bug (International Publishing and Software Inc.)"
-	description "ZX Bug (International Publishing and Software Inc.)"
-	year 1982
-	manufacturer "Artic (?)"
-	rom ( name "zxbug(ips).p" size 5350 crc af2c11ca md5 70354bfa74200e4578f92afc927db38b sha1 92827b6cb5ab8c7c64127c700c20c36902676cb4 )
-	rom ( name "ZXBug(IPS).tzx" size 5576 crc f8959e82 md5 2d051b4f0218c4c78d897ce2a851fe6d sha1 446c92783f64ea88a3faf3f0d5338223995d99a5 )
+	name "Fisherman (1982)(Sinclair User)"
+	description "Fisherman (1982)(Sinclair User)"
+	rom ( name "Fisherman (1982)(Sinclair User).p" size 1445 crc 99eee924 md5 e36cc739ec0c1b8c9f6520d39758a6cd sha1 4887a3aa60ce5525a24424e3aa27f953d7e63de4 )
 )
+
 game (
-	name "ZX Bug V3.125 (Monochrome Inlay) (Artic)"
-	description "ZX Bug V3.125 (Monochrome Inlay) (Artic)"
-	year 1981
-	manufacturer "Artic"
-	rom ( name "zxbug.p" size 5350 crc 2859b9eb md5 2766880aac6ae3b92031aaa2737af2ec sha1 4030b892fbb1906fe97ab601a37f9d4ffbf52a30 )
-	rom ( name "ZXBug.tzx" size 5572 crc b77b6a0d md5 c5fadbc61693ecca4761e523d2024999 sha1 5f513d59c871aa94dd8d1c1919fea0e8d5aae806 )
+	name "Flatman (1983)(J. Dave Rogers)"
+	description "Flatman (1983)(J. Dave Rogers)"
+	rom ( name "Flatman (1983)(J. Dave Rogers).p" size 3791 crc 3c12760f md5 945570631478f435e3bad4e5f555653c sha1 abb9322e8287baadd4024bfa4729d22586767771 )
 )
+
 game (
-	name "ZX Chess I (Black inlay) (Artic)"
-	description "ZX Chess I (Black inlay) (Artic)"
-	manufacturer "Artic"
-	rom ( name "zxchessi(black).p" size 14119 crc cce17d9c md5 2aa8d6a1b52211893f7a7264cff2bc1a sha1 ceca1c8f7719afe71d991a073a88561fcda27ae8 )
-	rom ( name "ZXChessI(Black).tzx" size 14337 crc 98f8fd30 md5 f2ee420566092a3ecd4d82f532bc98de sha1 b2ee8fb73779fc8b13b1bec533e59d762f6f871f )
+	name "Flight Simulation (1981)(Psion Software)[16K]"
+	description "Flight Simulation (1981)(Psion Software)[16K]"
+	rom ( name "Flight Simulation (1981)(Psion Software)[16K].p" size 13795 crc 1f0a54e3 md5 7bbf910f668c1bd5481a4d71e260c3b6 sha1 54763f7150e3c0221b59d4dee87a5ba420c41825 )
 )
+
 game (
-	name "ZX Chess II (Artic)"
-	description "ZX Chess II (Artic)"
-	manufacturer "Artic"
-	rom ( name "zxchessii.p" size 14192 crc a9ce4067 md5 0aabbe2f2fc2992535866dd50c957203 sha1 b2dd0eacd363a184feb09cc63a9dd26edb620eb4 )
-	rom ( name "ZXChessII.tzx" size 14422 crc 90f0224c md5 7febb46157a5ca656a1c70109fd727d1 sha1 1e99cb497498e471f5f0aeb85c79d292208107b2 )
+	name "Flipperkast (19xx)(-)(nl)"
+	description "Flipperkast (19xx)(-)(nl)"
+	rom ( name "Flipperkast (19xx)(-)(nl).p" size 6661 crc 3106f48e md5 83edff362c6d900d61a60511a10e9f80 sha1 b5344723bdf30cf4ab27936e3283190e65945c6f )
 )
+
 game (
-	name "ZX Chess II (Black inlay) (Artic)"
-	description "ZX Chess II (Black inlay) (Artic)"
-	manufacturer "Artic"
-	rom ( name "zxchessii.p" size 14192 crc a9ce4067 md5 0aabbe2f2fc2992535866dd50c957203 sha1 b2dd0eacd363a184feb09cc63a9dd26edb620eb4 )
-	rom ( name "ZXChessII.tzx" size 14422 crc 90f0224c md5 7febb46157a5ca656a1c70109fd727d1 sha1 1e99cb497498e471f5f0aeb85c79d292208107b2 )
+	name "Football Manager (19xx)(-)"
+	description "Football Manager (19xx)(-)"
+	rom ( name "Football Manager (19xx)(-).p" size 14736 crc fff630de md5 192646c148629b8f4b21cd9497c7c906 sha1 5a9fb7c31e7049ed46d1fce4f68551bb063d857d )
 )
+
 game (
-	name "ZX Chess II (Improved) (Artic)"
-	description "ZX Chess II (Improved) (Artic)"
-	year 1981
-	manufacturer "Artic"
-	rom ( name "zxchessii(improved).p" size 14096 crc 16e86ce7 md5 19d6e472a1121ea8d28cf0b79eef739d sha1 585fce3fb637abd4783f907f24d6945d9472b7e7 )
-	rom ( name "ZXChessII(Improved).tzx" size 14326 crc 60bbdc66 md5 00f547bd9654a6dcd024639c91152471 sha1 a4238332fe59d8e4e7048069cb6e26c0b357c16d )
+	name "Formcalc (19xx)(-)"
+	description "Formcalc (19xx)(-)"
+	rom ( name "Formcalc (19xx)(-).p" size 7388 crc 4bc6d4a3 md5 f0b7c3a33623efa1280dd7d441b2f2cd sha1 9c7739828ba86de5602d2d02dec8b795c65542c5 )
 )
+
 game (
-	name "ZX Chess II (IPS) (International Publishing and Software Inc.)"
-	description "ZX Chess II (IPS) (International Publishing and Software Inc.)"
-	year 1982
-	manufacturer "International Publishing and Software Inc."
-	rom ( name "zxchessii(ips).p" size 14096 crc 95534f49 md5 288fedccf17c6d1ec8312c219fe1398e sha1 df54149f4ed916f7b804a8e0b8e34f790505f7c0 )
-	rom ( name "ZXChessII(IPS).tzx" size 14326 crc e300ffc8 md5 489b56232d78bbeebdb69f4cc5fcc320 sha1 d06522009c0438e7e201611c1ec10e17650dbf39 )
+	name "Formula One (1983)(P. Dziwior)"
+	description "Formula One (1983)(P. Dziwior)"
+	rom ( name "Formula One (1983)(P. Dziwior).p" size 7788 crc 2e5d191a md5 d972195bbe7644c90056e6343838a344 sha1 50a9b3dbd2f74e8c3b9b79c4c3b85ccf4067fca1 )
 )
+
 game (
-	name "ZX Forth (Artic)"
-	description "ZX Forth (Artic)"
-	manufacturer "Artic Computing"
-	rom ( name "ZXForth.tzx" size 20567 crc 587d765f md5 421ddc790c350146af56d1683d3cf2b6 sha1 63c6e3cd88655b30cef4afcdf4fcab959210047f )
+	name "Formula One (1984)(John Diependaal)"
+	description "Formula One (1984)(John Diependaal)"
+	rom ( name "Formula One (1984)(John Diependaal).p" size 9053 crc 87cbafdf md5 be90a25c95593f928cdbb665ddb2395a sha1 542c471212d3d57b0e67fc74fe80ea0f27deb594 )
 )
+
 game (
-	name "ZX Forth (International Publishing and Software Inc.)"
-	description "ZX Forth (International Publishing and Software Inc.)"
-	year 1982
-	manufacturer "Artic"
-	rom ( name "ZXForth(IPS).tzx" size 12455 crc 73e4bf92 md5 408a2ad80923d4e802a4529c8facb917 sha1 5cd85e8a39cb6151c243b4d83dfaf88a4f23c3bc )
+	name "Formula One (19xx)(-)(it)"
+	description "Formula One (19xx)(-)(it)"
+	rom ( name "Formula One (19xx)(-)(it).p" size 2678 crc 560605f5 md5 fd39f3a11a68977da52b0ba9c509a224 sha1 a92820df69557219a94ccd9d068ef26dacd0e19a )
 )
+
 game (
-	name "ZX Othello (Moi)"
-	description "ZX Othello (Moi)"
-	year 1982
-	manufacturer "Moi"
-	rom ( name "Othello(Moi).tzx" size 12809 crc 96eeab64 md5 2b76c39d66873cfa8959cebdd71d5cec sha1 78f78e57bf940d87d020c39aa4218b273f612313 )
+	name "Formule One Race (19xx)(-)(nl)"
+	description "Formule One Race (19xx)(-)(nl)"
+	rom ( name "Formule One Race (19xx)(-)(nl).p" size 6686 crc 68ca0361 md5 8487ef1cf30672c3bf96ba35180b01b6 sha1 ed413f9f0fb5b814ff6a4d39562413f094de9150 )
 )
+
 game (
-	name "ZX Pro/File (Thomas B. Woods)"
-	description "ZX Pro/File (Thomas B. Woods)"
-	year 1983
-	manufacturer "Thomas B. Woods"
-	rom ( name "zxprofile.p" size 16071 crc 73f67b5b md5 e0021b805cbae2655a4158128931035d sha1 9ccb69ea8ef5d613440720d63e84e67675a4614f )
-	rom ( name "ZXProFile.tzx" size 16291 crc 5d5146cf md5 64b39d80729e025fad4828f378cc8032 sha1 214faff9ecc28e7d20e229554bfaae88a8b23b98 )
+	name "Fort Knox II (19xx)(Boldie Software)"
+	description "Fort Knox II (19xx)(Boldie Software)"
+	rom ( name "Fort Knox II (19xx)(Boldie Software).p" size 13982 crc 103d53eb md5 5ff181916ed40c0dcb1b4ba183f891b0 sha1 bdaaed6564a59ab7fa0f1cd026411a225ac46915 )
 )
+
 game (
-	name "ZX-Compiler (Silversoft)"
-	description "ZX-Compiler (Silversoft)"
-	year 1982
-	manufacturer "Silversoft"
-	rom ( name "zxcompiler.p" size 6931 crc f25627c4 md5 8603e97d1fe5548927e829fd2486f5a7 sha1 1ae703f1d6e47a4f6c3a07f0c5a11c233562782f )
-	rom ( name "ZXCompiler.tzx" size 7163 crc 491041a6 md5 bb0497bb6eeea52b39eb7e189f55728c sha1 09cecbec3370cfd1ff77e316c69661132f2e932f )
+	name "Forty Niner (19xx)(Cosmic Cockerel)"
+	description "Forty Niner (19xx)(Cosmic Cockerel)"
+	rom ( name "Forty Niner (19xx)(Cosmic Cockerel).p" size 13870 crc 74988954 md5 b6886d9fb835635208cbc13edb20671e sha1 3a5dc6527c36d67a0edcc6a0a0cf58c484ca49ed )
 )
+
 game (
-	name "ZX-MC (Picturesque)"
-	description "ZX-MC (Picturesque)"
-	manufacturer "Picturesque"
-	rom ( name "zxmc.p" size 3555 crc de00007d md5 1fe46c4d47a32b6c7b77144987a6c753 sha1 8897d32731370314da8bae6c4e8ae56761e4b3aa )
-	rom ( name "ZXMC.tzx" size 3781 crc bad36aef md5 a9804be70b200a01d551198de5d13e70 sha1 9edc5c21e1edd96e1a733908d9e7d39cec6df85e )
+	name "Forty Niner (19xx)(Cosmic Cockerel)[a2]"
+	description "Forty Niner (19xx)(Cosmic Cockerel)[a2]"
+	rom ( name "Forty Niner (19xx)(Cosmic Cockerel)[a2].p" size 13868 crc af159337 md5 70c64e30b56934d17039248eee9e4581 sha1 87762753b08c5141614f343e3f2eb56f978b3eea )
 )
+
 game (
-	name "ZX-Sideprint (Microsphere)"
-	description "ZX-Sideprint (Microsphere)"
-	year 1982
-	manufacturer "Microsphere"
-	rom ( name "zxsideprint.p" size 1941 crc db6371df md5 d263455884fa102d245f3109c9a66a2f sha1 869334c4250219aa8e6fcf6752d2eba5f6aa7e69 )
-	rom ( name "ZXSideprint.tzx" size 2175 crc 5f320b4a md5 d990bb98194f1a992e902aaaec9c3fbb sha1 6965f265cbfca8f6813f698be70ed0e709c59632 )
+	name "Forty Niner (19xx)(Cosmic Cockerel)[a3]"
+	description "Forty Niner (19xx)(Cosmic Cockerel)[a3]"
+	rom ( name "Forty Niner (19xx)(Cosmic Cockerel)[a3].p" size 13868 crc 4943d1e6 md5 1ae21aba41dfa61563f8d8311d18431e sha1 a56a663ebf97faf2dd310e88aa7271e66ae0d1ab )
 )
+
 game (
-	name "ZXagon"
-	description "ZXagon (2014) - Bob's interpretation of Terry Cavanagh's masterpiece 'Super Hexagon'."
-	rom ( name "ZXagon.p" size 15336 crc d6784677 md5 4a7f14d7f0d4918ca48c028ae151ccee sha1 59dae098079f00c3e72ec4647ccbd2ed99b979f1 )
+	name "Forty Niner (19xx)(Cosmic Cockerel)[a]"
+	description "Forty Niner (19xx)(Cosmic Cockerel)[a]"
+	rom ( name "Forty Niner (19xx)(Cosmic Cockerel)[a].p" size 13904 crc 8ad4318e md5 729972ff3143a12158f3270bfab00d7c sha1 e311753fffd3197bd411ff20b128cc6cbadff43f )
 )
+
 game (
-	name "ZXAS (Bug Byte)"
-	description "ZXAS (Bug Byte)"
-	year 1982
-	manufacturer "Bug Byte"
-	rom ( name "zxas.p" size 5619 crc db561ebf md5 60a230ce6474ecacff6dd1c1cc5760a3 sha1 6b4bd425549c0bdde54c33527506c213c8ccaa09 )
-	rom ( name "ZXAS.tzx" size 5843 crc fa15514c md5 a2ad68a98cee37835e84121b9ee8b53d sha1 0422f7eca685e2ee3981c86e44624b8ff0ff8aca )
+	name "Four Stroke Petrol Engine (1982)(B. Horsfield)"
+	description "Four Stroke Petrol Engine (1982)(B. Horsfield)"
+	rom ( name "Four Stroke Petrol Engine (1982)(B. Horsfield).p" size 3405 crc 92253013 md5 06a407591f41a3a80790250eedcb0ae5 sha1 94100f740e6afaee7dd3795b62bfb3264073ec5e )
 )
+
 game (
-	name "ZXAS (Gladstone) (Gladstone Electronics)"
-	description "ZXAS (Gladstone) (Gladstone Electronics)"
-	manufacturer "Bug Byte"
-	rom ( name "zxas(ge).p" size 5619 crc 850bab49 md5 7c622f096ad94f4201922e7cdea35c67 sha1 0b758fdb9bcfc94d9b37f743f78075595563c529 )
-	rom ( name "ZXAS(GE).tzx" size 5843 crc a448e4ba md5 beebbc4f4b2262f2e2c4aa3f45a62c69 sha1 e09abff8f1c771b7e1ace6b6612eb99dfa539654 )
+	name "Fourier Analysis (1987)(SMC)"
+	description "Fourier Analysis (1987)(SMC)"
+	rom ( name "Fourier Analysis (1987)(SMC).p" size 20872 crc 570f7e40 md5 4dce9f4d2fc7d69cf59c369938f61de8 sha1 e4b7706d2de41947fd2871811fe39027f57d47c3 )
 )
+
 game (
-	name "ZXAS (Monochrome) (Bug Byte)"
-	description "ZXAS (Monochrome) (Bug Byte)"
-	year 1981
-	manufacturer "Bug Byte"
-	rom ( name "zxas.p" size 5619 crc db561ebf md5 60a230ce6474ecacff6dd1c1cc5760a3 sha1 6b4bd425549c0bdde54c33527506c213c8ccaa09 )
-	rom ( name "ZXAS.tzx" size 5843 crc fa15514c md5 a2ad68a98cee37835e84121b9ee8b53d sha1 0422f7eca685e2ee3981c86e44624b8ff0ff8aca )
+	name "Fourier Series, The (1983)(Sinclair User)"
+	description "Fourier Series, The (1983)(Sinclair User)"
+	rom ( name "Fourier Series, The (1983)(Sinclair User).p" size 1220 crc cfa63f84 md5 027fdf0bf1fb9710cfda9085484b4111 sha1 64453473d69575b18fe0c85baaed3e80914c7cc1 )
 )
+
 game (
-	name "ZXAS (Printed instructions) (Bug Byte)"
-	description "ZXAS (Printed instructions) (Bug Byte)"
-	year 1982
-	manufacturer "Bug Byte"
-	rom ( name "zxas.p" size 5619 crc db561ebf md5 60a230ce6474ecacff6dd1c1cc5760a3 sha1 6b4bd425549c0bdde54c33527506c213c8ccaa09 )
-	rom ( name "ZXAS.tzx" size 5843 crc fa15514c md5 a2ad68a98cee37835e84121b9ee8b53d sha1 0422f7eca685e2ee3981c86e44624b8ff0ff8aca )
+	name "Fractions (19xx)(-)"
+	description "Fractions (19xx)(-)"
+	rom ( name "Fractions (19xx)(-).p" size 10747 crc b5e8e763 md5 473144889539215ee5814f1da21a76d4 sha1 5c45380ad51d775e7493cacb375cfe523f5c4a5e )
 )
+
 game (
-	name "ZXAS (Typed Inlay) (Bug Byte)"
-	description "ZXAS (Typed Inlay) (Bug Byte)"
-	year 1981
-	manufacturer "Bug Byte"
-	rom ( name "zxas.p" size 5619 crc db561ebf md5 60a230ce6474ecacff6dd1c1cc5760a3 sha1 6b4bd425549c0bdde54c33527506c213c8ccaa09 )
-	rom ( name "ZXAS.tzx" size 5843 crc fa15514c md5 a2ad68a98cee37835e84121b9ee8b53d sha1 0422f7eca685e2ee3981c86e44624b8ff0ff8aca )
+	name "Fred (19xx)(M.Z. Production)"
+	description "Fred (19xx)(M.Z. Production)"
+	rom ( name "Fred (19xx)(M.Z. Production).p" size 3857 crc de6bc5ab md5 3db5569f5002ff6340fce4fcb8ee5357 sha1 58857bfd10533f220dc599e6dd18df0eb772ebf7 )
 )
+
 game (
-	name "ZXAS (Yellow) (Bug Byte)"
-	description "ZXAS (Yellow) (Bug Byte)"
-	year 1982
-	manufacturer "Bug Byte"
-	rom ( name "zxas.p" size 5619 crc db561ebf md5 60a230ce6474ecacff6dd1c1cc5760a3 sha1 6b4bd425549c0bdde54c33527506c213c8ccaa09 )
-	rom ( name "ZXAS.tzx" size 5843 crc fa15514c md5 a2ad68a98cee37835e84121b9ee8b53d sha1 0422f7eca685e2ee3981c86e44624b8ff0ff8aca )
+	name "Freeway Crossing (19xx)(-)"
+	description "Freeway Crossing (19xx)(-)"
+	rom ( name "Freeway Crossing (19xx)(-).p" size 2014 crc 683c8aff md5 df593417061022d30120b6569fc26b73 sha1 878736d163b70c6ed9561b0d06342ebc9eb737ac )
 )
+
 game (
-	name "ZXDB (Bug Byte)"
-	description "ZXDB (Bug Byte)"
-	year 1982
-	manufacturer "Bug Byte"
-	rom ( name "zxdb.p" size 5857 crc f2454173 md5 b4f8b1ae06e3e801269abab746bd4131 sha1 7c5a6e0fe6d2f12d14cc9ce43a2fd712f629341d )
-	rom ( name "ZXDB.tzx" size 6081 crc f4bd2dc5 md5 95f75928eed2bd7acb2dee0ac8840d00 sha1 33604f3874337c4a579b9d1c6fb0d56887d2a128 )
+	name "Frekwentie LC (19xx)(-)(nl)"
+	description "Frekwentie LC (19xx)(-)(nl)"
+	rom ( name "Frekwentie LC (19xx)(-)(nl).p" size 4158 crc 0b07d625 md5 64fbbb620839f29002cd77579984e2a1 sha1 8662e43b039cc601701da4d01b16dff49a77dd49 )
 )
+
 game (
-	name "ZXDB (Typed Inlay, black) (Bug Byte)"
-	description "ZXDB (Typed Inlay, black) (Bug Byte)"
-	year 1982
-	manufacturer "Bug Byte"
-	rom ( name "zxdb.p" size 5857 crc f2454173 md5 b4f8b1ae06e3e801269abab746bd4131 sha1 7c5a6e0fe6d2f12d14cc9ce43a2fd712f629341d )
-	rom ( name "ZXDB.tzx" size 6081 crc f4bd2dc5 md5 95f75928eed2bd7acb2dee0ac8840d00 sha1 33604f3874337c4a579b9d1c6fb0d56887d2a128 )
+	name "Frequentie (19xx)(-)(nl)"
+	description "Frequentie (19xx)(-)(nl)"
+	rom ( name "Frequentie (19xx)(-)(nl).p" size 14715 crc f4e1668a md5 1fde1a72fafa59263d8d7bc00bf66d7b sha1 a7a67d9ad8818060835f2a27f130716c929cf658 )
 )
+
 game (
-	name "ZXDB (Typed Inlay, blue) (Bug Byte)"
-	description "ZXDB (Typed Inlay, blue) (Bug Byte)"
-	year 1982
-	manufacturer "Bug Byte"
-	rom ( name "zxdb.p" size 5857 crc f2454173 md5 b4f8b1ae06e3e801269abab746bd4131 sha1 7c5a6e0fe6d2f12d14cc9ce43a2fd712f629341d )
-	rom ( name "ZXDB.tzx" size 6081 crc f4bd2dc5 md5 95f75928eed2bd7acb2dee0ac8840d00 sha1 33604f3874337c4a579b9d1c6fb0d56887d2a128 )
+	name "Frequentie Memo (19xx)(J.P.P. de Jong)(nl)"
+	description "Frequentie Memo (19xx)(J.P.P. de Jong)(nl)"
+	rom ( name "Frequentie Memo (19xx)(J.P.P. de Jong)(nl).p" size 3139 crc 4976423b md5 6864afcb0d1373d5b266cf4c840bed5d sha1 e70202f6372946245479bb5966939007e7aad52d )
 )
+
 game (
-	name "ZXDB (Yellow) (Bug Byte)"
-	description "ZXDB (Yellow) (Bug Byte)"
-	year 1982
-	manufacturer "Bug Byte"
-	rom ( name "zxdb.p" size 5857 crc f2454173 md5 b4f8b1ae06e3e801269abab746bd4131 sha1 7c5a6e0fe6d2f12d14cc9ce43a2fd712f629341d )
-	rom ( name "ZXDB.tzx" size 6081 crc f4bd2dc5 md5 95f75928eed2bd7acb2dee0ac8840d00 sha1 33604f3874337c4a579b9d1c6fb0d56887d2a128 )
+	name "Frogger (1981)(Cornsoft)"
+	description "Frogger (1981)(Cornsoft)"
+	rom ( name "Frogger (1981)(Cornsoft).p" size 10670 crc 1c44bf27 md5 eb17b2fe02a961f4ab26f559e8274a75 sha1 53b72d38b4893f553e5d608e40927fe0c0848614 )
 )
+
 game (
-	name "ZXM Sound Box Super Editor (Timedata)"
-	description "ZXM Sound Box Super Editor (Timedata)"
-	year 1983
-	manufacturer "Timedata"
-	rom ( name "zxmsupereditor.p" size 2473 crc 37830a34 md5 c4a52e25b43580685f277856cf85ce72 sha1 1d030fe2bee1c42635299e7d0f925f5adb4582a7 )
-	rom ( name "ZXMSuperEditor.tzx" size 2693 crc 989424d1 md5 498e30b4cfd9e0e0d65df71e64fff20c sha1 9af273026fbd076097effee86e09a9f07d58f1fc )
+	name "Frogger (19xx)(-)"
+	description "Frogger (19xx)(-)"
+	rom ( name "Frogger (19xx)(-).p" size 3944 crc 780bead2 md5 06cea161bfaf8a9bf6b459199997646d sha1 655eddd153e58cb7b18d5dcbfd239780847fabac )
 )
+
 game (
-	name "ZXTK (Bug Byte)"
-	description "ZXTK (Bug Byte)"
-	year 1982
-	manufacturer "Bug Byte"
-	rom ( name "zxtk.p" size 2613 crc 89a5914b md5 c0793cb9bfd99ad68878accd3cc14b37 sha1 3ec38eccf7bf79f299a8ad93dcfcbf976cf91cb9 )
-	rom ( name "ZXTK.tzx" size 2837 crc 4f4182c4 md5 5dfcb789500923de2e3e818b735ff185 sha1 fd398501a5e72ef51c0fd817085e77300807fb57 )
+	name "Frogger (19xx)(-)(de)"
+	description "Frogger (19xx)(-)(de)"
+	rom ( name "Frogger (19xx)(-)(de).p" size 4581 crc 38cd7a30 md5 345e6262caaf2c6992af113c5add7f2a sha1 c3c90326efe4e2437866b1edb0ab3687415feef9 )
 )
+
 game (
-	name "ZXTK (Printed instructions) (Bug Byte)"
-	description "ZXTK (Printed instructions) (Bug Byte)"
-	year 1982
-	manufacturer "Bug Byte"
-	rom ( name "zxtk.p" size 2613 crc 89a5914b md5 c0793cb9bfd99ad68878accd3cc14b37 sha1 3ec38eccf7bf79f299a8ad93dcfcbf976cf91cb9 )
-	rom ( name "ZXTK.tzx" size 2837 crc 4f4182c4 md5 5dfcb789500923de2e3e818b735ff185 sha1 fd398501a5e72ef51c0fd817085e77300807fb57 )
+	name "Froggie (1983)(Richard Braunton)"
+	description "Froggie (1983)(Richard Braunton)"
+	rom ( name "Froggie (1983)(Richard Braunton).p" size 7459 crc a36b2a25 md5 9f0acd65501bdac23d975f37a986a06a sha1 dc5c2c2f2e04ff25845afe4ca5cb7a8d1fadc113 )
 )
+
 game (
-	name "ZXTK (Yellow) (Bug Byte)"
-	description "ZXTK (Yellow) (Bug Byte)"
-	year 1982
-	manufacturer "Bug Byte"
-	rom ( name "zxtk.p" size 2613 crc 89a5914b md5 c0793cb9bfd99ad68878accd3cc14b37 sha1 3ec38eccf7bf79f299a8ad93dcfcbf976cf91cb9 )
-	rom ( name "ZXTK.tzx" size 2837 crc 4f4182c4 md5 5dfcb789500923de2e3e818b735ff185 sha1 fd398501a5e72ef51c0fd817085e77300807fb57 )
+	name "Froggie (1983)(Richard Braunton)(nl)"
+	description "Froggie (1983)(Richard Braunton)(nl)"
+	rom ( name "Froggie (1983)(Richard Braunton)(nl).p" size 7633 crc 7c3ed168 md5 2ab88eef6c7b2d9d356c11e148e8b3d5 sha1 0babb991c8e3c1480c5e06192d0e547f26b8c1bf )
+)
+
+game (
+	name "Froggie (1983)(Richard Braunton)[a2]"
+	description "Froggie (1983)(Richard Braunton)[a2]"
+	rom ( name "Froggie (1983)(Richard Braunton)[a2].p" size 7458 crc 7a11e3c0 md5 5fa27d9a6002f3a239c1e6ddf152fe20 sha1 23b8073fd6805e9e6d9de092716c4a3b6e0f1674 )
+)
+
+game (
+	name "Froggie (1983)(Richard Braunton)[a]"
+	description "Froggie (1983)(Richard Braunton)[a]"
+	rom ( name "Froggie (1983)(Richard Braunton)[a].p" size 7212 crc 5ff8906d md5 b07adcb370fde8a63a92ac2e797b7591 sha1 533cce1da47f92dcff43b25fb69bdfed5c51ad46 )
+)
+
+game (
+	name "Frustration (1983)(M.J. Whitcombe)"
+	description "Frustration (1983)(M.J. Whitcombe)"
+	rom ( name "Frustration (1983)(M.J. Whitcombe).p" size 3033 crc 165fd5f4 md5 22116be138c2caf6cf70d33ba55892bb sha1 7d4f419fd7e1cb5c19e6a78ce104a05ecf6197d3 )
+)
+
+game (
+	name "Fungaloids (19xx)(-)"
+	description "Fungaloids (19xx)(-)"
+	rom ( name "Fungaloids (19xx)(-).p" size 9110 crc d2662f46 md5 9e4a962be8470c711770515b5b60cbf9 sha1 2b38e47efc9cc0e02ebc8c51d4631fdea650cf3c )
+)
+
+game (
+	name "Funky (19xx)(-)(de)"
+	description "Funky (19xx)(-)(de)"
+	rom ( name "Funky (19xx)(-)(de).p" size 4478 crc e33632ab md5 278e7a8d4fb670a118637b4c57dbaeec sha1 c64fe6abcdd9b4fdc2d93a47222aeedeb3fa29f7 )
+)
+
+game (
+	name "G.P.O. Postage Rates (19xx)(-)"
+	description "G.P.O. Postage Rates (19xx)(-)"
+	rom ( name "G.P.O. Postage Rates (19xx)(-).p" size 1297 crc c6fa4130 md5 b84a9cb58b5b17f22c6aff0662ccfee0 sha1 49aba0fcd86801b09992c3d24a5663fbfb35302c )
+)
+
+game (
+	name "Galactic Invasion (19xx)(-)(de)"
+	description "Galactic Invasion (19xx)(-)(de)"
+	rom ( name "Galactic Invasion (19xx)(-)(de).p" size 3434 crc 63153375 md5 47f88062317a34588ceaf8163128ed80 sha1 234efb28b48f6a457941d36d5134e4d599624112 )
+)
+
+game (
+	name "Galaktischer Angriff (19xx)(-)(de)"
+	description "Galaktischer Angriff (19xx)(-)(de)"
+	rom ( name "Galaktischer Angriff (19xx)(-)(de).p" size 2756 crc 81e26d05 md5 1ba82f83cc57af06ad2b37c6757bfbd7 sha1 c5324526a6e413cbd3a2be4400091cbe1d6ae6b8 )
+)
+
+game (
+	name "Galaxians (1982)(Tony Beckwith)"
+	description "Galaxians (1982)(Tony Beckwith)"
+	rom ( name "Galaxians (1982)(Tony Beckwith).p" size 4173 crc a5c29904 md5 0a0f6d8ed201af3b8eae963d958594f6 sha1 d688b7c2daeced4990b8e495feb5d2e89cb1781c )
+)
+
+game (
+	name "Galaxy Invaders (19xx)(-)"
+	description "Galaxy Invaders (19xx)(-)"
+	rom ( name "Galaxy Invaders (19xx)(-).p" size 3841 crc 0a10224d md5 b66326bdb75cfb4771823d0a5578d569 sha1 563bdb6101d6955a9f53ca64d2ef08b7302e5655 )
+)
+
+game (
+	name "Galaxy Invaders (19xx)(-)[a]"
+	description "Galaxy Invaders (19xx)(-)[a]"
+	rom ( name "Galaxy Invaders (19xx)(-)[a].p" size 3812 crc 36217c7d md5 c4e9e931e6cfc659b1f3622253d9a2da sha1 d65ac555804f0af1414a1cda79f8b240c4d1964b )
+)
+
+game (
+	name "Galaxy Warrior (1981)(Artic Computing)"
+	description "Galaxy Warrior (1981)(Artic Computing)"
+	rom ( name "Galaxy Warrior (1981)(Artic Computing).p" size 4603 crc 8788b326 md5 2b4e0f4fcf77a87b9fc251482d57107d sha1 73f670363653c785c10b29d6e4e9146c09ca74cb )
+)
+
+game (
+	name "Galaxy Warrior (1981)(Artic Computing)[a]"
+	description "Galaxy Warrior (1981)(Artic Computing)[a]"
+	rom ( name "Galaxy Warrior (1981)(Artic Computing)[a].p" size 4583 crc 7e0b8ec8 md5 317477d19d6108bf9d3cb90cdffb1c43 sha1 53a06dd869f19ed13b14135ed694c3bfd8003c96 )
+)
+
+game (
+	name "Galgje II (1985)(JSKOSoft)(nl)"
+	description "Galgje II (1985)(JSKOSoft)(nl)"
+	rom ( name "Galgje II (1985)(JSKOSoft)(nl).p" size 3114 crc a8e43eff md5 476dbe8146ec88fda70f6652b7b6ec1d sha1 50b7149781ed1b8b1022a71b792e8dd8ab81454f )
+)
+
+game (
+	name "Game of Puckman, The (1982)(John Hardman)"
+	description "Game of Puckman, The (1982)(John Hardman)"
+	rom ( name "Game of Puckman, The (1982)(John Hardman).p" size 10602 crc 41bebcdb md5 b4ea5f287a8a582bbf5921ca69ea2a05 sha1 22adcc80fa3c2ab5145e3d938bd0d94796e0e4a9 )
+)
+
+game (
+	name "Game of Puckman, The (1982)(John Hardman)[a2]"
+	description "Game of Puckman, The (1982)(John Hardman)[a2]"
+	rom ( name "Game of Puckman, The (1982)(John Hardman)[a2].p" size 10634 crc 57cda065 md5 b70b83d515eb7f65c83a06760078589c sha1 7e3f2d858eee59bd172f3d2283bc31d8d6bd9289 )
+)
+
+game (
+	name "Game of Puckman, The (1982)(John Hardman)[a]"
+	description "Game of Puckman, The (1982)(John Hardman)[a]"
+	rom ( name "Game of Puckman, The (1982)(John Hardman)[a].p" size 10601 crc 875cdf1a md5 9fdd4ee22bfb7ba815f403ce93f5aeba sha1 08ea2702ce02010dc7861ea2a5611b4eea09d9bf )
+)
+
+game (
+	name "Games (19xx)(-)(nl)"
+	description "Games (19xx)(-)(nl)"
+	rom ( name "Games (19xx)(-)(nl).p" size 7841 crc 9ce82908 md5 c6ed2a30d8c9737d1c730c327c7417ee sha1 653fd7a59ccdec8ab109d02213036bfbe527ad5a )
+)
+
+game (
+	name "Games Collection (19xx)(-)"
+	description "Games Collection (19xx)(-)"
+	rom ( name "Games Collection (19xx)(-).p" size 10618 crc 1afc44d7 md5 a1e1e1c47cecb87c62d1f12afab09e8a sha1 3cedb5d5f1d722e1080341eb40be1a2255616e2e )
+)
+
+game (
+	name "Ganymede II (1982)(Nick Wilson)"
+	description "Ganymede II (1982)(Nick Wilson)"
+	rom ( name "Ganymede II (1982)(Nick Wilson).p" size 11210 crc 9dfbba74 md5 614114a67feaec8ec39bae7d11c13420 sha1 6bea49ab67b1d923c850922751c3866471b8f671 )
+)
+
+game (
+	name "Ganymede II (1982)(Nick Wilson)[a]"
+	description "Ganymede II (1982)(Nick Wilson)[a]"
+	rom ( name "Ganymede II (1982)(Nick Wilson)[a].p" size 11246 crc 887393cd md5 79c5c7eafbfe750b7e19be60d918b56b sha1 2da262626f9dfca0f85862a031d134ec4927f114 )
+)
+
+game (
+	name "Gauntlet, The (1982)(Colourmatic Computing)"
+	description "Gauntlet, The (1982)(Colourmatic Computing)"
+	rom ( name "Gauntlet, The (1982)(Colourmatic Computing).p" size 14562 crc 34763407 md5 53a9fae8ecb28d5e9379e144c76d00b5 sha1 d3544d19c2db5bee493488be48840aa684c3398b )
+)
+
+game (
+	name "Gauntlet, The (1982)(Colourmatic Computing)[a]"
+	description "Gauntlet, The (1982)(Colourmatic Computing)[a]"
+	rom ( name "Gauntlet, The (1982)(Colourmatic Computing)[a].p" size 14530 crc a7d26fba md5 a82136d640edef16ec7f8c84f5b3860d sha1 95e4cdc75bdf979c7197ecf45508b624f2437a6b )
+)
+
+game (
+	name "Gekkenhuis (1984)(S.S.S.)(nl)"
+	description "Gekkenhuis (1984)(S.S.S.)(nl)"
+	rom ( name "Gekkenhuis (1984)(S.S.S.)(nl).p" size 12565 crc 4a666857 md5 58420a7df22229b9c24c85378ed08bf7 sha1 9cc3ca8fd530b51db712850086104ac7e17c06e8 )
+)
+
+game (
+	name "Geld (19xx)(Edwin Mol ZX-81 Productions)(nl)"
+	description "Geld (19xx)(Edwin Mol ZX-81 Productions)(nl)"
+	rom ( name "Geld (19xx)(Edwin Mol ZX-81 Productions)(nl).p" size 4436 crc c9158546 md5 d03dab8b403ae07b36e4d45c6b02a392 sha1 df8d13cad518d4c5556d9dae9249b0c4c0b0bee3 )
+)
+
+game (
+	name "General Relocater (19xx)(-)(nl)"
+	description "General Relocater (19xx)(-)(nl)"
+	rom ( name "General Relocater (19xx)(-)(nl).p" size 3035 crc 9c0d1bdb md5 d2845528057f570ca79565704b42fd64 sha1 fc5f5688fe83cec0435b44846cbdfde2301dc9d0 )
+)
+
+game (
+	name "Generalized Mandelbrot Prototype (1988)(-)"
+	description "Generalized Mandelbrot Prototype (1988)(-)"
+	rom ( name "Generalized Mandelbrot Prototype (1988)(-).p" size 20503 crc 02e371a9 md5 73cf0412d46ccc615322a0c655cd0b2c sha1 34fff31e711b386056cc62435aba3ac86ca89982 )
+)
+
+game (
+	name "George (1982)(Aackosoft)(nl)"
+	description "George (1982)(Aackosoft)(nl)"
+	rom ( name "George (1982)(Aackosoft)(nl).p" size 3578 crc ee3df79c md5 93cfb5a2456adbbb4c8bc3fead26c34e sha1 3e9ef6d845c7372f7465e6fb29f607e46d9d9741 )
+)
+
+game (
+	name "Ghost Driver (1982)(H. Stamm)(de)"
+	description "Ghost Driver (1982)(H. Stamm)(de)"
+	rom ( name "Ghost Driver (1982)(H. Stamm)(de).p" size 2103 crc 19c23e67 md5 f6bad146fd4df88df1b77a9a4984767e sha1 fb5512aa02e26d077dfdd12295c9009de39bfe82 )
+)
+
+game (
+	name "Ghost Driver (1982)(H. Stamm)(de)[a]"
+	description "Ghost Driver (1982)(H. Stamm)(de)[a]"
+	rom ( name "Ghost Driver (1982)(H. Stamm)(de)[a].p" size 2056 crc c7e7e443 md5 8201533b19720fef93e86906712e32cf sha1 4459059b38219d65fbbdf19c169242258f1bb60f )
+)
+
+game (
+	name "Ghost Hunt (19xx)(PSS)"
+	description "Ghost Hunt (19xx)(PSS)"
+	rom ( name "Ghost Hunt (19xx)(PSS).p" size 5329 crc edf86308 md5 4514a6e7f9ce0bf5c75f506c27c8f99a sha1 bda1cb33d559581acd28fd247ef86bd9370bfe54 )
+)
+
+game (
+	name "Ghost Hunt (19xx)(PSS)[a]"
+	description "Ghost Hunt (19xx)(PSS)[a]"
+	rom ( name "Ghost Hunt (19xx)(PSS)[a].p" size 5242 crc 3fd7e5d0 md5 6ff1cb6b6861f02b8e27f8b5ee8d6278 sha1 7b21c6fd6a6a70692aace5c23e41122ad3a2583c )
+)
+
+game (
+	name "Ghosts (19xx)(-)"
+	description "Ghosts (19xx)(-)"
+	rom ( name "Ghosts (19xx)(-).p" size 5358 crc 825948c6 md5 542af93f0cf2a42803bed6a07ab60798 sha1 74bef529a32b8b85328e083f7f69231215738fcd )
+)
+
+game (
+	name "Glooper (19xx)(Quicksilva)"
+	description "Glooper (19xx)(Quicksilva)"
+	rom ( name "Glooper (19xx)(Quicksilva).p" size 7216 crc 01c580c7 md5 fa0042143a65e5c0c7b4ce68c4b4b53d sha1 92857d45f35d907d92b7f9f0699dfb1c4582335c )
+)
+
+game (
+	name "Glooper (19xx)(Quicksilva)[a]"
+	description "Glooper (19xx)(Quicksilva)[a]"
+	rom ( name "Glooper (19xx)(Quicksilva)[a].p" size 7195 crc 403ac7fd md5 09320c094498d71ca929a060a3a43397 sha1 0ad25d64d97b063188878cbc602dcf06a33d276a )
+)
+
+game (
+	name "Gloops (1982)(Tony Beckwith)"
+	description "Gloops (1982)(Tony Beckwith)"
+	rom ( name "Gloops (1982)(Tony Beckwith).p" size 11986 crc 13c1185e md5 a47b293d6c19c050947e8baa3ff0fca3 sha1 177450c78befa5d18509db23184c6ab8908cb4b8 )
+)
+
+game (
+	name "Gloops (1982)(Tony Beckwith)[a]"
+	description "Gloops (1982)(Tony Beckwith)[a]"
+	rom ( name "Gloops (1982)(Tony Beckwith)[a].p" size 12007 crc adeb0da1 md5 2e9d9b370668bf0018ed8de805e21af3 sha1 970af4cf24fadfd301ae6ab905caf5507348a46b )
+)
+
+game (
+	name "GM Test (19xx)(-)"
+	description "GM Test (19xx)(-)"
+	rom ( name "GM Test (19xx)(-).p" size 1407 crc 5190136c md5 d45c8dfc3d16bd93a4c266ca8e994ffa sha1 d778258c7ddf78a4115cb00552ae26fa7f3250c4 )
+)
+
+game (
+	name "Go-Ball (19xx)(F. Hunold)"
+	description "Go-Ball (19xx)(F. Hunold)"
+	rom ( name "Go-Ball (19xx)(F. Hunold).p" size 3420 crc 20a693ef md5 43c45805862190cb30d12c5322a906f5 sha1 21498a738313ea5ded5ab4568edf6e227a93fbd3 )
+)
+
+game (
+	name "Gobang (1984)(D. Kriener)(de)"
+	description "Gobang (1984)(D. Kriener)(de)"
+	rom ( name "Gobang (1984)(D. Kriener)(de).p" size 5065 crc a60a558c md5 1968dab2667da404d79b6bc59e7e6047 sha1 20636ede322728bdf80aa40b8c25c9af59356a31 )
+)
+
+game (
+	name "Gobang of Chinees Schaak (19xx)(-)(nl)"
+	description "Gobang of Chinees Schaak (19xx)(-)(nl)"
+	rom ( name "Gobang of Chinees Schaak (19xx)(-)(nl).p" size 11142 crc c0481fa2 md5 842f3002280a597c491d15a114b8ec10 sha1 18416734d0c3a0b63c33f88c605e7f574023176e )
+)
+
+game (
+	name "Gold Rush - Treasure Trails (1983)(Sinclair User)[16K]"
+	description "Gold Rush - Treasure Trails (1983)(Sinclair User)[16K]"
+	rom ( name "Gold Rush - Treasure Trails (1983)(Sinclair User)[16K].p" size 4742 crc f786b3eb md5 b1d46547bb863dd1abdbab8a6af016b6 sha1 524d00ffea2d739cd12f0fd15473d5515438c6c6 )
+)
+
+game (
+	name "Golf (19xx)(-)"
+	description "Golf (19xx)(-)"
+	rom ( name "Golf (19xx)(-).p" size 5385 crc ebdbe17c md5 873dbef7b7d8249b168b2b8ec17637db sha1 f0b2ef6a9996b18b7144d83a503389ffb3ec2873 )
+)
+
+game (
+	name "Golf fuer Zwei (19xx)(-)(de)"
+	description "Golf fuer Zwei (19xx)(-)(de)"
+	rom ( name "Golf fuer Zwei (19xx)(-)(de).p" size 8696 crc c462b1ae md5 d986f032a08582cb8edb3d75d483a862 sha1 3534afe6ae98f6b667d0987687f6bc1f0a2c457e )
+)
+
+game (
+	name "Good Habits (1989)(-)"
+	description "Good Habits (1989)(-)"
+	rom ( name "Good Habits (1989)(-).p" size 3148 crc be49bc7f md5 26e42148a55aa698ff2fe96916815019 sha1 dfb952c5c269974774215090f4f38002b55d2e3a )
+)
+
+game (
+	name "Graben (1982)(Thoralf Klatt)(de)"
+	description "Graben (1982)(Thoralf Klatt)(de)"
+	rom ( name "Graben (1982)(Thoralf Klatt)(de).p" size 7208 crc 897372ab md5 0c35f20e8d5f403c22dfe45a2dfe7612 sha1 924dec43e7a41e610682e5adfc393f8057929fba )
+)
+
+game (
+	name "Graffity (1989)(Carlo Delhez)"
+	description "Graffity (1989)(Carlo Delhez)"
+	rom ( name "Graffity (1989)(Carlo Delhez).p" size 7991 crc a34fee44 md5 1c9e82848caefa84b256e3df52ca101b sha1 51dfaa01390f70c8cb02585acfbe6f7657bcd525 )
+)
+
+game (
+	name "Graffity (1989)(Carlo Delhez)[a2]"
+	description "Graffity (1989)(Carlo Delhez)[a2]"
+	rom ( name "Graffity (1989)(Carlo Delhez)[a2].p" size 8023 crc 91a33ca4 md5 88dd66cc63227fe370db8828d93625a9 sha1 6ad673383123a9131e25b733129806db953a8192 )
+)
+
+game (
+	name "Graffity (1989)(Carlo Delhez)[a3]"
+	description "Graffity (1989)(Carlo Delhez)[a3]"
+	rom ( name "Graffity (1989)(Carlo Delhez)[a3].p" size 7201 crc 28114721 md5 bb7ea2bb578bf3b3f21117b2d180f079 sha1 8e2225e0ca9a7c7b81bb163f6d68efdf71b92fde )
+)
+
+game (
+	name "Graffity (1989)(Carlo Delhez)[a]"
+	description "Graffity (1989)(Carlo Delhez)[a]"
+	rom ( name "Graffity (1989)(Carlo Delhez)[a].p" size 7161 crc bb1b58b3 md5 a57299eec075631a519e23c05064d9c5 sha1 bf4671bf613a4ea519e0f65809869630721d24e6 )
+)
+
+game (
+	name "Grand Prix (1983)(Sinclair User)"
+	description "Grand Prix (1983)(Sinclair User)"
+	rom ( name "Grand Prix (1983)(Sinclair User).p" size 1482 crc 6ddef21b md5 128ffe2b33ff00234182b88fe8959d42 sha1 f918ecb997e9f9da52b18d1e1c704b06256552da )
+)
+
+game (
+	name "Grand Prix (19xx)(-)"
+	description "Grand Prix (19xx)(-)"
+	rom ( name "Grand Prix (19xx)(-).p" size 2179 crc 567bb719 md5 af998212f7eb8bdbd0f4ae549f8bd70b sha1 aa9ec5213b8f28caf2d41af28c84087df22bf8c6 )
+)
+
+game (
+	name "Grand Prix (19xx)(-)[a]"
+	description "Grand Prix (19xx)(-)[a]"
+	rom ( name "Grand Prix (19xx)(-)[a].p" size 2133 crc ddebe229 md5 8e704d719a30e3eb45992f918d9e6ad2 sha1 d42f33c20d355b7a7dc579db3d7112b3c5bfb149 )
+)
+
+game (
+	name "Grand Prix (19xx)(F. Hunold)"
+	description "Grand Prix (19xx)(F. Hunold)"
+	rom ( name "Grand Prix (19xx)(F. Hunold).p" size 2320 crc db678bdf md5 9262f7ef66dc6c54bbb952dff43e5cd8 sha1 07b4b480a2cf5e3556be91b30a7c7e7795cd3195 )
+)
+
+game (
+	name "Graphical Golf (1981)(Ian Turtle)"
+	description "Graphical Golf (1981)(Ian Turtle)"
+	rom ( name "Graphical Golf (1981)(Ian Turtle).p" size 7856 crc 2450749d md5 de46275fcaca0d0200127522abc82d2d sha1 7b2c898076e1415390e26be180eaaba31bc24e02 )
+)
+
+game (
+	name "Greedy Gulch (19xx)(-)"
+	description "Greedy Gulch (19xx)(-)"
+	rom ( name "Greedy Gulch (19xx)(-).p" size 15593 crc 595bd253 md5 76e4834a90d913b186f053a688700e79 sha1 b9639bfca1e42104bb124c3a169c32195c04a162 )
+)
+
+game (
+	name "Grey Test (19xx)(-)"
+	description "Grey Test (19xx)(-)"
+	rom ( name "Grey Test (19xx)(-).p" size 1955 crc 8de6a137 md5 747e88ffe8506ad654811ea9a33539a9 sha1 f79b9a510f39563572c817d3e381bed14fc87b3b )
+)
+
+game (
+	name "Greyhound (19xx)(-)"
+	description "Greyhound (19xx)(-)"
+	rom ( name "Greyhound (19xx)(-).p" size 15038 crc 8a26861f md5 d3b482659d07bb029a9122f2724e9d94 sha1 e13997ec63699daf1b1880e10ba53938f17888bf )
+)
+
+game (
+	name "Greyhound (19xx)(-)[a]"
+	description "Greyhound (19xx)(-)[a]"
+	rom ( name "Greyhound (19xx)(-)[a].p" size 15072 crc dcfbdb17 md5 e7772a2282bba0c34b6481372bf234b1 sha1 4956ca853df23945fffb10e23c4d34e28c6369b8 )
+)
+
+game (
+	name "Greys - Shading Example (19xx)(-)"
+	description "Greys - Shading Example (19xx)(-)"
+	rom ( name "Greys - Shading Example (19xx)(-).p" size 966 crc 8f3be7ac md5 7858aaa329d213280573096372913cd8 sha1 a599460fe9d818de0c5118cd10bee13aad790ab9 )
+)
+
+game (
+	name "Grieks Decoder (19xx)(Compuvision)"
+	description "Grieks Decoder (19xx)(Compuvision)"
+	rom ( name "Grieks Decoder (19xx)(Compuvision).p" size 7716 crc 900b615e md5 9e37ac6093cb51691366c637be611a5b sha1 76f48b070868f5f7c0e6e8d877da03a8019b853e )
+)
+
+game (
+	name "Grimm's Fairy Trails (19xx)(-)"
+	description "Grimm's Fairy Trails (19xx)(-)"
+	rom ( name "Grimm's Fairy Trails (19xx)(-).p" size 9340 crc efa885b5 md5 9e53bc537c42881a2f8c84d6923b7122 sha1 2f196d7195fdc3a1c6ade0241ee5fff047a64543 )
+)
+
+game (
+	name "Guess X in 60 Secs (19xx)(-)"
+	description "Guess X in 60 Secs (19xx)(-)"
+	rom ( name "Guess X in 60 Secs (19xx)(-).p" size 553 crc 4d6a37e7 md5 c2472e1d8d80c1764d29a2d428534ecd sha1 947ba1b81c57576ae9f25daa248741ccb36493f1 )
+)
+
+game (
+	name "Gulp (1982)(Campbell Systems)"
+	description "Gulp (1982)(Campbell Systems)"
+	rom ( name "Gulp (1982)(Campbell Systems).p" size 4454 crc f3ee207a md5 84fba9d4df3834c3ca145e7c70918ed3 sha1 4578ff839ce6b3a1aafb93913897474211418b7d )
+)
+
+game (
+	name "Gulp - Intro (1982)(Campbell Systems)"
+	description "Gulp - Intro (1982)(Campbell Systems)"
+	rom ( name "Gulp - Intro (1982)(Campbell Systems).p" size 4551 crc 1369ba47 md5 5e261fd484bd52d11bbf0ef1ca367d2a sha1 8b0bad5dd166ff570496050db8cd569936a8e16b )
+)
+
+game (
+	name "Gulp II (1982)(Campbell Systems)"
+	description "Gulp II (1982)(Campbell Systems)"
+	rom ( name "Gulp II (1982)(Campbell Systems).p" size 6836 crc 69d1322c md5 fac56fa1f5f7e173231474c15827f655 sha1 df21e69d4f54c9fd38ac669b444cbba103fa5b69 )
+)
+
+game (
+	name "Gulp II (1982)(Campbell Systems)(nl)"
+	description "Gulp II (1982)(Campbell Systems)(nl)"
+	rom ( name "Gulp II (1982)(Campbell Systems)(nl).p" size 6215 crc b5bbec48 md5 de056f9ae93bc81d8ef42055cdf441a5 sha1 b9fcc1e9348e7aa94dfc037461938f560281fa6f )
+)
+
+game (
+	name "Gun Command (1981)(P.E. Canter)"
+	description "Gun Command (1981)(P.E. Canter)"
+	rom ( name "Gun Command (1981)(P.E. Canter).p" size 3050 crc 059c6945 md5 528963487dcbc7c6ec8fd13413221d30 sha1 cb631dffa13309a93ae0777bd9a1ad7aa28b1348 )
+)
+
+game (
+	name "Gunfight (19xx)(JMS)"
+	description "Gunfight (19xx)(JMS)"
+	rom ( name "Gunfight (19xx)(JMS).p" size 4337 crc dd7af8ad md5 4f4082a37d6d534715ef793bd8d59020 sha1 54f336414e17db9c07872af15bf6db9647baff79 )
+)
+
+game (
+	name "Gunfight (19xx)(JMS)[a2]"
+	description "Gunfight (19xx)(JMS)[a2]"
+	rom ( name "Gunfight (19xx)(JMS)[a2].p" size 4295 crc 1f375ddf md5 e7ba9a3818d4562f0b8e530d99fc5399 sha1 59cad552b306ea8de468119a1563b647cace2d33 )
+)
+
+game (
+	name "Gunfight (19xx)(JMS)[a]"
+	description "Gunfight (19xx)(JMS)[a]"
+	rom ( name "Gunfight (19xx)(JMS)[a].p" size 4300 crc 721b765a md5 0dd1f8e55642c7c622be6a3fc5a37361 sha1 57387f6a3f721044c71b976740a3b729583616b4 )
+)
+
+game (
+	name "Guus Flater (19xx)(Maparo-Elusoft)"
+	description "Guus Flater (19xx)(Maparo-Elusoft)"
+	rom ( name "Guus Flater (19xx)(Maparo-Elusoft).p" size 7406 crc debeb048 md5 7aa4227350b6095c5e830fd0be666276 sha1 14bdfe7c2398fb8f49e9111c7e606bc3c97d865a )
+)
+
+game (
+	name "Guzzlers (19xx)(Database Software)"
+	description "Guzzlers (19xx)(Database Software)"
+	rom ( name "Guzzlers (19xx)(Database Software).p" size 6439 crc ade6fd7f md5 a875e0857f4791d9f3dcace132efc09e sha1 697bfc9255e399f6d2e1ee60514893df48e7a5a4 )
+)
+
+game (
+	name "Hammurabi (19xx)(Creative Computing)(de)"
+	description "Hammurabi (19xx)(Creative Computing)(de)"
+	rom ( name "Hammurabi (19xx)(Creative Computing)(de).p" size 6843 crc df9e4e33 md5 4dda4c41c8ad167ee3f956a5c8847cc2 sha1 50251c5c5a5ca89b0650843c17eff694a833e9bc )
+)
+
+game (
+	name "Hammurabi (19xx)(Creative Computing)(de)[a]"
+	description "Hammurabi (19xx)(Creative Computing)(de)[a]"
+	rom ( name "Hammurabi (19xx)(Creative Computing)(de)[a].p" size 6815 crc 43d1410f md5 71147975c8371f6a31f036624f4ef428 sha1 a8a69833ad44027ed2c0f3bad11851f5ad16d8ac )
+)
+
+game (
+	name "Hangman (19xx)(-)"
+	description "Hangman (19xx)(-)"
+	rom ( name "Hangman (19xx)(-).p" size 3702 crc 0b140ecf md5 90efa6a358a0c9fb0b8c6fb0d1315644 sha1 850d39bafc84f63a2a8bb2335f6cb96a52c44aeb )
+)
+
+game (
+	name "Hangman (19xx)(-)(de)"
+	description "Hangman (19xx)(-)(de)"
+	rom ( name "Hangman (19xx)(-)(de).p" size 3832 crc 16c16017 md5 0f4184a2cd300d115e35437879c1e0e3 sha1 d4b998acf5b2a2d723f349ebcf766010046826cd )
+)
+
+game (
+	name "Hangman (19xx)(-)(de)[a]"
+	description "Hangman (19xx)(-)(de)[a]"
+	rom ( name "Hangman (19xx)(-)(de)[a].p" size 3810 crc 1978372e md5 5f464f80dcf638a2c5cda1b39d4e6939 sha1 af806fcda1b36b8ae9ffbe88f76d60ab4bc206fd )
+)
+
+game (
+	name "Hangman (19xx)(Elbert van Putten)(nl)"
+	description "Hangman (19xx)(Elbert van Putten)(nl)"
+	rom ( name "Hangman (19xx)(Elbert van Putten)(nl).p" size 5459 crc b22d2688 md5 1eebcebf50a5a610c5ae33def9f5fc3e sha1 10811612121f0ef3c0d252e697a9072b3c035911 )
+)
+
+game (
+	name "Haunted House Adventure (19xx)(-)"
+	description "Haunted House Adventure (19xx)(-)"
+	rom ( name "Haunted House Adventure (19xx)(-).p" size 11100 crc e6cfe562 md5 2d88cd807fbb8387de35065b52d34ead sha1 a256c67191c6d5f2268dcbfd2c832e125b19f055 )
+)
+
+game (
+	name "Haydn (19xx)(-)"
+	description "Haydn (19xx)(-)"
+	rom ( name "Haydn (19xx)(-).p" size 1364 crc 3cdc9e70 md5 d328be8a9185641793702889e2e1e1a8 sha1 53cb52a87883365284740d3c3f217f3dad80f7fb )
+)
+
+game (
+	name "Heli (19xx)(-)"
+	description "Heli (19xx)(-)"
+	rom ( name "Heli (19xx)(-).p" size 2091 crc c3bdc45e md5 4ba6230b29697e30b50b83baca779e5c sha1 e1b0442d1c9225688ed0dec35ad9487b440a6ff4 )
+)
+
+game (
+	name "Hero Maker - Part 1 (1983)(Fontana Publishing)"
+	description "Hero Maker - Part 1 (1983)(Fontana Publishing)"
+	rom ( name "Hero Maker - Part 1 (1983)(Fontana Publishing).p" size 7109 crc f1706965 md5 6f05a33b511abf6bff9bbc4284e54d70 sha1 0fd98c3e308028d375b81aa5e0e059f281c215e5 )
+)
+
+game (
+	name "Hero Maker - Part 2 (1983)(Fontana Publishing)"
+	description "Hero Maker - Part 2 (1983)(Fontana Publishing)"
+	rom ( name "Hero Maker - Part 2 (1983)(Fontana Publishing).p" size 8817 crc 568954d0 md5 722a164f51d0e952947f9d2b39ba3832 sha1 caf7e75ee34cdcf5bc3e6f49c3d8e4ce09ef2382 )
+)
+
+game (
+	name "Hero Maker - Part 3 (1983)(Fontana Publishing)"
+	description "Hero Maker - Part 3 (1983)(Fontana Publishing)"
+	rom ( name "Hero Maker - Part 3 (1983)(Fontana Publishing).p" size 10729 crc d89e21e2 md5 b095dadc89cf3ff6b08464cad74ba7e4 sha1 50ed180de835d7d63482534d708b169546870bf8 )
+)
+
+game (
+	name "HEX Entry (19xx)(-)"
+	description "HEX Entry (19xx)(-)"
+	rom ( name "HEX Entry (19xx)(-).p" size 1404 crc 13d94319 md5 2fe67e083521e88b69116a26255d0077 sha1 6d2d1a7304e53239886947db1558d4bebd7570e6 )
+)
+
+game (
+	name "Hex Look (19xx)(-)"
+	description "Hex Look (19xx)(-)"
+	rom ( name "Hex Look (19xx)(-).p" size 666 crc a1dafd6c md5 2c016971d81849c0f33229eeb2e24b59 sha1 882f56abb103924b0d0da96f12d1bfe82148e1d9 )
+)
+
+game (
+	name "Hi-Res (19xx)(Stefan Heupt)"
+	description "Hi-Res (19xx)(Stefan Heupt)"
+	rom ( name "Hi-Res (19xx)(Stefan Heupt).p" size 2725 crc ace0ca01 md5 d03c94f0af544ce7126813572862b8df sha1 c4212e678a4235cf15cc27cb16e3c813dd1aed9a )
+)
+
+game (
+	name "Hi-Res Invaders (1987)(SMC)"
+	description "Hi-Res Invaders (1987)(SMC)"
+	rom ( name "Hi-Res Invaders (1987)(SMC).p" size 11000 crc a6566572 md5 d018bb60f78caad93f51b2f97fa54233 sha1 a22227d580c8ff703da0df335431d6cd7b82139c )
+)
+
+game (
+	name "Histogram (19xx)(-)"
+	description "Histogram (19xx)(-)"
+	rom ( name "Histogram (19xx)(-).p" size 1917 crc 3ff6dba2 md5 0d67b72eaa358e7fe47ba39ba118c728 sha1 6089bbfa79db93787d2b01865349f0c753e878e2 )
+)
+
+game (
+	name "Hitch-Hiker (1982)(Simon Lane)"
+	description "Hitch-Hiker (1982)(Simon Lane)"
+	rom ( name "Hitch-Hiker (1982)(Simon Lane).p" size 15368 crc 2f016f4d md5 3c6effb1986545f5eb051688f2f54aec sha1 f75cb023eee600227e105d1ede1bb490dabb7633 )
+)
+
+game (
+	name "Hitch-Hiker (1982)(Simon Lane)[a]"
+	description "Hitch-Hiker (1982)(Simon Lane)[a]"
+	rom ( name "Hitch-Hiker (1982)(Simon Lane)[a].p" size 14637 crc 916d676c md5 2088ed4ca80b4c4cd03f5ce8f25dd353 sha1 cf54e00af449e66c3775dac367d06dc81fc50df1 )
+)
+
+game (
+	name "Hoger-Lager (19xx)(Logical Computers)(nl)"
+	description "Hoger-Lager (19xx)(Logical Computers)(nl)"
+	rom ( name "Hoger-Lager (19xx)(Logical Computers)(nl).p" size 1366 crc cd249801 md5 3f8c0afca9383810ef9069f6816257cd sha1 93073061200ae70d878be7889fe585a6c4fd9678 )
+)
+
+game (
+	name "Home Accounts (19xx)(-)"
+	description "Home Accounts (19xx)(-)"
+	rom ( name "Home Accounts (19xx)(-).p" size 7677 crc f22bd63e md5 cf9103145dcd9a7c4444cfa1566b3e81 sha1 76d764b8217837a16b8d2f64604ac212ab00991c )
+)
+
+game (
+	name "Home Finance (19xx)(-)"
+	description "Home Finance (19xx)(-)"
+	rom ( name "Home Finance (19xx)(-).p" size 6425 crc f6204092 md5 3ebc1cbe1e03317d1cfb2e00f244a786 sha1 f0b2837e01a3236ba55d92104a1c8ed370713669 )
+)
+
+game (
+	name "Hopper (19xx)(PSS)"
+	description "Hopper (19xx)(PSS)"
+	rom ( name "Hopper (19xx)(PSS).p" size 10833 crc 550f7d41 md5 696410f069ab8eff0285ac59235ee276 sha1 d50c8627404837a9895b6f7669db48672cfff573 )
+)
+
+game (
+	name "Hopper (19xx)(PSS)[a2]"
+	description "Hopper (19xx)(PSS)[a2]"
+	rom ( name "Hopper (19xx)(PSS)[a2].p" size 10968 crc 131e3af2 md5 8b93f9a1579955b1665a8298cbd08bcc sha1 120f179f02be3fa2c43f8bdf9979c0f70ebc4485 )
+)
+
+game (
+	name "Hopper (19xx)(PSS)[a3]"
+	description "Hopper (19xx)(PSS)[a3]"
+	rom ( name "Hopper (19xx)(PSS)[a3].p" size 3520 crc 003b0c62 md5 d3f72b73059f67f7d203234e2165ee23 sha1 cda1266c4c91566e3fd20e6f36f71e21de61f6d0 )
+)
+
+game (
+	name "Hopper (19xx)(PSS)[a]"
+	description "Hopper (19xx)(PSS)[a]"
+	rom ( name "Hopper (19xx)(PSS)[a].p" size 10833 crc 965d961a md5 f76d900361978e5a354569718c918783 sha1 9e5b1e824f492a88999c023646486a9620e1c89f )
+)
+
+game (
+	name "Horse Race (19xx)(-)(de)"
+	description "Horse Race (19xx)(-)(de)"
+	rom ( name "Horse Race (19xx)(-)(de).p" size 1932 crc 0140f25a md5 9722581dec83be93fcdb77fe8bdfab8e sha1 622237f7723db29b448e30462604fe4c1a1929c1 )
+)
+
+game (
+	name "Hot Pursuit (1983)(Sinclair User)[16K]"
+	description "Hot Pursuit (1983)(Sinclair User)[16K]"
+	rom ( name "Hot Pursuit (1983)(Sinclair User)[16K].p" size 2056 crc a94bd84e md5 0ee7933d8b07f72f914a775f46b1bba6 sha1 a45a33fc123e07e0b664a1072e6841de507a1f8a )
+)
+
+game (
+	name "Hot Z v2.32 Memotech (1983)(Sinware)"
+	description "Hot Z v2.32 Memotech (1983)(Sinware)"
+	rom ( name "Hot Z v2.32 Memotech (1983)(Sinware).p" size 14631 crc 0bb37321 md5 a03a81759428fbac14034c8ae5c5f0df sha1 f14deabd0c40a78376dad6a68d35c1fbbb6fb1ea )
+)
+
+game (
+	name "Hou Ze Gevangen (19xx)(-)(nl)"
+	description "Hou Ze Gevangen (19xx)(-)(nl)"
+	rom ( name "Hou Ze Gevangen (19xx)(-)(nl).p" size 3264 crc 1c85481e md5 9c5ce9d886fc2133cfa6b343a7f4a29e sha1 27aa8f57ee1b7df9bc289fd246f15cede3f04354 )
+)
+
+game (
+	name "Hou Ze Gevangen (19xx)(Logical Computers)(nl)"
+	description "Hou Ze Gevangen (19xx)(Logical Computers)(nl)"
+	rom ( name "Hou Ze Gevangen (19xx)(Logical Computers)(nl).p" size 3403 crc 96112f89 md5 161c94d8736075cc45a72e4759f8dd79 sha1 73f71f34f5497250b41f5436f65ccf544ddd3d24 )
+)
+
+game (
+	name "HRG - Hochaufloesende Grafik fuer ZX-81 (19xx)(-)(de)"
+	description "HRG - Hochaufloesende Grafik fuer ZX-81 (19xx)(-)(de)"
+	rom ( name "HRG - Hochaufloesende Grafik fuer ZX-81 (19xx)(-)(de).p" size 5459 crc ba8ff162 md5 6c9cec59b781418caf4db84cf40fe979 sha1 f728f740e5c244f3568a71603e63e9751abd57ef )
+)
+
+game (
+	name "Hunt the Wumpus (19xx)(-)[m]"
+	description "Hunt the Wumpus (19xx)(-)[m]"
+	rom ( name "Hunt the Wumpus (19xx)(-)[m].p" size 1856 crc 09dc7ad8 md5 e4b10ae268ad926681cefec2015cd879 sha1 d3d3312c6ecaa9a4fe1ea2dcd067259de352e05c )
+)
+
+game (
+	name "Hurkle (19xx)(-)"
+	description "Hurkle (19xx)(-)"
+	rom ( name "Hurkle (19xx)(-).p" size 2340 crc 1acc1d3a md5 d8c91bdf566f9971841b1c0d6719478e sha1 17aad2b9b4866020afc3039a5befd2eae22fa2b1 )
+)
+
+game (
+	name "Hydrocarbons (19xx)(-)"
+	description "Hydrocarbons (19xx)(-)"
+	rom ( name "Hydrocarbons (19xx)(-).p" size 6136 crc 047d4549 md5 17a2d0557f1a225c5d02357158caa6c8 sha1 ac01a8e3e294580b4f73548b64f603a4f7ec1adc )
+)
+
+game (
+	name "Inca Tomb (19xx)(-)"
+	description "Inca Tomb (19xx)(-)"
+	rom ( name "Inca Tomb (19xx)(-).p" size 10850 crc e93ee232 md5 6f56941f4b7581dca9df15a3fbe90024 sha1 e1134fdc959294adfe61fa9aa0b0df64f1a37a6c )
+)
+
+game (
+	name "Index (1982)(Vincent H. Chase)"
+	description "Index (1982)(Vincent H. Chase)"
+	rom ( name "Index (1982)(Vincent H. Chase).p" size 7704 crc 342cfa72 md5 aafe37ab01231cc3c5afc703cfa82e26 sha1 de818ad4081258e75a03bb6d88b9dc795b3fe3d0 )
+)
+
+game (
+	name "Inhaltsverzeichnis (19xx)(-)(de)"
+	description "Inhaltsverzeichnis (19xx)(-)(de)"
+	rom ( name "Inhaltsverzeichnis (19xx)(-)(de).p" size 12814 crc 0ea987c1 md5 8251ba4d9c9b190d23f455ec04db6dcf sha1 6daf81a3179fbd2816149bdce54e0b25d82862d9 )
+)
+
+game (
+	name "Intruder (19xx)(-)"
+	description "Intruder (19xx)(-)"
+	rom ( name "Intruder (19xx)(-).p" size 2854 crc c656b4bb md5 65fb488953e84b82f3ce2308fabea7f9 sha1 a70dda98418f3cbbe8ff08fa7f63ab543721adec )
+)
+
+game (
+	name "Invaders (1982)(Ch. Zwerschke)(de)"
+	description "Invaders (1982)(Ch. Zwerschke)(de)"
+	rom ( name "Invaders (1982)(Ch. Zwerschke)(de).p" size 2130 crc 18f70b80 md5 1d2b46811e725234bbc5ff4aa2223091 sha1 226a23aa8ffcc36abb0fd94270b2beebacd943ec )
+)
+
+game (
+	name "Invaders (1982)(Ch. Zwerschke)(de)[a]"
+	description "Invaders (1982)(Ch. Zwerschke)(de)[a]"
+	rom ( name "Invaders (1982)(Ch. Zwerschke)(de)[a].p" size 2108 crc 1bc14253 md5 e1d4fa442342b7633ddc05bcf9b1ca74 sha1 facd5c0918aa54130fb54a2a59f1b3fc452aa55d )
+)
+
+game (
+	name "Invaders (19xx)(-)"
+	description "Invaders (19xx)(-)"
+	rom ( name "Invaders (19xx)(-).p" size 7548 crc 09b04f9c md5 ba7cbc7c1592d2e199b2c2c57c067811 sha1 9ba98e7e8a7295ac3fce4e4862c0cace21ca6c61 )
+)
+
+game (
+	name "Invaders (19xx)(-)[a]"
+	description "Invaders (19xx)(-)[a]"
+	rom ( name "Invaders (19xx)(-)[a].p" size 7580 crc 775f9ee3 md5 8fea05e0a2e82a7e76bf47305bc4129b sha1 e259400f16153ef00e7a096ff2d56e8e337988be )
+)
+
+game (
+	name "Invaders (19xx)(JMS)"
+	description "Invaders (19xx)(JMS)"
+	rom ( name "Invaders (19xx)(JMS).p" size 4310 crc 98b562de md5 6fe9cf6ff6aaee089112981e3f121989 sha1 292ae192c979b35e14bb2185e0f3272ae56b4394 )
+)
+
+game (
+	name "Invaders (19xx)(JMS)[a2]"
+	description "Invaders (19xx)(JMS)[a2]"
+	rom ( name "Invaders (19xx)(JMS)[a2].p" size 4273 crc 6709a690 md5 572728f377101c98ed9c7b3e1e5cd3da sha1 62b7fcc3513769a03fa3a565ad685aed94693b00 )
+)
+
+game (
+	name "Invaders (19xx)(JMS)[a]"
+	description "Invaders (19xx)(JMS)[a]"
+	rom ( name "Invaders (19xx)(JMS)[a].p" size 4284 crc 1a745cbd md5 5a02106d63020e4cb73cd96c276ee58b sha1 1a93fb5e07d8ced2d2abb5307889a45c5a82de0d )
+)
+
+game (
+	name "Invasion (19xx)(-)(de)"
+	description "Invasion (19xx)(-)(de)"
+	rom ( name "Invasion (19xx)(-)(de).p" size 2874 crc 7de82f7b md5 ae999df9c5b23714362e2e2c589e83b6 sha1 99c811c53ed2f65bb56098a1258c5eaf10ef8653 )
+)
+
+game (
+	name "Invasion Force (1982)(Artic Computing)"
+	description "Invasion Force (1982)(Artic Computing)"
+	rom ( name "Invasion Force (1982)(Artic Computing).p" size 7658 crc 780e3620 md5 ea849815cbe179d1b7cc86ae73b29b53 sha1 9ec62f221684f1a2fb58d05b867128f5b0acea0e )
+)
+
+game (
+	name "Invasion Force (1982)(Artic Computing)[a]"
+	description "Invasion Force (1982)(Artic Computing)[a]"
+	rom ( name "Invasion Force (1982)(Artic Computing)[a].p" size 7692 crc 894b5795 md5 8c6ae2ddf3b27a9fbcc298298b67c245 sha1 605e3c590497bc74082834cbd42277b4783dc045 )
+)
+
+game (
+	name "Inversion (1982)(N.L. Martino)"
+	description "Inversion (1982)(N.L. Martino)"
+	rom ( name "Inversion (1982)(N.L. Martino).p" size 14483 crc 0db0f6bd md5 e3113acb2b27f3005f6ae9b47027eb63 sha1 3899f510016c80eed7e8e9f9eafe01d483667ece )
+)
+
+game (
+	name "Inversion (1982)(N.L. Martino)[a]"
+	description "Inversion (1982)(N.L. Martino)[a]"
+	rom ( name "Inversion (1982)(N.L. Martino)[a].p" size 14486 crc d89c105a md5 812981057a91551c90fe7112ad8b2f1f sha1 3a8554e9090976ccbdfabed3a96d70719ca49d9b )
+)
+
+game (
+	name "Ira (1982)(Vincent H. Chase)"
+	description "Ira (1982)(Vincent H. Chase)"
+	rom ( name "Ira (1982)(Vincent H. Chase).p" size 8254 crc 21976d0c md5 d0e6b42501d884f96339da99c279eb2f sha1 f8f0e825f0aa874350c08dc7b9e6cb6630cd3a97 )
+)
+
+game (
+	name "Ira Programm (1982)(Vincent C. Chase)"
+	description "Ira Programm (1982)(Vincent C. Chase)"
+	rom ( name "Ira Programm (1982)(Vincent C. Chase).p" size 8298 crc 3a175347 md5 9d79a2f3476582417e2b1c5d8e1e8fc3 sha1 0b7760124a469647e7144477ded5d40c0bcfe0e8 )
+)
+
+game (
+	name "Irrgarten (19xx)(-)(de)"
+	description "Irrgarten (19xx)(-)(de)"
+	rom ( name "Irrgarten (19xx)(-)(de).p" size 1524 crc 42e84ec6 md5 1d8c22bd1a6a1ba07f289e1d93b906f1 sha1 4da474badd2195175016f6de863667fc76d862f3 )
+)
+
+game (
+	name "Irrgarten (19xx)(Ch. Zwerschke)(de)"
+	description "Irrgarten (19xx)(Ch. Zwerschke)(de)"
+	rom ( name "Irrgarten (19xx)(Ch. Zwerschke)(de).p" size 5618 crc 167038a5 md5 4ac822831b32eebece36654c2d825e0a sha1 3b36bedb0a756a28928abd2e0e0f4b17793caf1c )
+)
+
+game (
+	name "Irrgarten (19xx)(Ch. Zwerschke)(de)[a]"
+	description "Irrgarten (19xx)(Ch. Zwerschke)(de)[a]"
+	rom ( name "Irrgarten (19xx)(Ch. Zwerschke)(de)[a].p" size 5596 crc ee17964a md5 c7d7e8065a0b303df6589b236e7f6979 sha1 853816f2b938f952c9eae97cc307bee26480f7d3 )
+)
+
+game (
+	name "Island Kingdom (1982)(American Micro Products)"
+	description "Island Kingdom (1982)(American Micro Products)"
+	rom ( name "Island Kingdom (1982)(American Micro Products).p" size 13164 crc 14bee768 md5 dbfcceaf05dcccaea5a43dd97747668a sha1 8eafcd05ceb3d5934de3c89b4b7eb3778e9ecbc4 )
+)
+
+game (
+	name "Julia Sets (1987)(Fred Nachbaur)"
+	description "Julia Sets (1987)(Fred Nachbaur)"
+	rom ( name "Julia Sets (1987)(Fred Nachbaur).p" size 14209 crc c556b084 md5 e96ab74436dfa4be1716099b5883a828 sha1 ed7a13b892358e048654f24b53bdc51365fc162e )
+)
+
+game (
+	name "Jump (19xx)(H. Stamm)(de)"
+	description "Jump (19xx)(H. Stamm)(de)"
+	rom ( name "Jump (19xx)(H. Stamm)(de).p" size 4888 crc fc9f612c md5 581b69b6439b46c7f088dd0bb7ec0fd0 sha1 ed4f4e6f32dba0ee375494d24d9449950dfd006d )
+)
+
+game (
+	name "Jump (19xx)(H. Stamm)(de)[a]"
+	description "Jump (19xx)(H. Stamm)(de)[a]"
+	rom ( name "Jump (19xx)(H. Stamm)(de)[a].p" size 4866 crc f9e79aed md5 fb8748fb0a96b46ce3764d32a7986a4a sha1 06cc61177add76a95f478c2e1c18cefc765eb52f )
+)
+
+game (
+	name "Kalabriasz (19xx)(-)"
+	description "Kalabriasz (19xx)(-)"
+	rom ( name "Kalabriasz (19xx)(-).p" size 13472 crc 1c880471 md5 a655a448072cbc26b515b16f6009795b sha1 b698feba661d67009384f1109bb948a7d8d1c516 )
+)
+
+game (
+	name "Kaleidoscope (19xx)(-)"
+	description "Kaleidoscope (19xx)(-)"
+	rom ( name "Kaleidoscope (19xx)(-).p" size 1184 crc b1f89a3e md5 c98dea8e8ab59f08a5ad900eeaaf74ad sha1 3d7739574ce55d94a7ce97b574cc5ee6eba8541f )
+)
+
+game (
+	name "Kamel (19xx)(Creative Computing)(de)"
+	description "Kamel (19xx)(Creative Computing)(de)"
+	rom ( name "Kamel (19xx)(Creative Computing)(de).p" size 8414 crc 7466782c md5 ab73d055e6ca2beea663edb055184ad1 sha1 3cf594acfa1477a3aeeba2e7c2058b563af302d1 )
+)
+
+game (
+	name "Kamel (19xx)(Creative Computing)(de)[a]"
+	description "Kamel (19xx)(Creative Computing)(de)[a]"
+	rom ( name "Kamel (19xx)(Creative Computing)(de)[a].p" size 8385 crc 7e7147b1 md5 678ca06c41b76e0d524d3c24f33e4940 sha1 1db3aba87768fd39e153e16d38b12011e947de06 )
+)
+
+game (
+	name "Kaufhaus (19xx)(-)"
+	description "Kaufhaus (19xx)(-)"
+	rom ( name "Kaufhaus (19xx)(-).p" size 1318 crc 2372836d md5 15c7b7b898b3a16799956626ba54f77e sha1 096b4070d67cbd0e0b1aab8271b8de2128f05624 )
+)
+
+game (
+	name "Kegeln (19xx)(-)(nl)"
+	description "Kegeln (19xx)(-)(nl)"
+	rom ( name "Kegeln (19xx)(-)(nl).p" size 5800 crc f1d5411e md5 472f333c207e4f331b02a95f0f399f6e sha1 d9d300bfcc65da95f7bab7b149ede0401896920e )
+)
+
+game (
+	name "Keyboard Read Test (19xx)(-)"
+	description "Keyboard Read Test (19xx)(-)"
+	rom ( name "Keyboard Read Test (19xx)(-).p" size 1031 crc 4dbf4f17 md5 fa76cbdab553dcee84562081d1d80f35 sha1 f03a37c50f101f44cb586cb7ab5448fdebe6a513 )
+)
+
+game (
+	name "Keyboard Sound (19xx)(-)"
+	description "Keyboard Sound (19xx)(-)"
+	rom ( name "Keyboard Sound (19xx)(-).p" size 1133 crc fe264e80 md5 610150b89f0ad567f4be28bfdffe5456 sha1 e50b6669651230b0ba41145d2a1cef420f557920 )
+)
+
+game (
+	name "Kimcalc (19xx)(-)"
+	description "Kimcalc (19xx)(-)"
+	rom ( name "Kimcalc (19xx)(-).p" size 7084 crc 8b662f5b md5 1062a7fb35faecbc84716dfe8b7aabfc sha1 00bb96abd41e0b3e49bb932ca72c1841c9c21981 )
+)
+
+game (
+	name "Kinetisches Gasmodell (1983)(Ch. Zwerschke)(de)"
+	description "Kinetisches Gasmodell (1983)(Ch. Zwerschke)(de)"
+	rom ( name "Kinetisches Gasmodell (1983)(Ch. Zwerschke)(de).p" size 1542 crc 274a7dbc md5 89b0077c6c394444b28e5e942d09f22e sha1 47935a44c974ba9ccd05807751b77d633a70e623 )
+)
+
+game (
+	name "Kinetisches Gasmodell (1983)(Ch. Zwerschke)(de)[a]"
+	description "Kinetisches Gasmodell (1983)(Ch. Zwerschke)(de)[a]"
+	rom ( name "Kinetisches Gasmodell (1983)(Ch. Zwerschke)(de)[a].p" size 1519 crc 5c80c892 md5 0137339ac8b038f16de039b024934ab7 sha1 9e474e575c366c24e6661114c4983f4446f2526e )
+)
+
+game (
+	name "Kleurcode Weerstanden (19xx)(-)(nl)"
+	description "Kleurcode Weerstanden (19xx)(-)(nl)"
+	rom ( name "Kleurcode Weerstanden (19xx)(-)(nl).p" size 4315 crc 88ad9b2a md5 01c55f4654b0bb7f888cc40630776acb sha1 a3ea8303105593af8ee24dda7043a968c7f997a7 )
+)
+
+game (
+	name "Klok (19xx)(-)(nl)"
+	description "Klok (19xx)(-)(nl)"
+	rom ( name "Klok (19xx)(-)(nl).p" size 1347 crc 1a5a6bab md5 2583833f0ed4227b78f8105d205cd7b8 sha1 7cef7d7cc99cdbad18cabbcd564c83a5f7f7ae46 )
+)
+
+game (
+	name "Knights Quest, The (1983)(Phipps Associates)(Part 1 of 3)"
+	description "Knights Quest, The (1983)(Phipps Associates)(Part 1 of 3)"
+	rom ( name "Knights Quest, The (1983)(Phipps Associates)(Part 1 of 3).p" size 16216 crc 697b0621 md5 a67c1e898d109b3b53fcaf749b0b1b72 sha1 fb862ea0dac6fd26e43366a4ec6dd93910dca9d9 )
+)
+
+game (
+	name "Knights Quest, The (1983)(Phipps Associates)(Part 1 of 3)[GOTO 20]"
+	description "Knights Quest, The (1983)(Phipps Associates)(Part 1 of 3)[GOTO 20]"
+	rom ( name "Knights Quest, The (1983)(Phipps Associates)(Part 1 of 3)[GOTO 20].p" size 16250 crc 5ec39c29 md5 a6c8b324ce3e7ec6def874544f2cdfe9 sha1 c55d5affab9bdfd899530b3cc254024919d99fcb )
+)
+
+game (
+	name "Knights Quest, The (1983)(Phipps Associates)(Part 2 of 3)"
+	description "Knights Quest, The (1983)(Phipps Associates)(Part 2 of 3)"
+	rom ( name "Knights Quest, The (1983)(Phipps Associates)(Part 2 of 3).p" size 16156 crc 640d46ca md5 c5bd185af3c739f94853a0f54169f907 sha1 b9b2b9afccac8aa2d298b8ca77bae9a06f8d4fa3 )
+)
+
+game (
+	name "Knights Quest, The (1983)(Phipps Associates)(Part 2 of 3)[GOTO 20]"
+	description "Knights Quest, The (1983)(Phipps Associates)(Part 2 of 3)[GOTO 20]"
+	rom ( name "Knights Quest, The (1983)(Phipps Associates)(Part 2 of 3)[GOTO 20].p" size 16192 crc 92de49ac md5 b37c332ac955d83bb1eba0fcfb9597be sha1 e8138b733fdff9ef7afa0e9e8cf500c3b5543c2d )
+)
+
+game (
+	name "Knights Quest, The (1983)(Phipps Associates)(Part 3 of 3)"
+	description "Knights Quest, The (1983)(Phipps Associates)(Part 3 of 3)"
+	rom ( name "Knights Quest, The (1983)(Phipps Associates)(Part 3 of 3).p" size 16095 crc ee28c7ef md5 6d2510c85f5232b59b3b5efd588f3f97 sha1 d76b64e64aa6d36a09b4de6c23fac919216592d1 )
+)
+
+game (
+	name "Knights Quest, The (1983)(Phipps Associates)(Part 3 of 3)[GOTO 20]"
+	description "Knights Quest, The (1983)(Phipps Associates)(Part 3 of 3)[GOTO 20]"
+	rom ( name "Knights Quest, The (1983)(Phipps Associates)(Part 3 of 3)[GOTO 20].p" size 16130 crc 769068d2 md5 e6edb87f964174a30009498e5481f1bf sha1 e6322b1984e24c428f6f03b40a4b9f116fa81c4a )
+)
+
+game (
+	name "Knights Quest, The - Intro (1983)(Phipps Associates)"
+	description "Knights Quest, The - Intro (1983)(Phipps Associates)"
+	rom ( name "Knights Quest, The - Intro (1983)(Phipps Associates).p" size 3849 crc 714d0d4e md5 c8360edeb29989e648a05da5e053d228 sha1 a4c08a03a065f829f6abe6f16453c573dffca77e )
+)
+
+game (
+	name "Knikkers (19xx)(W. Bos)(nl)"
+	description "Knikkers (19xx)(W. Bos)(nl)"
+	rom ( name "Knikkers (19xx)(W. Bos)(nl).p" size 4069 crc 3d532bec md5 144d28fb6ee2b85a339b579104ecfa67 sha1 f13d4b51deabde854a3725151cb3c2ff105fc24c )
+)
+
+game (
+	name "Knippe Routine (19xx)(-)(nl)"
+	description "Knippe Routine (19xx)(-)(nl)"
+	rom ( name "Knippe Routine (19xx)(-)(nl).p" size 1653 crc 4eedf11a md5 8c79cb005e6bc4d03da960b278a30bec sha1 8790630e4fef457f178bbdde4b6616ec01cd602f )
+)
+
+game (
+	name "Knoop (19xx)(-)(nl)"
+	description "Knoop (19xx)(-)(nl)"
+	rom ( name "Knoop (19xx)(-)(nl).p" size 2863 crc 38812def md5 48d4422ba5ead03049f297dcf68c0d8d sha1 8eb53551eb99abcc5035cde91594c48919bdd05c )
+)
+
+game (
+	name "Kolenmijn - Verkorte Spelregels (1983)(Kluwer Technische Boeken)(nl)"
+	description "Kolenmijn - Verkorte Spelregels (1983)(Kluwer Technische Boeken)(nl)"
+	rom ( name "Kolenmijn - Verkorte Spelregels (1983)(Kluwer Technische Boeken)(nl).p" size 10945 crc db792eb4 md5 4abb6a06f97785b5455cf04082527aa9 sha1 ebb2de6d26eca39cebfb0c5116a168b3ed396ccb )
+)
+
+game (
+	name "Kolenmijn - Verkorte Spelregels (1983)(Kluwer Technische Boeken)(nl)[a]"
+	description "Kolenmijn - Verkorte Spelregels (1983)(Kluwer Technische Boeken)(nl)[a]"
+	rom ( name "Kolenmijn - Verkorte Spelregels (1983)(Kluwer Technische Boeken)(nl)[a].p" size 10772 crc a7ada9aa md5 793af2d9ce28e686f4bf7a9ed7ff7e05 sha1 9a8581666b15b9ce3957ba77a93e3a00cfce0340 )
+)
+
+game (
+	name "Kong (1983)(Sinclair User)"
+	description "Kong (1983)(Sinclair User)"
+	rom ( name "Kong (1983)(Sinclair User).p" size 1697 crc 15926328 md5 ca34d3920cbde094d7af2faea9e9a8f2 sha1 99ae93aa1eeca4bb1e064e5470f5aa6fe36a5400 )
+)
+
+game (
+	name "Kosten (19xx)(-)(nl)"
+	description "Kosten (19xx)(-)(nl)"
+	rom ( name "Kosten (19xx)(-)(nl).p" size 10638 crc 1e1738a9 md5 ddf717a0545b1ec1e55ce287db23c06b sha1 9040fb00426850a9fc7f7a3f6eadbc3e1c25cb5e )
+)
+
+game (
+	name "Krazy Kong (19xx)(Herosoft)"
+	description "Krazy Kong (19xx)(Herosoft)"
+	rom ( name "Krazy Kong (19xx)(Herosoft).p" size 8260 crc 9b2e836c md5 1628847a21d5ce776bd25cb123800f6a sha1 14c3f5f9470a383f7148599a9a317ba19f14387d )
+)
+
+game (
+	name "Krazy Kong (19xx)(PSS)"
+	description "Krazy Kong (19xx)(PSS)"
+	rom ( name "Krazy Kong (19xx)(PSS).p" size 8250 crc 892ff2bb md5 a1a6d48c6ccf0023f9cbe8cf3a5ab17e sha1 ee6dd1bdb6245f24fbeb478a408369a27f47e4a8 )
+)
+
+game (
+	name "Krazy Kong (19xx)(PSS)[a2]"
+	description "Krazy Kong (19xx)(PSS)[a2]"
+	rom ( name "Krazy Kong (19xx)(PSS)[a2].p" size 8241 crc 82e37287 md5 67d6145d87e44cc41237ff19e90468ae sha1 c5a294b925d643b37bc0b86a429fd577bae580d6 )
+)
+
+game (
+	name "Krazy Kong (19xx)(PSS)[a]"
+	description "Krazy Kong (19xx)(PSS)[a]"
+	rom ( name "Krazy Kong (19xx)(PSS)[a].p" size 8238 crc 59b1f51a md5 c7da694922d709cf14835f7de215a54c sha1 849be357e4cab0092899eb23c05844c92542e380 )
+)
+
+game (
+	name "Kruemelmonster (19xx)(-)(de)"
+	description "Kruemelmonster (19xx)(-)(de)"
+	rom ( name "Kruemelmonster (19xx)(-)(de).p" size 1770 crc 5abef900 md5 0352d24153b427e5076adf2f81973ddb sha1 d27de97edcf076864459c24cd425eff047aecd80 )
+)
+
+game (
+	name "Kruncher, The (1986)(S+K Enterprises)"
+	description "Kruncher, The (1986)(S+K Enterprises)"
+	rom ( name "Kruncher, The (1986)(S+K Enterprises).p" size 2718 crc 0bc86740 md5 52665bb01da5f5159b3bc6d430a3a042 sha1 c29450781bcb49d83a9d3f32cac876d92d60e84a )
+)
+
+game (
+	name "Kunst (19xx)(-)(nl)"
+	description "Kunst (19xx)(-)(nl)"
+	rom ( name "Kunst (19xx)(-)(nl).p" size 1647 crc b5fe2a25 md5 b9e1095cd0f834e0d02204142db6fb6c sha1 ff387cea6027bd9a31cdf3139f851efccb0bebd4 )
+)
+
+game (
+	name "L-Systems (1987)(Gregory C. Harder)"
+	description "L-Systems (1987)(Gregory C. Harder)"
+	rom ( name "L-Systems (1987)(Gregory C. Harder).p" size 9799 crc 56771958 md5 b1d92497b931c2f4cacad160eab559a4 sha1 a12f7c8f8e808c585d5bac69d402d58b05dbf2de )
+)
+
+game (
+	name "Landscape (1982)(G. Owen)"
+	description "Landscape (1982)(G. Owen)"
+	rom ( name "Landscape (1982)(G. Owen).p" size 3404 crc d4b42ce5 md5 a27076682a8f79f3e6a4a502fddb8634 sha1 5e7a6b92fcd593d0d0127d759717755100233b9a )
+)
+
+game (
+	name "Landscape (1982)(G. Owen)[a]"
+	description "Landscape (1982)(G. Owen)[a]"
+	rom ( name "Landscape (1982)(G. Owen)[a].p" size 3341 crc baed7474 md5 3753198f2d0a0ae907b7584ed895e22e sha1 c05d7dab6dd914da14135475854982ca1937d447 )
+)
+
+game (
+	name "Laser Bases (19xx)(-)"
+	description "Laser Bases (19xx)(-)"
+	rom ( name "Laser Bases (19xx)(-).p" size 8834 crc 450f33c0 md5 4c20a3bb70e50b07159439e645cd1563 sha1 8f6ce1dddf596e7d12b19192241821497dcfbf3c )
+)
+
+game (
+	name "Laser Duel (19xx)(-)"
+	description "Laser Duel (19xx)(-)"
+	rom ( name "Laser Duel (19xx)(-).p" size 3386 crc a6cdc8bf md5 1cc56e5311c58eba7eb267a1271fe135 sha1 334d5bf920ac604a7d5d247ce8155c6c00d4e985 )
+)
+
+game (
+	name "Lawine (19xx)(A. Reuter)"
+	description "Lawine (19xx)(A. Reuter)"
+	rom ( name "Lawine (19xx)(A. Reuter).p" size 2940 crc 2829ac34 md5 1148c14ff826e6c59c2e7106deebf036 sha1 5ff6461a89a8a1d522c52b97f7fa477ff3123167 )
+)
+
+game (
+	name "Le Mans (19xx)(-)"
+	description "Le Mans (19xx)(-)"
+	rom ( name "Le Mans (19xx)(-).p" size 2806 crc 795f259e md5 60fcf0a7ae59bd18ad9f167c42cad6f0 sha1 c00460197e615147c5e9e259e6d46c6c8556d4f7 )
+)
+
+game (
+	name "Learning Lab Starters (19xx)(-)"
+	description "Learning Lab Starters (19xx)(-)"
+	rom ( name "Learning Lab Starters (19xx)(-).p" size 2960 crc 076fa4e8 md5 03f476cb7e95c1cd3ea5b4af323d4be3 sha1 cba7b6049338f8b8c536a9365a7ef0f214b508d5 )
+)
+
+game (
+	name "Lichtkrant (1984)(MVS)(nl)"
+	description "Lichtkrant (1984)(MVS)(nl)"
+	rom ( name "Lichtkrant (1984)(MVS)(nl).p" size 1795 crc 33027c0e md5 33bce123108e55e49eed667e74820867 sha1 2444672bf7e7bd36b4654865ab562756fda4ef75 )
+)
+
+game (
+	name "Life (19xx)(-)"
+	description "Life (19xx)(-)"
+	rom ( name "Life (19xx)(-).p" size 3888 crc 5b0efb91 md5 42bb07326766c75b9ac969e0383a3467 sha1 c3cca00fa03b51412073e76c0aaea6d8024f055c )
+)
+
+game (
+	name "Life (19xx)(-)(de)"
+	description "Life (19xx)(-)(de)"
+	rom ( name "Life (19xx)(-)(de).p" size 3632 crc b5264c36 md5 8a393e14ca1d3a0d8f1b38b5634aebed sha1 eae5c285aec5076cdce540a5a15ad58bb4e0a410 )
+)
+
+game (
+	name "Life (19xx)(-)(de)[a]"
+	description "Life (19xx)(-)(de)[a]"
+	rom ( name "Life (19xx)(-)(de)[a].p" size 3610 crc 4108277d md5 cfe585d5e16f9fedbfca4498f007627e sha1 e1219ce78d6322cde1ef07f12052178a3bb44d72 )
+)
+
+game (
+	name "Life (19xx)(-)(nl)"
+	description "Life (19xx)(-)(nl)"
+	rom ( name "Life (19xx)(-)(nl).p" size 6481 crc 79a2fdff md5 97be14ed863ed1279ed0914fc10a78df sha1 8c5b18c658e26666f43f67d1f2b25d49adc5ff56 )
+)
+
+game (
+	name "Life (19xx)(J.R. Ball)"
+	description "Life (19xx)(J.R. Ball)"
+	rom ( name "Life (19xx)(J.R. Ball).p" size 2976 crc 43aca2d2 md5 c40545dfd29477a75980071cd9061c6f sha1 8c5f20194c89b2e0c3654abf2bdc24219431ed06 )
+)
+
+game (
+	name "Life Expectancy (19xx)(-)"
+	description "Life Expectancy (19xx)(-)"
+	rom ( name "Life Expectancy (19xx)(-).p" size 5728 crc 0cc1629d md5 bfc6cceb01555b5dd42ff3bc33d4fa58 sha1 0800c9560704cf65840d4d3bdc10c44b2f8cd54d )
+)
+
+game (
+	name "Life Mit Plot (19xx)(-)[16K]"
+	description "Life Mit Plot (19xx)(-)[16K]"
+	rom ( name "Life Mit Plot (19xx)(-)[16K].p" size 3186 crc 0f075336 md5 43f4f6887fc03d9c1a2ab7f047177692 sha1 2b9a39b8dfe73d7c8b3cf116e2cc2661f42e2089 )
+)
+
+game (
+	name "Lijnen Tekenen Met Behulp van de Formule y=ax+b (19xx)(-)(nl)"
+	description "Lijnen Tekenen Met Behulp van de Formule y=ax+b (19xx)(-)(nl)"
+	rom ( name "Lijnen Tekenen Met Behulp van de Formule y=ax+b (19xx)(-)(nl).p" size 1908 crc 8ec55dd7 md5 ab45463b25dc9e2d1b54c8cc92654bd6 sha1 0e3c425fd4b8fbb58ff2e3b0a4e6f36edb13d30f )
+)
+
+game (
+	name "Lineaire Hypotheek (19xx)(Teleac BV)(nl)"
+	description "Lineaire Hypotheek (19xx)(Teleac BV)(nl)"
+	rom ( name "Lineaire Hypotheek (19xx)(Teleac BV)(nl).p" size 8220 crc 3f44063f md5 b2bc71c8c9fda3bc88b9778f4d7a445d sha1 4b53b3f668dcaa91cc448002b542ec59604a3b41 )
+)
+
+game (
+	name "Linette (19xx)(-)"
+	description "Linette (19xx)(-)"
+	rom ( name "Linette (19xx)(-).p" size 1783 crc 97c72fab md5 66ebdda57278c3459394f6866b6fe5fd sha1 113bac39a563f13614b0cca2eb4eb3992e12904e )
+)
+
+game (
+	name "Lissajous (19xx)(-)"
+	description "Lissajous (19xx)(-)"
+	rom ( name "Lissajous (19xx)(-).p" size 1133 crc 9e577366 md5 83f5ca35c191b29045c641ad7741d267 sha1 1f9906d35fc06a8012708c646eae5db3cfc686ba )
+)
+
+game (
+	name "Little Brick Out (1982)(Ch. Zwerschke)"
+	description "Little Brick Out (1982)(Ch. Zwerschke)"
+	rom ( name "Little Brick Out (1982)(Ch. Zwerschke).p" size 2481 crc 9fd71b4b md5 f336f7b0a4ddf4cdd12aa73a8ce31138 sha1 0688df4866e96c8c78aebd0f9ab040d09006c29c )
+)
+
+game (
+	name "Little Brick Out (1982)(Ch. Zwerschke)[a]"
+	description "Little Brick Out (1982)(Ch. Zwerschke)[a]"
+	rom ( name "Little Brick Out (1982)(Ch. Zwerschke)[a].p" size 2460 crc 11d84076 md5 f57687bacd83fffe6447841061ddd881 sha1 48a40089cc54f7e4bfb4fd7300768c1ee2297e83 )
+)
+
+game (
+	name "Little Invaders (19xx)(-)"
+	description "Little Invaders (19xx)(-)"
+	rom ( name "Little Invaders (19xx)(-).p" size 2380 crc 5944dc61 md5 0b957aa626cc90bb424934fc2efee51f sha1 e6e98b1b795d20f106a967e5aad3e38a1907f4d9 )
+)
+
+game (
+	name "Loader (19xx)(-)"
+	description "Loader (19xx)(-)"
+	rom ( name "Loader (19xx)(-).p" size 1214 crc 6001c8e3 md5 9cba7471e732e7891ba805402609ce11 sha1 9408cdb7a70e4cd4e2fb61ca42deeed1e376587a )
+)
+
+game (
+	name "Loader (19xx)(-)[a]"
+	description "Loader (19xx)(-)[a]"
+	rom ( name "Loader (19xx)(-)[a].p" size 1068 crc fb65164c md5 7390c09eabe6cd9344ae225644d90e99 sha1 4ded4980cd247a2bec4a489f7d6c2ba8adab4dd7 )
+)
+
+game (
+	name "Loans (19xx)(-)"
+	description "Loans (19xx)(-)"
+	rom ( name "Loans (19xx)(-).p" size 1834 crc a82096b5 md5 ddb4ad96e9d164962513e22ce6f0223e sha1 1731514aee7a5692d224b1006c64e02b131c4835 )
+)
+
+game (
+	name "Lock Breaker (19xx)(-)"
+	description "Lock Breaker (19xx)(-)"
+	rom ( name "Lock Breaker (19xx)(-).p" size 1129 crc 9f486fdc md5 8e4481eff9d8dda6cc52ed566fdcd190 sha1 e53e1398efc592cfaae42a701e13cde1235408d4 )
+)
+
+game (
+	name "Long Multiplication Sums (19xx)(-)"
+	description "Long Multiplication Sums (19xx)(-)"
+	rom ( name "Long Multiplication Sums (19xx)(-).p" size 3979 crc d19b194e md5 7bbd6130438b46f8815b64d804bd127b sha1 143fbbb963852dd50f852675f79c4060c4bcf862 )
+)
+
+game (
+	name "Looper (19xx)(-)"
+	description "Looper (19xx)(-)"
+	rom ( name "Looper (19xx)(-).p" size 1016 crc 9b4ef6bc md5 99d2aa2cdba5ea561cb54afaed150b19 sha1 f78bb53b781a2ca80b30106d82d70df43683df90 )
+)
+
+game (
+	name "Looptekst (19xx)(-)(nl)"
+	description "Looptekst (19xx)(-)(nl)"
+	rom ( name "Looptekst (19xx)(-)(nl).p" size 6237 crc 55c116cd md5 647a84aece00add5abe3870359abd3be sha1 3cd834942a70a006ce0b73e1fdc6b04c377026c7 )
+)
+
+game (
+	name "Loopy Zoo (1983)(Peter Davis)[m David Buttery]"
+	description "Loopy Zoo (1983)(Peter Davis)[m David Buttery]"
+	rom ( name "Loopy Zoo (1983)(Peter Davis)[m David Buttery].p" size 1659 crc c7acf50f md5 0e338e485ef9f46ae926a03ecd704885 sha1 03598cc33dedd2593b0254d781dc21f9a429e61d )
+)
+
+game (
+	name "Lucky Jackpot (1981)(Artic Computing)"
+	description "Lucky Jackpot (1981)(Artic Computing)"
+	rom ( name "Lucky Jackpot (1981)(Artic Computing).p" size 752 crc d312933b md5 4fa3161d46a42aee6773f9639b1cc08c sha1 ea6955bbeede06ed53adf1c908068980a7995b75 )
+)
+
+game (
+	name "Luftwaffe (1984)(Sinclair User)[16K]"
+	description "Luftwaffe (1984)(Sinclair User)[16K]"
+	rom ( name "Luftwaffe (1984)(Sinclair User)[16K].p" size 5384 crc 12420bf2 md5 a8263013f5aa07c62907cda891002297 sha1 18bb3a7c76992f246195dd39ee17551ad64c78ce )
+)
+
+game (
+	name "Luna (19xx)(-)(de)"
+	description "Luna (19xx)(-)(de)"
+	rom ( name "Luna (19xx)(-)(de).p" size 5483 crc 4f2672c1 md5 012298edde6b78c9ccb80374a92ee5b2 sha1 602b48fe335fdb5f7987bd5891fba0aa0569e9d5 )
+)
+
+game (
+	name "Lunar Lander (1981)(E.E. Tozer)"
+	description "Lunar Lander (1981)(E.E. Tozer)"
+	rom ( name "Lunar Lander (1981)(E.E. Tozer).p" size 7487 crc cc6cd832 md5 10a351935773949d9ada6c5d1d07b949 sha1 578b15ccc250ec32ce42164112f583192a21e85f )
+)
+
+game (
+	name "Lunar Lander (19xx)(-)"
+	description "Lunar Lander (19xx)(-)"
+	rom ( name "Lunar Lander (19xx)(-).p" size 2041 crc 92b0ca96 md5 031769b8d0f63b919d4484f8e7f7313f sha1 233f8bf10519e6ebd8ef1acdd9b2da7ab17f5ce2 )
+)
+
+game (
+	name "Lunar Rescue (1982)(Kevin J. Bezant)"
+	description "Lunar Rescue (1982)(Kevin J. Bezant)"
+	rom ( name "Lunar Rescue (1982)(Kevin J. Bezant).p" size 4688 crc 210dfcf5 md5 87d0ac15a90c273be89372e127ef798d sha1 ffeb00f67d158763adc82be9132406b927287ece )
+)
+
+game (
+	name "Lunar Rescue (19xx)(-)"
+	description "Lunar Rescue (19xx)(-)"
+	rom ( name "Lunar Rescue (19xx)(-).p" size 3780 crc 318a6490 md5 32088448fd7bdc83b91ece14e99f374b sha1 b3df54f8a2ee85a251bdcc9297484481552acb65 )
+)
+
+game (
+	name "Lunar Rescue (19xx)(-)[a]"
+	description "Lunar Rescue (19xx)(-)[a]"
+	rom ( name "Lunar Rescue (19xx)(-)[a].p" size 3814 crc 0a2ffc4e md5 5cd31aac53d8daabb6bad459d4a7e15e sha1 29202419158c85e6d054d728b53a973d7ede527b )
+)
+
+game (
+	name "Luner (1982)(P. du Plessis)"
+	description "Luner (1982)(P. du Plessis)"
+	rom ( name "Luner (1982)(P. du Plessis).p" size 7437 crc 031543db md5 7c9467db3986d3d078ffb06ba510ebf5 sha1 bdbfb95fe96658eab08d8bcc58a4ae7cf520e2bf )
+)
+
+game (
+	name "Maanlander (1982)(Kluwer Technische Boeken)(nl)"
+	description "Maanlander (1982)(Kluwer Technische Boeken)(nl)"
+	rom ( name "Maanlander (1982)(Kluwer Technische Boeken)(nl).p" size 4362 crc 25ecabe9 md5 a1f4e6b44c12b3937055f7698ea56283 sha1 f868549c6309227eb9268cf1809fe132e584af45 )
+)
+
+game (
+	name "Machine Code City (19xx)(-)(nl)"
+	description "Machine Code City (19xx)(-)(nl)"
+	rom ( name "Machine Code City (19xx)(-)(nl).p" size 3489 crc dbff38bd md5 7aef4726e8995fb5e13ee7bdd9f301ca sha1 ca2c0183554331e8a97c5a2d3ef5c9e9c5fd91ed )
+)
+
+game (
+	name "Machine Code City (19xx)(-)(nl)[a]"
+	description "Machine Code City (19xx)(-)(nl)[a]"
+	rom ( name "Machine Code City (19xx)(-)(nl)[a].p" size 4743 crc 2c3fe0a4 md5 af9e6e2c2356a7b2006e4b1f38e0b1be sha1 e142abf9797e560c5ce8acd4cbeab8d61a64f6ed )
+)
+
+game (
+	name "Machine Code RANDOM (19xx)(-)(nl)"
+	description "Machine Code RANDOM (19xx)(-)(nl)"
+	rom ( name "Machine Code RANDOM (19xx)(-)(nl).p" size 2052 crc 41903de3 md5 f379f1736831cefc25da88f1597e9e54 sha1 8bcd55f33dcb4fb94eddff42deec8a745dc5c060 )
+)
+
+game (
+	name "Macro-Life (1986)(Gregory C. Harder)[16K]"
+	description "Macro-Life (1986)(Gregory C. Harder)[16K]"
+	rom ( name "Macro-Life (1986)(Gregory C. Harder)[16K].p" size 7919 crc f55506c0 md5 490534dd9b8a73fb62be44072e91aa54 sha1 2d6c1903cb48326ee18ed7253d2d475a07991472 )
+)
+
+game (
+	name "Macro-Life (1986)(Gregory C. Harder)[32K]"
+	description "Macro-Life (1986)(Gregory C. Harder)[32K]"
+	rom ( name "Macro-Life (1986)(Gregory C. Harder)[32K].p" size 8826 crc 9f685226 md5 77f776fe46c6c1af5b8048c73a56f17a sha1 08acda774d9b7dbdd6c80aaecc098c4476e5389d )
+)
+
+game (
+	name "Mad Miner (19xx)(-)"
+	description "Mad Miner (19xx)(-)"
+	rom ( name "Mad Miner (19xx)(-).p" size 5489 crc c9f47076 md5 2548e375fe5f193496cf6dbc4ffcb03c sha1 b7d7883f92161819cb511fe351260acaf13feab5 )
+)
+
+game (
+	name "Mad Miner (19xx)(-)[a]"
+	description "Mad Miner (19xx)(-)[a]"
+	rom ( name "Mad Miner (19xx)(-)[a].p" size 5144 crc a073a508 md5 91a3949ecf53f1209f7c6025c7097ec4 sha1 71b80c1cab1e56e54224cb9458ea54b150b1a32e )
+)
+
+game (
+	name "Madjump 2 (19xx)(-)(nl)"
+	description "Madjump 2 (19xx)(-)(nl)"
+	rom ( name "Madjump 2 (19xx)(-)(nl).p" size 3656 crc 7bf91fb8 md5 a81ce3ec82f687cd7c943e409972a90a sha1 13a7d896154b401419246c05de1c73eb0659bba8 )
+)
+
+game (
+	name "Magic Mountain (1982)(Phipps Associates)"
+	description "Magic Mountain (1982)(Phipps Associates)"
+	rom ( name "Magic Mountain (1982)(Phipps Associates).p" size 15702 crc 84dc65ce md5 c919b633a4a4da3a079ed4a51bb07213 sha1 fe5451ba5fe1203ee68d9f483b1a2afa521e449e )
+)
+
+game (
+	name "Magic Squares (1983)(Sinclair User)"
+	description "Magic Squares (1983)(Sinclair User)"
+	rom ( name "Magic Squares (1983)(Sinclair User).p" size 1390 crc c12d003e md5 8779a678582003aab2be0d83b2dc644c sha1 5d39c4d249ba9c5ce4dea03f0415212c5867675a )
+)
+
+game (
+	name "Magisches Quadrat (19xx)(-)(de)"
+	description "Magisches Quadrat (19xx)(-)(de)"
+	rom ( name "Magisches Quadrat (19xx)(-)(de).p" size 2296 crc b156b9c2 md5 06d9871e5690144c8c1444000229dace sha1 c9bb728113f4d2dc4d04ab1eea25ecade88bf45a )
+)
+
+game (
+	name "Mahagoni (19xx)(-)"
+	description "Mahagoni (19xx)(-)"
+	rom ( name "Mahagoni (19xx)(-).p" size 1367 crc c16f350f md5 3bc97fd1a701384d3fec3933ccafd097 sha1 af0ff0fecaf1ce16fbd7a8922fa2a89b2de3fc09 )
+)
+
+game (
+	name "Mandelbrot Sets (1987)(Fred Nachbaur)"
+	description "Mandelbrot Sets (1987)(Fred Nachbaur)"
+	rom ( name "Mandelbrot Sets (1987)(Fred Nachbaur).p" size 14028 crc 60342400 md5 847e65f95303da26bd401826a8e542e0 sha1 67c1a1792188c1e1318b50004e64d317db01eeb9 )
+)
+
+game (
+	name "MAQ (1997)(Martin Weese)(de)"
+	description "MAQ (1997)(Martin Weese)(de)"
+	rom ( name "MAQ (1997)(Martin Weese)(de).p" size 13748 crc 20144d90 md5 284da5f11502ee5eaeddea2a809516b2 sha1 396b52c4d744f8fb3070e366723aceac9432d35a )
+)
+
+game (
+	name "Markelse Avonturen (19xx)(Logical Computers)(nl)"
+	description "Markelse Avonturen (19xx)(Logical Computers)(nl)"
+	rom ( name "Markelse Avonturen (19xx)(Logical Computers)(nl).p" size 10220 crc 89a2490e md5 744b99dfe7c162f02685913e72dc0d7f sha1 b8201ef7df0ffd84166274ec122455d1a3df215c )
+)
+
+game (
+	name "Mars Landing (19xx)(-)(de)"
+	description "Mars Landing (19xx)(-)(de)"
+	rom ( name "Mars Landing (19xx)(-)(de).p" size 2099 crc ca1d7eaa md5 a04dd7d1c8cbe2b2363ef57510d5a4c6 sha1 1cc80bddcc05ad7424198af0a6b48a30872ec0ca )
+)
+
+game (
+	name "Marslander (19xx)(-)(nl)"
+	description "Marslander (19xx)(-)(nl)"
+	rom ( name "Marslander (19xx)(-)(nl).p" size 2534 crc d2587a7f md5 25deabcfe1a2eb4ff5812411dc83ec5a sha1 a2db03dd2864d21cd0de185a4edd4331a2371196 )
+)
+
+game (
+	name "Martian Affairs (19xx)(Logical Computers)"
+	description "Martian Affairs (19xx)(Logical Computers)"
+	rom ( name "Martian Affairs (19xx)(Logical Computers).p" size 14415 crc d45803f3 md5 24a3f40b97af02240563c2c2d689cd94 sha1 fbc3a7a17bbcb15c6d0e4ffc37c5e8f002514cff )
+)
+
+game (
+	name "Martian Cricket (19xx)(-)"
+	description "Martian Cricket (19xx)(-)"
+	rom ( name "Martian Cricket (19xx)(-).p" size 4328 crc e1bee315 md5 79c89262b7f822ce4cf0ed90375981ff sha1 cc03f94860cd4a0e47b972e15f715cadb8ef4cda )
+)
+
+game (
+	name "Martian Land (19xx)(-)"
+	description "Martian Land (19xx)(-)"
+	rom ( name "Martian Land (19xx)(-).p" size 11976 crc 95251887 md5 c0c583583c78856f4b0d42c78e6108cf sha1 fd338ec15390fc1ffd41d812693de4bd38fd0971 )
+)
+
+game (
+	name "Mastermind (19xx)(-)"
+	description "Mastermind (19xx)(-)"
+	rom ( name "Mastermind (19xx)(-).p" size 1489 crc d323c8e2 md5 bcc67c0e5dc782acf4c4d1cd1fc939b7 sha1 b815e1d0ddc40b537a5b8e5d2449d9d92b7434e4 )
+)
+
+game (
+	name "Mastermind (19xx)(-)(de)"
+	description "Mastermind (19xx)(-)(de)"
+	rom ( name "Mastermind (19xx)(-)(de).p" size 2449 crc 61760a6a md5 5f63d05eee94bb81c836f5cd20c9d6e4 sha1 1521a336b19d7289e5d6d48c7dc35332647941e0 )
+)
+
+game (
+	name "Mastermind (19xx)(-)(nl)"
+	description "Mastermind (19xx)(-)(nl)"
+	rom ( name "Mastermind (19xx)(-)(nl).p" size 5219 crc 618e907f md5 e37c587197ba8458ccc34e92a969f3f7 sha1 670ab4904a88d57bfbdb089f1adb708ce353a63f )
+)
+
+game (
+	name "Mastermind (19xx)(Creative Computing)"
+	description "Mastermind (19xx)(Creative Computing)"
+	rom ( name "Mastermind (19xx)(Creative Computing).p" size 2700 crc e3a05333 md5 02040bd1d7ca92ddb62fc38bf4af55e3 sha1 7ad717bed9f70bdb3d7f37aa7a12fa5ddccfeab0 )
+)
+
+game (
+	name "Math Maze (1982)(Sinclair User)"
+	description "Math Maze (1982)(Sinclair User)"
+	rom ( name "Math Maze (1982)(Sinclair User).p" size 1736 crc cd68e7f6 md5 26974fddb19b3ee32c5805b142e96cb1 sha1 6510f92812f2c18ae42a8c0d6625ce84e21dfe44 )
+)
+
+game (
+	name "Maths (19xx)(-)"
+	description "Maths (19xx)(-)"
+	rom ( name "Maths (19xx)(-).p" size 1526 crc 8fde935c md5 fe290270458d55948f84554b0067b194 sha1 dc4857182f2cbbf7edbcca56712222426fc40cbc )
+)
+
+game (
+	name "Maths (19xx)(-)[a]"
+	description "Maths (19xx)(-)[a]"
+	rom ( name "Maths (19xx)(-)[a].p" size 1446 crc d3f372d6 md5 ce3a2c5f5ac9f72c78cdab76807fd467 sha1 2fb3e753a9b71698fcfc3c8ddc888c259798283d )
+)
+
+game (
+	name "Mayday, Mayday (19xx)(-)"
+	description "Mayday, Mayday (19xx)(-)"
+	rom ( name "Mayday, Mayday (19xx)(-).p" size 2814 crc e3c54d96 md5 b02c4769256b81f7a362198978ffdac4 sha1 2e0abe3516c2a27681a00e1c78dda15f04f13c40 )
+)
+
+game (
+	name "Maze (19xx)(-)"
+	description "Maze (19xx)(-)"
+	rom ( name "Maze (19xx)(-).p" size 1940 crc a08ca1ce md5 36c9fd4438d2521a5cd04df089a3b30a sha1 28b1e8048691ed1a71311de6177a63cb2199f555 )
+)
+
+game (
+	name "Maze (19xx)(-)[a]"
+	description "Maze (19xx)(-)[a]"
+	rom ( name "Maze (19xx)(-)[a].p" size 1933 crc a0326f09 md5 6d992cca0216c5145597e253e7059734 sha1 de0c1753364e171ddf077198b3814d33da2c91dc )
+)
+
+game (
+	name "Maze Chase (19xx)(-)"
+	description "Maze Chase (19xx)(-)"
+	rom ( name "Maze Chase (19xx)(-).p" size 2039 crc fc049bd9 md5 45dba5012e6b6230618219d956a9b144 sha1 70ffe9c0d44a6b2d10344aed4e57571caedaa9bb )
+)
+
+game (
+	name "Mazeman (1982)(Abersoft)"
+	description "Mazeman (1982)(Abersoft)"
+	rom ( name "Mazeman (1982)(Abersoft).p" size 5910 crc ff5b7ec1 md5 116f7ae748a6928dd71f9141e4f7546b sha1 3e3c36ef114b1a8ed65f76981adb86bd91f377b4 )
+)
+
+game (
+	name "Mazes (19xx)(-)"
+	description "Mazes (19xx)(-)"
+	rom ( name "Mazes (19xx)(-).p" size 10566 crc 07c60625 md5 4fdbae1a87630202dab534db8c8d3e17 sha1 374efebb935825cf7efd8ccbee8d35ca5730c46d )
+)
+
+game (
+	name "Mazogs (1981)(Bug-Byte Software)"
+	description "Mazogs (1981)(Bug-Byte Software)"
+	rom ( name "Mazogs (1981)(Bug-Byte Software).p" size 12898 crc ccd03383 md5 03f575af86144cde6efb7f2dba36c3bb sha1 3371fe6f4ae07111e80ce913f4b4bce7a485387f )
+)
+
+game (
+	name "Mazogs (1981)(Bug-Byte Software)[a]"
+	description "Mazogs (1981)(Bug-Byte Software)[a]"
+	rom ( name "Mazogs (1981)(Bug-Byte Software)[a].p" size 12939 crc c8cd09c2 md5 4152f1448928531ba6c79058668c05ee sha1 714cbae0d41ff051539bd4dbbd6ea8b80ff1f815 )
+)
+
+game (
+	name "Mazogs (19xx)(-)"
+	description "Mazogs (19xx)(-)"
+	rom ( name "Mazogs (19xx)(-).p" size 12887 crc 6611d9e5 md5 393f8cff307093839991d38f100a4776 sha1 13e3ee96e1bd968cf8039abdc7e6abc0beb15a55 )
+)
+
+game (
+	name "Meditor (1983)(A. Krebs)(de)"
+	description "Meditor (1983)(A. Krebs)(de)"
+	rom ( name "Meditor (1983)(A. Krebs)(de).p" size 5331 crc 6cc889f1 md5 85143443b1e69f5fcb2d83a87fbe05b0 sha1 f8ad0a3eac6ab96955e609e93672e5251b68db33 )
+)
+
+game (
+	name "Meditor-Kalkulation (1983)(A. Krebs)(de)"
+	description "Meditor-Kalkulation (1983)(A. Krebs)(de)"
+	rom ( name "Meditor-Kalkulation (1983)(A. Krebs)(de).p" size 2372 crc 91f935c3 md5 69ca046ea76b9bb6e39e02aa3e03e3e8 sha1 1212903d53c340ed2693ebb59c9fb4631cb39eb8 )
+)
+
+game (
+	name "Medium-Lettertjes (19xx)(-)(nl)"
+	description "Medium-Lettertjes (19xx)(-)(nl)"
+	rom ( name "Medium-Lettertjes (19xx)(-)(nl).p" size 1494 crc 92d7a854 md5 3e0898224a50864c93e1f6ddba965191 sha1 59d91c27e6e1e339190a77333f2bd1dc46757d87 )
+)
+
+game (
+	name "Meisjes-Internaat (19xx)(-)"
+	description "Meisjes-Internaat (19xx)(-)"
+	rom ( name "Meisjes-Internaat (19xx)(-).p" size 14876 crc 1468f5f7 md5 949003963334b57e14578166b4e8abea sha1 9537381269317d9804f5a523bb11e0a8b59f3342 )
+)
+
+game (
+	name "Memory (1985)(JSKOSoft)(nl)"
+	description "Memory (1985)(JSKOSoft)(nl)"
+	rom ( name "Memory (1985)(JSKOSoft)(nl).p" size 6327 crc 197c5d3e md5 e17499d5ffeef9386c8587e00b357718 sha1 f18d99b5403b9fc06443dab5aae1b7fd7763e5f3 )
+)
+
+game (
+	name "Memory (19xx)(-)"
+	description "Memory (19xx)(-)"
+	rom ( name "Memory (19xx)(-).p" size 1808 crc 762b94b9 md5 07e3cff225fd371e626569e003f789eb sha1 2ca04812d4b50132c650c96285b8291bc0eeb024 )
+)
+
+game (
+	name "Memory Left Routine (19xx)(-)"
+	description "Memory Left Routine (19xx)(-)"
+	rom ( name "Memory Left Routine (19xx)(-).p" size 1009 crc b7934d84 md5 80f54ba0c341a7711d7f340a1f31533e sha1 f603ee892cbdbc41220bb1f4340ed27ae4d5edcd )
+)
+
+game (
+	name "Memory Magic (19xx)(-)"
+	description "Memory Magic (19xx)(-)"
+	rom ( name "Memory Magic (19xx)(-).p" size 2152 crc 32b7b472 md5 b9a7e56db1a71cf4a199e8755257f597 sha1 90e9e9cf3dc65763315805c31b8bc628438853a5 )
+)
+
+game (
+	name "Memory Test (19xx)(-)"
+	description "Memory Test (19xx)(-)"
+	rom ( name "Memory Test (19xx)(-).p" size 1195 crc cb408e04 md5 ada4b1ecdd5f9eb99451c6c5a8b419c7 sha1 59dc8e655669ca8f21c03e9a51d004f35a769517 )
+)
+
+game (
+	name "Memory Test (19xx)(-)(de)"
+	description "Memory Test (19xx)(-)(de)"
+	rom ( name "Memory Test (19xx)(-)(de).p" size 1449 crc c9046972 md5 0ae259332d1a6fe7aa884e2936ed9e5e sha1 2c7a0b7e49f4751940c35b48cc3a024a3796d76d )
+)
+
+game (
+	name "Menace (19xx)(-)"
+	description "Menace (19xx)(-)"
+	rom ( name "Menace (19xx)(-).p" size 1166 crc 738014e2 md5 b4e5f1d9177929b1f580956e5e8108bf sha1 83f485acf65ccb2d13c6cea4484b3580fa7d318e )
+)
+
+game (
+	name "Mens Erger Je Niet (19xx)(Herosoft)(nl)"
+	description "Mens Erger Je Niet (19xx)(Herosoft)(nl)"
+	rom ( name "Mens Erger Je Niet (19xx)(Herosoft)(nl).p" size 14402 crc e9dce84c md5 3ebbf55277d0c6b30a573919a6848aa3 sha1 0e4d275c4b5281774c511420a15eecdd94ed06ff )
+)
+
+game (
+	name "Mensch Aergere Dich Nicht (19xx)(-)"
+	description "Mensch Aergere Dich Nicht (19xx)(-)"
+	rom ( name "Mensch Aergere Dich Nicht (19xx)(-).p" size 14050 crc c46a4dd9 md5 db27b4cec514d299e967444b3896f0de sha1 4af34fcd44a68ae42f97234758de3c4e78f83989 )
+)
+
+game (
+	name "Merchant (19xx)(-)"
+	description "Merchant (19xx)(-)"
+	rom ( name "Merchant (19xx)(-).p" size 15638 crc 13608bd3 md5 06e039e740f0f8480597bd99ec06fe62 sha1 0742764f15a6d14d157bba0dfc8978e34b7c2dd8 )
+)
+
+game (
+	name "Merchant of Venus (1982)(Crystal Computing)"
+	description "Merchant of Venus (1982)(Crystal Computing)"
+	rom ( name "Merchant of Venus (1982)(Crystal Computing).p" size 16161 crc e5fdf66e md5 22ba646ca0b3c56a508d51069cc6ae03 sha1 49afbbbbff9a71af8aa7f4f60f87ed0fa007c02b )
+)
+
+game (
+	name "Merchant of Venus (1982)(Crystal Computing)[a]"
+	description "Merchant of Venus (1982)(Crystal Computing)[a]"
+	rom ( name "Merchant of Venus (1982)(Crystal Computing)[a].p" size 16191 crc 8e988486 md5 b1a2674c008ad8384db20b6444722e10 sha1 3ca6222b2c3806eeac7988581224357309091b10 )
+)
+
+game (
+	name "Meteor (19xx)(-)"
+	description "Meteor (19xx)(-)"
+	rom ( name "Meteor (19xx)(-).p" size 3156 crc 5bbabe55 md5 250b92ad4213b7dedb375f4979f57a46 sha1 6678f25e3e056c0654cbad080dcb0e4c39f53a59 )
+)
+
+game (
+	name "Meteor (19xx)(-)(de)"
+	description "Meteor (19xx)(-)(de)"
+	rom ( name "Meteor (19xx)(-)(de).p" size 1559 crc f1bad33e md5 45255d996910f578346fc75d91b7aaaa sha1 83efb867ade11d852145a29727325a405af8bb54 )
+)
+
+game (
+	name "Meteors II (19xx)(-)"
+	description "Meteors II (19xx)(-)"
+	rom ( name "Meteors II (19xx)(-).p" size 3484 crc 6b7fefc0 md5 83e1ad66f1f72ea91a3f64ade5fcda29 sha1 2785d8937ea1823e26e096bad7c0f41bc279d66d )
+)
+
+game (
+	name "Meteors II (19xx)(-)[a2]"
+	description "Meteors II (19xx)(-)[a2]"
+	rom ( name "Meteors II (19xx)(-)[a2].p" size 3301 crc 991c9e17 md5 d6f0f50d20afe479cbf00773f00bd82b sha1 ce3f0c4309df4e89499d5b56a835b654cd50124a )
+)
+
+game (
+	name "Meteors II (19xx)(-)[a]"
+	description "Meteors II (19xx)(-)[a]"
+	rom ( name "Meteors II (19xx)(-)[a].p" size 3464 crc d4068b90 md5 875f9a1adfd58e07cc71c92b7d04f44a sha1 a02a3732cd7032a5e72c51fb3a84addd87f50332 )
+)
+
+game (
+	name "Metric 2 (1982)(J. Gishen)"
+	description "Metric 2 (1982)(J. Gishen)"
+	rom ( name "Metric 2 (1982)(J. Gishen).p" size 2247 crc 70503210 md5 4886d562fb5737a2bc0a090d5462aadb sha1 0dd70e049794ed035b8d34f2519d448267fd57c2 )
+)
+
+game (
+	name "Metric Conversion (19xx)(-)"
+	description "Metric Conversion (19xx)(-)"
+	rom ( name "Metric Conversion (19xx)(-).p" size 15988 crc 4b0cf76f md5 ff0ffe8b2aaa263f8bd6f28896a5d7f3 sha1 bfa89c5f607839a492f8d337a515c1578320d332 )
+)
+
+game (
+	name "Micro Bug (19xx)(-)(es)"
+	description "Micro Bug (19xx)(-)(es)"
+	rom ( name "Micro Bug (19xx)(-)(es).p" size 3104 crc 8044f36b md5 2654cd8bb280d05d3154b191241b75ca sha1 02a9419bbb09298f6d56a3f88da0a3e96e2ce62b )
+)
+
+game (
+	name "Micro Mouse Goes De-Bugging (19xx)(MC Lothlorien)"
+	description "Micro Mouse Goes De-Bugging (19xx)(MC Lothlorien)"
+	rom ( name "Micro Mouse Goes De-Bugging (19xx)(MC Lothlorien).p" size 8529 crc 5d3a1851 md5 225568b03ba755e5bf4289835c68415e sha1 9285779806af9ae7ca12c9270e5f4d3dd151cd64 )
+)
+
+game (
+	name "Micromaus (19xx)(-)[16K]"
+	description "Micromaus (19xx)(-)[16K]"
+	rom ( name "Micromaus (19xx)(-)[16K].p" size 3500 crc f8c21a42 md5 a9ebcfe3087ffd93dbb399aac8458e29 sha1 fd79eee657c48d4cf251e7f708b1f34bc7871dcd )
+)
+
+game (
+	name "Microvaders (19xx)(-)(nl)"
+	description "Microvaders (19xx)(-)(nl)"
+	rom ( name "Microvaders (19xx)(-)(nl).p" size 6292 crc 224eebce md5 3fe4acefae5fbb62fed9147ee6c05b10 sha1 24c2ddde2df069ff8e4fcfe96617ab8811d75b18 )
+)
+
+game (
+	name "Mijnopruiming (19xx)(-)(nl)"
+	description "Mijnopruiming (19xx)(-)(nl)"
+	rom ( name "Mijnopruiming (19xx)(-)(nl).p" size 2568 crc bac0df76 md5 3bb66b471f823e9a8c933004562e6a7d sha1 a54ea18143b7aab822316cabc493408361652078 )
+)
+
+game (
+	name "Millionaire (19xx)(Creative Computing)"
+	description "Millionaire (19xx)(Creative Computing)"
+	rom ( name "Millionaire (19xx)(Creative Computing).p" size 8674 crc 8538e817 md5 8afc66eab62a381e1f29b88b0f82a018 sha1 b21246988b11f9f1fb825415a0a8cc88ec5119ce )
+)
+
+game (
+	name "Millionaire (19xx)(Creative Computing)[a]"
+	description "Millionaire (19xx)(Creative Computing)[a]"
+	rom ( name "Millionaire (19xx)(Creative Computing)[a].p" size 8652 crc 013e6e45 md5 5dab222d92d145cd3848300946cb1fc6 sha1 9b42f5aec82b85a121d52d56d0aaf3b6bd62e6a6 )
+)
+
+game (
+	name "Minefields (1982)(Sinclair User)[16K]"
+	description "Minefields (1982)(Sinclair User)[16K]"
+	rom ( name "Minefields (1982)(Sinclair User)[16K].p" size 2118 crc 1a3c5fdb md5 ac7060f0f085c413e41746b25483a1d2 sha1 a0e58269611aac722b5109a706f644ae5e58dbec )
+)
+
+game (
+	name "Minesweeper (19xx)(Bodo Wenzel)"
+	description "Minesweeper (19xx)(Bodo Wenzel)"
+	rom ( name "Minesweeper (19xx)(Bodo Wenzel).p" size 12545 crc 429ea27a md5 161de80ada097c807cf6c0dd186c99fa sha1 fb54522a742f5d3411dafa98a11909cd16ccc70f )
+)
+
+game (
+	name "Mini-Monitor (19xx)(-)(nl)"
+	description "Mini-Monitor (19xx)(-)(nl)"
+	rom ( name "Mini-Monitor (19xx)(-)(nl).p" size 2996 crc b67e1d5b md5 9f8bbb06517964d5d0febde4bc27832b sha1 f64c68dee9be11ad465763563cc97937279de218 )
+)
+
+game (
+	name "Mining (19xx)(-)"
+	description "Mining (19xx)(-)"
+	rom ( name "Mining (19xx)(-).p" size 2041 crc 11a91f1a md5 045310cc4b7470e075f7ad85e62290a8 sha1 5b3bac412ce485fc562907e2bb57252695283059 )
+)
+
+game (
+	name "Mirror Life (19xx)(-)"
+	description "Mirror Life (19xx)(-)"
+	rom ( name "Mirror Life (19xx)(-).p" size 3103 crc 6e380b24 md5 76f8da8da498dceca00ed75f2d420400 sha1 4f3530b96099ccf0d6ab09c9594ec90ca6a42d54 )
+)
+
+game (
+	name "Missile (1983)(M. V.D. Velden)(nl)"
+	description "Missile (1983)(M. V.D. Velden)(nl)"
+	rom ( name "Missile (1983)(M. V.D. Velden)(nl).p" size 5324 crc c7220813 md5 19dc59e44669b7b12843a9e2d0cc4eeb sha1 f304d3dd8e8aeada804dbdc075a4add290bddd93 )
+)
+
+game (
+	name "Missile Command (1983)(Ch. Zwerschke)(de)"
+	description "Missile Command (1983)(Ch. Zwerschke)(de)"
+	rom ( name "Missile Command (1983)(Ch. Zwerschke)(de).p" size 4566 crc 813326af md5 3d3edd0ec3887f5bd28e977583241848 sha1 c7e741c265a9cfcbb8f52cdd2ae01c04884efdbb )
+)
+
+game (
+	name "Missile Command (1983)(Ch. Zwerschke)(de)[a]"
+	description "Missile Command (1983)(Ch. Zwerschke)(de)[a]"
+	rom ( name "Missile Command (1983)(Ch. Zwerschke)(de)[a].p" size 3702 crc 96f18e4b md5 e80afa5cb59e03f19c56023de7e95697 sha1 a8e3cec7f645e2fe7b126408c01ddc7c3f72747e )
+)
+
+game (
+	name "Mission Apollo (19xx)(-)(nl)"
+	description "Mission Apollo (19xx)(-)(nl)"
+	rom ( name "Mission Apollo (19xx)(-)(nl).p" size 11333 crc d0075801 md5 94cd322232697896454972c82bb7b2d2 sha1 df1ffe20fbc42be157edd3ec949caee9f68193ec )
+)
+
+game (
+	name "Model (19xx)(Willi)"
+	description "Model (19xx)(Willi)"
+	rom ( name "Model (19xx)(Willi).p" size 14967 crc 496d90bb md5 1af6d23fd5214cc1e2725d9e8903af6c sha1 242b272c1831dd48932409c42d83e9bb6010f517 )
+)
+
+game (
+	name "Mole-Hunter (19xx)(-)"
+	description "Mole-Hunter (19xx)(-)"
+	rom ( name "Mole-Hunter (19xx)(-).p" size 1584 crc a266bb02 md5 813c3ab87871145f13f224c2b2cf94a5 sha1 5a0f6dc554db0f312204d042641bb33d2537863c )
+)
+
+game (
+	name "Mondphasen (19xx)(-)(de)"
+	description "Mondphasen (19xx)(-)(de)"
+	rom ( name "Mondphasen (19xx)(-)(de).p" size 1964 crc 677333aa md5 003641adefefdb50fa66bdc62bb82cb7 sha1 5419e8c5fd7531cfbb2b558c1f10017e4d0a6838 )
+)
+
+game (
+	name "Money (19xx)(De Stier ZX-81 Programma)(nl)"
+	description "Money (19xx)(De Stier ZX-81 Programma)(nl)"
+	rom ( name "Money (19xx)(De Stier ZX-81 Programma)(nl).p" size 4461 crc 277ec54d md5 e903375d22cd6c213e1fa3766108f41f sha1 e75605eca72e2385fc18e67e91d48519638ba808 )
+)
+
+game (
+	name "Money Analyser 2 - Present Worth Comparison (19xx)(-)"
+	description "Money Analyser 2 - Present Worth Comparison (19xx)(-)"
+	rom ( name "Money Analyser 2 - Present Worth Comparison (19xx)(-).p" size 2168 crc dae021a2 md5 f988d66592196559174c61855984645f sha1 50eecffcf5f51c0b9937d5d356ec50cd13bf97c2 )
+)
+
+game (
+	name "Money Analyser 2 - Present Worth Comparison (19xx)(-)[a]"
+	description "Money Analyser 2 - Present Worth Comparison (19xx)(-)[a]"
+	rom ( name "Money Analyser 2 - Present Worth Comparison (19xx)(-)[a].p" size 2412 crc fc42010f md5 04fa3e0550acc44a6bc8283e94e27dfd sha1 d4e2f72e7b606e7c26ebeb2befb2c76c8f0318ad )
+)
+
+game (
+	name "Money Analyser 2 - Rate of Return (19xx)(-)"
+	description "Money Analyser 2 - Rate of Return (19xx)(-)"
+	rom ( name "Money Analyser 2 - Rate of Return (19xx)(-).p" size 2148 crc 0bbe1d65 md5 c6fdc388a378b0dc222f6d52167245fa sha1 ef683b6c635c3343a7400a435b5818aa028bbcf7 )
+)
+
+game (
+	name "Money Analyser 2 - Rate of Return (19xx)(-)[a]"
+	description "Money Analyser 2 - Rate of Return (19xx)(-)[a]"
+	rom ( name "Money Analyser 2 - Rate of Return (19xx)(-)[a].p" size 2133 crc 038acf10 md5 1c75dfcfec9f16f6a3c98087bb0566a7 sha1 f67c77a6b8fb317369ff2c3c218293e026368352 )
+)
+
+game (
+	name "Moneygrabber (1984)(Hogroprog)"
+	description "Moneygrabber (1984)(Hogroprog)"
+	rom ( name "Moneygrabber (1984)(Hogroprog).p" size 6325 crc 3187de1e md5 c1423323816c50486a90c24f86807c7c sha1 4ff7354c205270e16e3562cdd32172a71a8b81e2 )
+)
+
+game (
+	name "Moni - Hexmonitor (19xx)(-)(de)"
+	description "Moni - Hexmonitor (19xx)(-)(de)"
+	rom ( name "Moni - Hexmonitor (19xx)(-)(de).p" size 1570 crc d63336fb md5 9978cd9056783d9eeea9e95cbfea9cb4 sha1 817628784ba8da5db7a8707d966d39d18a8b7294 )
+)
+
+game (
+	name "Moni - Hexmonitor (19xx)(-)(de)[a]"
+	description "Moni - Hexmonitor (19xx)(-)(de)[a]"
+	rom ( name "Moni - Hexmonitor (19xx)(-)(de)[a].p" size 1328 crc 4ffa9eef md5 11601bcfd3a5dea4df995aa758a77181 sha1 04bb8b15b5ff6a63de4a6cdf61dafb2ff3aaadeb )
+)
+
+game (
+	name "Monitor (19xx)(-)"
+	description "Monitor (19xx)(-)"
+	rom ( name "Monitor (19xx)(-).p" size 5949 crc 5711f25a md5 3bd40fcf3dd9dc296771cb78c38e43b8 sha1 1fa580ef56899547b218e9b46dbccae5262aeaa5 )
+)
+
+game (
+	name "Monopoly (1982)(Work Force)"
+	description "Monopoly (1982)(Work Force)"
+	rom ( name "Monopoly (1982)(Work Force).p" size 15672 crc 82807999 md5 e5e6d8a68b4eb3fe6f12b18b55ccd8cb sha1 f705c752173dd5ffcc00e60cf75ebe197189e813 )
+)
+
+game (
+	name "Monster Mine, The (1982)(W.E. McGowan)"
+	description "Monster Mine, The (1982)(W.E. McGowan)"
+	rom ( name "Monster Mine, The (1982)(W.E. McGowan).p" size 10790 crc c3fd25dc md5 8476efc5556ce72dafe7cccf507cfba9 sha1 ff6f653c28e3063ed8c88c73769a5c6253d8dee8 )
+)
+
+game (
+	name "Monster Mine, The (1982)(W.E. McGowan)[a]"
+	description "Monster Mine, The (1982)(W.E. McGowan)[a]"
+	rom ( name "Monster Mine, The (1982)(W.E. McGowan)[a].p" size 10844 crc fc8a262c md5 03962fc1cf3a6d9c5e9be3b36cfc8c84 sha1 50db20e347a5b86eb3fd24e2ae98bba4df99128a )
+)
+
+game (
+	name "Moonlander (19xx)(-)"
+	description "Moonlander (19xx)(-)"
+	rom ( name "Moonlander (19xx)(-).p" size 6274 crc 02fd0a62 md5 b763c8612cdf6b6ff8384c7083392cd5 sha1 0e999ecc9ee2473400283c535fb8b3c170631cdd )
+)
+
+game (
+	name "Moordenar (19xx)(-)"
+	description "Moordenar (19xx)(-)"
+	rom ( name "Moordenar (19xx)(-).p" size 12075 crc 745dd209 md5 76cac8dc63898a981f2bf414f96b5e4f sha1 231fca12f1d3a512e355a5c2d83f6df2e1dd7eef )
+)
+
+game (
+	name "Morse Leer Programma (19xx)(-)(nl)"
+	description "Morse Leer Programma (19xx)(-)(nl)"
+	rom ( name "Morse Leer Programma (19xx)(-)(nl).p" size 7702 crc 3ac2169f md5 bb40b16a21c71030ab41f55cc0fa3b51 sha1 1e6090b714a8267892a9bc47640ca3dfe4d1cfaf )
+)
+
+game (
+	name "Morse Reader (1984)(G40IK - G40IL)"
+	description "Morse Reader (1984)(G40IK - G40IL)"
+	rom ( name "Morse Reader (1984)(G40IK - G40IL).p" size 8864 crc 2192ec61 md5 a1c9043fa1771ad6926dfaf238bf6604 sha1 20c29db90b529d9e3754da16ef3f0ce09d0b49a4 )
+)
+
+game (
+	name "Morse Seinen (19xx)(-)(nl)"
+	description "Morse Seinen (19xx)(-)(nl)"
+	rom ( name "Morse Seinen (19xx)(-)(nl).p" size 2923 crc fd0d6412 md5 16489771e47031ad410be63ea0d21855 sha1 a38a03f7a00bd37432623f2f93d1ec27174194c7 )
+)
+
+game (
+	name "Morseman 4 (1984)(LMC)"
+	description "Morseman 4 (1984)(LMC)"
+	rom ( name "Morseman 4 (1984)(LMC).p" size 7411 crc ec379d15 md5 88d2372a5537eaf8f423233e1fec944e sha1 103b6e5af9ad0b9910ed6ccdc0f4eb2d4640ca98 )
+)
+
+game (
+	name "Mortgage (19xx)(T.J. Software Production)"
+	description "Mortgage (19xx)(T.J. Software Production)"
+	rom ( name "Mortgage (19xx)(T.J. Software Production).p" size 10365 crc 8f14ce33 md5 3997688cc2cdb539d767904a27cef5eb sha1 6c2eef18fe7e9708747a74bd4346809f6ec31103 )
+)
+
+game (
+	name "Mountains (19xx)(-)"
+	description "Mountains (19xx)(-)"
+	rom ( name "Mountains (19xx)(-).p" size 1569 crc 282a9894 md5 8adaac364c087bea7a9cbe247c5682f4 sha1 6424e1b8e0c4c40ca43ba0844ccf9f66e9f35620 )
+)
+
+game (
+	name "Mugsy (19xx)(-)"
+	description "Mugsy (19xx)(-)"
+	rom ( name "Mugsy (19xx)(-).p" size 16000 crc 7132d05d md5 37cbcd0e49e903770367acd3af68f1b9 sha1 db360b4c4e772f57e85d412de80cc082fb1167cb )
+)
+
+game (
+	name "Multigraphics v2.3 (1981)(Bridge Software)"
+	description "Multigraphics v2.3 (1981)(Bridge Software)"
+	rom ( name "Multigraphics v2.3 (1981)(Bridge Software).p" size 14953 crc 2ef007af md5 5674c343d0a5640084d9576bcc86d9f1 sha1 1caffc4901081b315dcdf36738a29a76be15efec )
+)
+
+game (
+	name "Muncher 2 (1983)(Robert Turner)"
+	description "Muncher 2 (1983)(Robert Turner)"
+	rom ( name "Muncher 2 (1983)(Robert Turner).p" size 6606 crc 306a528b md5 916f99a5ef603653c70a682dd9f7cd6f sha1 789475f3d1c85fd7b90c7de83ae96a20ebe449df )
+)
+
+game (
+	name "Munchy (1982)(A. Laird)"
+	description "Munchy (1982)(A. Laird)"
+	rom ( name "Munchy (1982)(A. Laird).p" size 7533 crc 7862f3c9 md5 4562805e8bdfcc628a2423873ff876c6 sha1 55fdf41e3b82c73b2d11a18f59d6c643b77354f4 )
+)
+
+game (
+	name "Murgatroyds (1981)(Collins Computing)"
+	description "Murgatroyds (1981)(Collins Computing)"
+	rom ( name "Murgatroyds (1981)(Collins Computing).p" size 7133 crc c13da3b1 md5 28ad81ac89c4e326704485b3d62e9e79 sha1 91475bb019c7889e5e10ac0eaf5c8966590d0790 )
+)
+
+game (
+	name "Murgatroyds Revenge (1982)(Collins Computing)"
+	description "Murgatroyds Revenge (1982)(Collins Computing)"
+	rom ( name "Murgatroyds Revenge (1982)(Collins Computing).p" size 12715 crc f853239b md5 e645e0086c120c806ffe94f2e182c18b sha1 e4414ef75d7aea4287eb54b3c0a7e56fa5c22922 )
+)
+
+game (
+	name "Music - ZX-80 Magic Book (19xx)(-)(nl)"
+	description "Music - ZX-80 Magic Book (19xx)(-)(nl)"
+	rom ( name "Music - ZX-80 Magic Book (19xx)(-)(nl).p" size 2454 crc 41ec7682 md5 064464b597fd4486cd37b77a28d46ce8 sha1 41901f66c618b5d3ba3ed5af0e7506ffd1b85c62 )
+)
+
+game (
+	name "Music Educator 1 (19xx)(-)"
+	description "Music Educator 1 (19xx)(-)"
+	rom ( name "Music Educator 1 (19xx)(-).p" size 14228 crc 0952588c md5 f9f1b667f0ebf6bd2e943daf8658ea99 sha1 cbb37ce31b58e2aae16a03319332b3de36e94b86 )
+)
+
+game (
+	name "Music Educator 1 (19xx)(-)[a]"
+	description "Music Educator 1 (19xx)(-)[a]"
+	rom ( name "Music Educator 1 (19xx)(-)[a].p" size 14199 crc 625265e1 md5 e3131db352c4060dd3b6140a9c36a184 sha1 4f0a5e55bbf6536253aeee6d38e9adbbecd68dfb )
+)
+
+game (
+	name "Music Master (19xx)(-)(nl)"
+	description "Music Master (19xx)(-)(nl)"
+	rom ( name "Music Master (19xx)(-)(nl).p" size 3965 crc 9c09eeb9 md5 3a176ef336ec3e78086f35c3f031b729 sha1 750acd8529efeab636fb3c626720d0efb912b735 )
+)
+
+game (
+	name "Music Master (19xx)(-)(nl)[a2]"
+	description "Music Master (19xx)(-)(nl)[a2]"
+	rom ( name "Music Master (19xx)(-)(nl)[a2].p" size 3969 crc d59689cc md5 647428debdb6367b1647d484e9523541 sha1 3b51bf24b44ac6877f67d87b93fe3f6c99e70ac5 )
+)
+
+game (
+	name "Music Master (19xx)(-)(nl)[a]"
+	description "Music Master (19xx)(-)(nl)[a]"
+	rom ( name "Music Master (19xx)(-)(nl)[a].p" size 3965 crc 517bfe42 md5 e48c3c7d2eb3a6e30e30ad13bbebb164 sha1 e57543744b01414db5efa1ec97656ea8edf9062f )
+)
+
+game (
+	name "Music Plus (19xx)(-)"
+	description "Music Plus (19xx)(-)"
+	rom ( name "Music Plus (19xx)(-).p" size 1837 crc 7f2d15f4 md5 1e696ef041a53926a533ec21f5127c7a sha1 6bd3e3421fc4c10aaf0fb275ebeb0d6f5990b600 )
+)
+
+game (
+	name "Names (19xx)(-)"
+	description "Names (19xx)(-)"
+	rom ( name "Names (19xx)(-).p" size 1506 crc 073abc5a md5 b743fcf1be0a294f2b1a6422805acd02 sha1 bbecceeb303a2a914fa3d90f1cc0277ab467adca )
+)
+
+game (
+	name "Namtir Raiders (1982)(Artic Computing)"
+	description "Namtir Raiders (1982)(Artic Computing)"
+	rom ( name "Namtir Raiders (1982)(Artic Computing).p" size 3771 crc 492c3967 md5 1b4d13a2cf02c1bd7d1f0059c2f6ebed sha1 6792becedd03bc7e5c85202a34fd0ae3583adb99 )
+)
+
+game (
+	name "Namtir Raiders (1982)(Artic Computing)[a2]"
+	description "Namtir Raiders (1982)(Artic Computing)[a2]"
+	rom ( name "Namtir Raiders (1982)(Artic Computing)[a2].p" size 3740 crc f522703c md5 7b345c19c6fedd970ce02a225b8dd63c sha1 9142a433d082fd4e2d0d2953f52ca31b62008415 )
+)
+
+game (
+	name "Namtir Raiders (1982)(Artic Computing)[a]"
+	description "Namtir Raiders (1982)(Artic Computing)[a]"
+	rom ( name "Namtir Raiders (1982)(Artic Computing)[a].p" size 3741 crc 74439b09 md5 cd4cdc17665b9d8ec453c68522824750 sha1 1bf4127d30af02b7671ea150110da0123d96d635 )
+)
+
+game (
+	name "Netherwallop Golf (19xx)(-)"
+	description "Netherwallop Golf (19xx)(-)"
+	rom ( name "Netherwallop Golf (19xx)(-).p" size 14616 crc 58487672 md5 e656e562e5e3cc4bddb725a9d14295fa sha1 1287caa1208a3320b6a500e2746d26efad7e3533 )
+)
+
+game (
+	name "Network (19xx)(-)"
+	description "Network (19xx)(-)"
+	rom ( name "Network (19xx)(-).p" size 3214 crc 4cdc818a md5 4c966d4ad591e2332415c25d8d71520d sha1 368b4d09de6386b88f3013c7e7cb362d0b1236e0 )
+)
+
+game (
+	name "News Monger (19xx)(-)(nl)"
+	description "News Monger (19xx)(-)(nl)"
+	rom ( name "News Monger (19xx)(-)(nl).p" size 5404 crc 407dedbb md5 955c5051cc128914c4088bc28010ca66 sha1 ff0b365357d7c5acd9978c3aac46aa695a35bd71 )
+)
+
+game (
+	name "Night Driver (1982)(Ch. Zwerschke)"
+	description "Night Driver (1982)(Ch. Zwerschke)"
+	rom ( name "Night Driver (1982)(Ch. Zwerschke).p" size 1868 crc 687e6ab0 md5 c2ef4ce54a51e996a64e14b167434bf1 sha1 a445c8622c7b0a60c8db0725a730e29cad6abb4c )
+)
+
+game (
+	name "Night Driver (1982)(Ch. Zwerschke)[a]"
+	description "Night Driver (1982)(Ch. Zwerschke)[a]"
+	rom ( name "Night Driver (1982)(Ch. Zwerschke)[a].p" size 1846 crc 9d420e83 md5 e7b3f8d29243fae381dd5d79ae982fd5 sha1 8da6761b55a4d17d141b2e6b964a7b5fb8058c03 )
+)
+
+game (
+	name "Night Gunner (1982)(Digital Integration)"
+	description "Night Gunner (1982)(Digital Integration)"
+	rom ( name "Night Gunner (1982)(Digital Integration).p" size 5113 crc 48e266a6 md5 7c6fcc40e7a55e39c73c38175244b984 sha1 a5ca1e2f586eb18ea2a4f14d1b15548dffbca89b )
+)
+
+game (
+	name "Night Gunner (1982)(Digital Integration)[a]"
+	description "Night Gunner (1982)(Digital Integration)[a]"
+	rom ( name "Night Gunner (1982)(Digital Integration)[a].p" size 5150 crc e3b217af md5 545a38d9b850e8f62de9368977fe4ff5 sha1 6bd567a0bba08e0526f44e06e2338f682cbcb70f )
+)
+
+game (
+	name "Nightmare Park (1981)(Breadhill)"
+	description "Nightmare Park (1981)(Breadhill)"
+	rom ( name "Nightmare Park (1981)(Breadhill).p" size 11665 crc 972d2485 md5 dc924f7e2a7efb774eb50c1e7ee6bfad sha1 41caf60080b4c83d8ed2a2682d10b7513e2f9f36 )
+)
+
+game (
+	name "Nim (19xx)(Fred Nachbaur)"
+	description "Nim (19xx)(Fred Nachbaur)"
+	rom ( name "Nim (19xx)(Fred Nachbaur).p" size 1537 crc 6a676db4 md5 0acc15e3aa03ff8ba8876bce18a15c11 sha1 2964db4ab122b0cecc4d3b0d12152f1c700c1233 )
+)
+
+game (
+	name "No List (19xx)(-)(nl)"
+	description "No List (19xx)(-)(nl)"
+	rom ( name "No List (19xx)(-)(nl).p" size 1402 crc abdd4599 md5 502e429f9071ee656cb12fce63542bcf sha1 8f67f7b84076ca31fb18cea225eeff6eede2313d )
+)
+
+game (
+	name "Nobleman (1983)(Sinclair User)[16K]"
+	description "Nobleman (1983)(Sinclair User)[16K]"
+	rom ( name "Nobleman (1983)(Sinclair User)[16K].p" size 8527 crc 0ebb20f7 md5 fd5674ad435451d705db8e45aa4137cd sha1 50c91cc770a8618a81d2169df949bb4c9a617c94 )
+)
+
+game (
+	name "Noodle (19xx)(-)"
+	description "Noodle (19xx)(-)"
+	rom ( name "Noodle (19xx)(-).p" size 1109 crc 0a70e57e md5 aad63f42efbb8c3c5d4ce312aea89fc9 sha1 e42338261a89808e7a7c5aa1fe57a8e4044e7d79 )
+)
+
+game (
+	name "Nowotnik Puzzle, The (1982)(Phipps Associates)"
+	description "Nowotnik Puzzle, The (1982)(Phipps Associates)"
+	rom ( name "Nowotnik Puzzle, The (1982)(Phipps Associates).p" size 7408 crc 6f500e85 md5 a27f50a6901fcda9e370dc2c857d52f6 sha1 54f7013072bf4e5db19ef4f8074ddc9ae154aac5 )
+)
+
+game (
+	name "Old House, The (19xx)(VVP Software)(nl)"
+	description "Old House, The (19xx)(VVP Software)(nl)"
+	rom ( name "Old House, The (19xx)(VVP Software)(nl).p" size 14806 crc 922994da md5 5c06825f5494dd1fa3e01863d433f5f3 sha1 b51f141988b50ba75f24d1fc6a47f82e7f0b4945 )
+)
+
+game (
+	name "Olympiade (1984)(Jan Wegter)(nl)"
+	description "Olympiade (1984)(Jan Wegter)(nl)"
+	rom ( name "Olympiade (1984)(Jan Wegter)(nl).p" size 11695 crc 23cabead md5 5098fc84465bcad68855f367a1227a61 sha1 84f46e6f980330a6550593b2bf61dd96933e0e07 )
+)
+
+game (
+	name "Olympiade (1984)(W. Eisheuer)(de)"
+	description "Olympiade (1984)(W. Eisheuer)(de)"
+	rom ( name "Olympiade (1984)(W. Eisheuer)(de).p" size 11825 crc 723cd91b md5 68140ebf128e83e7a136b9befe2a4843 sha1 6858d30287123e6fa40920adef9bef4c73d63c66 )
+)
+
+game (
+	name "Olympiade (1985)(W. Messing)(de)"
+	description "Olympiade (1985)(W. Messing)(de)"
+	rom ( name "Olympiade (1985)(W. Messing)(de).p" size 12348 crc bc98b21d md5 d393dc36ab4cdeb480b11d695f1f2e0d sha1 612460aa1fc9a19b98cef588e4d951c05464b40b )
+)
+
+game (
+	name "Omzetten DEC Naar HEX (19xx)(-)(nl)"
+	description "Omzetten DEC Naar HEX (19xx)(-)(nl)"
+	rom ( name "Omzetten DEC Naar HEX (19xx)(-)(nl).p" size 1986 crc 0771c589 md5 729fddd99e81e892eb6c43fa57d21625 sha1 47a44c1db0722cfab22af8180b344b139a1e375b )
+)
+
+game (
+	name "On-Eindige Kalender (19xx)(-)(nl)"
+	description "On-Eindige Kalender (19xx)(-)(nl)"
+	rom ( name "On-Eindige Kalender (19xx)(-)(nl).p" size 3240 crc 7fd19bc0 md5 8b1168cc1b3b7e1d6f24dd1afee6a298 sha1 5d3d9de93305d96c10c9bddaeddb95f26ccf8320 )
+)
+
+game (
+	name "Onbekend (19xx)(-)(nl)"
+	description "Onbekend (19xx)(-)(nl)"
+	rom ( name "Onbekend (19xx)(-)(nl).p" size 1782 crc 8c6f1707 md5 719a45a5771e6e47f36f5eb7647594be sha1 e09565ab205923313b82329fa24d435ab1119039 )
+)
+
+game (
+	name "Op Avontuur Met de Enterprise (19xx)(-)(nl)"
+	description "Op Avontuur Met de Enterprise (19xx)(-)(nl)"
+	rom ( name "Op Avontuur Met de Enterprise (19xx)(-)(nl).p" size 15031 crc 89fae023 md5 97283de4e8f236f7257080b31af2b8b3 sha1 ac65199f39eea52cae6f4c20c436a185dcd9cde4 )
+)
+
+game (
+	name "Orbiter (19xx)(Herosoft)(nl)"
+	description "Orbiter (19xx)(Herosoft)(nl)"
+	rom ( name "Orbiter (19xx)(Herosoft)(nl).p" size 11539 crc bd82a39e md5 701b0d52747f79ed3bc5d7297837a49c sha1 0e293dae4a5ada4b72cd0b4edeaf7940219b73fb )
+)
+
+game (
+	name "Oregon Trail (1982)(Marion Stubbs)"
+	description "Oregon Trail (1982)(Marion Stubbs)"
+	rom ( name "Oregon Trail (1982)(Marion Stubbs).p" size 15405 crc 09693333 md5 7b04c77621dd02f3c72e28d75a52b72e sha1 abdd2597f4e2d2566fbf6833c73062535818f6aa )
+)
+
+game (
+	name "Orion (19xx)(-)(de)"
+	description "Orion (19xx)(-)(de)"
+	rom ( name "Orion (19xx)(-)(de).p" size 5246 crc d55708aa md5 121ca5b0f4b5b39dab51db54b196a88d sha1 ade19943f6643fa8497723268812686af3a59556 )
+)
+
+game (
+	name "Othello (1981)(Vortex Software)"
+	description "Othello (1981)(Vortex Software)"
+	rom ( name "Othello (1981)(Vortex Software).p" size 11664 crc 7a73fa9e md5 b74dd52ea38ce43cdfc890c3e98a0c22 sha1 8786f2970a7781bca94c644371fa4217342524c0 )
+)
+
+game (
+	name "Othello (19xx)(-)(de)"
+	description "Othello (19xx)(-)(de)"
+	rom ( name "Othello (19xx)(-)(de).p" size 5339 crc 36103995 md5 ba8350d60b07c13c15c2e56197d3fb5e sha1 4f742d1255ad8c31c60ab457ab256263eb6d9148 )
+)
+
+game (
+	name "Overdrive (1983)(Peter Davis)[m David Buttery]"
+	description "Overdrive (1983)(Peter Davis)[m David Buttery]"
+	rom ( name "Overdrive (1983)(Peter Davis)[m David Buttery].p" size 2144 crc 7c9e68ee md5 70bb883a7db6ba0458fc8cc2238cadf5 sha1 3011e193ddfde476bc4523c9e2be7748d2b08ea6 )
+)
+
+game (
+	name "OXO (19xx)(-)"
+	description "OXO (19xx)(-)"
+	rom ( name "OXO (19xx)(-).p" size 1434 crc febbc5c6 md5 b78a3aeabfadd13a738513646f4aea5a sha1 efc7b397b2f4c0538fd6156ba833fbbf1aba41bd )
+)
+
+game (
+	name "Pac-81 (1984)(Your Computer)"
+	description "Pac-81 (1984)(Your Computer)"
+	rom ( name "Pac-81 (1984)(Your Computer).p" size 4181 crc 657df1f4 md5 105f252df3f5616a63242a9a712061a0 sha1 b01baa5c6ed8d45390b0e101c8bb4482f85ad0be )
+)
+
+game (
+	name "Pac-81 (19xx)(Danny Loeff)"
+	description "Pac-81 (19xx)(Danny Loeff)"
+	rom ( name "Pac-81 (19xx)(Danny Loeff).p" size 4134 crc 6538dc14 md5 60acc9a8cb223f11ac542b6071e75723 sha1 aa327b6a1dab0a4bec60f3ba4cb280f4314d736e )
+)
+
+game (
+	name "Pac-man (19xx)(Logical Computers)(nl)"
+	description "Pac-man (19xx)(Logical Computers)(nl)"
+	rom ( name "Pac-man (19xx)(Logical Computers)(nl).p" size 7726 crc d9011462 md5 9e528a232fe868d7ebaf78d77de769a8 sha1 1c80386fdcc29e10b5f096c5ac3a0e1f24d2d8f8 )
+)
+
+game (
+	name "Pace (19xx)(-)"
+	description "Pace (19xx)(-)"
+	rom ( name "Pace (19xx)(-).p" size 1845 crc 3c1106b6 md5 befc39bcd222a35acd1cc9c125470e6d sha1 71ae0f8b92e880fc142126a065e0e32f7ad62ada )
+)
+
+game (
+	name "Packman (1983)(Gammasoft)(nl)"
+	description "Packman (1983)(Gammasoft)(nl)"
+	rom ( name "Packman (1983)(Gammasoft)(nl).p" size 10514 crc e666d2bf md5 8c2bfad4fe03b60634b8e92efd834fe8 sha1 2318b76087f49214f927ab864b370d052a13fca5 )
+)
+
+game (
+	name "Packman (19xx)(-)(nl)"
+	description "Packman (19xx)(-)(nl)"
+	rom ( name "Packman (19xx)(-)(nl).p" size 3801 crc 32e3af5f md5 3fe9c303e8a624cbeed490a538c11921 sha1 e63f5aa21711226b97d88ab8521cc2ed4461398f )
+)
+
+game (
+	name "Pacman (19xx)(-)"
+	description "Pacman (19xx)(-)"
+	rom ( name "Pacman (19xx)(-).p" size 3707 crc 0bcfe352 md5 3593003030a73f777b8805c9f6b5b453 sha1 1486734d3c005c7328c47283761e009005d3d1d1 )
+)
+
+game (
+	name "Pacman (19xx)(Philip Harwood)"
+	description "Pacman (19xx)(Philip Harwood)"
+	rom ( name "Pacman (19xx)(Philip Harwood).p" size 4427 crc c9f05a03 md5 e7044d044ebf4b6026c09bfcfd10876a sha1 8bfc07cf768ef52d84597a5578f6ba5f12431c43 )
+)
+
+game (
+	name "Pacman (19xx)(Philip Harwood)[a]"
+	description "Pacman (19xx)(Philip Harwood)[a]"
+	rom ( name "Pacman (19xx)(Philip Harwood)[a].p" size 4405 crc 5afecba8 md5 fcc31744b9e276ffb9d9169a808937a0 sha1 1d76db42957fb26ebe041867d4ef4a1af9496dd7 )
+)
+
+game (
+	name "Pacman (19xx)(Solidware)(nl)"
+	description "Pacman (19xx)(Solidware)(nl)"
+	rom ( name "Pacman (19xx)(Solidware)(nl).p" size 4378 crc 5b9165a4 md5 96fb45f5f97563a102e21ada1f44c541 sha1 bce6cd13f9755a9933ac1750f75db6e48b239507 )
+)
+
+game (
+	name "Pacman (19xx)(Solidware)(nl)[a]"
+	description "Pacman (19xx)(Solidware)(nl)[a]"
+	rom ( name "Pacman (19xx)(Solidware)(nl)[a].p" size 4380 crc 5d586faa md5 6703ad8f4a3dc6f16bbb7ccbef594a69 sha1 c2b3dc8a392c6e1a0bf49678e030cc9d693339a8 )
+)
+
+game (
+	name "Pairs (1982)(P. Rushton)"
+	description "Pairs (1982)(P. Rushton)"
+	rom ( name "Pairs (1982)(P. Rushton).p" size 10187 crc 386dbc3f md5 64ce93245be830173832ff8413ff3f06 sha1 900ee3023b930a3570fcd122e09a41a34def102c )
+)
+
+game (
+	name "Pakkerik (19xx)(-)(nl)"
+	description "Pakkerik (19xx)(-)(nl)"
+	rom ( name "Pakkerik (19xx)(-)(nl).p" size 2213 crc 1e14be6f md5 305584c779e7bb4234d99bf6745e60d4 sha1 21045c94d47d3c9fc8ff39a5511feb768f0f06aa )
+)
+
+game (
+	name "Panzer Schlacht (1982)(H. Stamm)"
+	description "Panzer Schlacht (1982)(H. Stamm)"
+	rom ( name "Panzer Schlacht (1982)(H. Stamm).p" size 3459 crc 61ade8f2 md5 9bbf487dc4f3921c3385b5b42f772744 sha1 1f5c74999cb544065700e93f53e89043a2ab317d )
+)
+
+game (
+	name "Panzer Schlacht (1982)(H. Stamm)[a]"
+	description "Panzer Schlacht (1982)(H. Stamm)[a]"
+	rom ( name "Panzer Schlacht (1982)(H. Stamm)[a].p" size 3444 crc 68129597 md5 b15cc654947304db32749d67c9195952 sha1 0c6d5c071178c9869c8c8f5c7c984f9add11d7ab )
+)
+
+game (
+	name "Panzerde (19xx)(-)"
+	description "Panzerde (19xx)(-)"
+	rom ( name "Panzerde (19xx)(-).p" size 1120 crc 885254de md5 a6b788659708a39739006fca99572111 sha1 a83b843e82c3db3a6f3c35e128a1cf8b0c86fe0c )
+)
+
+game (
+	name "Parachoot (1982)(P. du Plessis)"
+	description "Parachoot (1982)(P. du Plessis)"
+	rom ( name "Parachoot (1982)(P. du Plessis).p" size 5536 crc 0e36c35e md5 3f6850ab82c6bfef97d7f6398ce95e7e sha1 a39e271c1db7ef39b841060cb359b7848367009f )
+)
+
+game (
+	name "Patience (19xx)(-)"
+	description "Patience (19xx)(-)"
+	rom ( name "Patience (19xx)(-).p" size 6435 crc 4c651f37 md5 2d166da9a16d275483db5db765f8ec8f sha1 4e2890ba4abad263479ddb7a2a27ef2247d2933d )
+)
+
+game (
+	name "Patience (19xx)(-)[a]"
+	description "Patience (19xx)(-)[a]"
+	rom ( name "Patience (19xx)(-)[a].p" size 3716 crc c8e4551d md5 89b644eb432c66d911b8f44077ad7e02 sha1 0771fd146e3a936e2a45977e4cce081dd4c09b52 )
+)
+
+game (
+	name "Patterns (19xx)(-)"
+	description "Patterns (19xx)(-)"
+	rom ( name "Patterns (19xx)(-).p" size 1536 crc 1c31bda8 md5 1e928ab808d94a1073e125a7dc326231 sha1 161d5bd489bd1ea60d9e7ef7a1e5f7670906d9d5 )
+)
+
+game (
+	name "Patterns (19xx)(-)[a]"
+	description "Patterns (19xx)(-)[a]"
+	rom ( name "Patterns (19xx)(-)[a].p" size 1161 crc 376d17a9 md5 d9d14b4e9cafe805634eff203fe1d4a4 sha1 4ff753e9281cb026ff06a283d57624ce620c9b9a )
+)
+
+game (
+	name "Peeper (19xx)(VVP Software)"
+	description "Peeper (19xx)(VVP Software)"
+	rom ( name "Peeper (19xx)(VVP Software).p" size 3260 crc 7eb63b52 md5 b18b78aa632323bad5d83d8fc8539ffc sha1 646da04bed95b3ba7f7a80e2bd153cf4eeff44fc )
+)
+
+game (
+	name "Pengoinscape Navigator (19xx)(-)"
+	description "Pengoinscape Navigator (19xx)(-)"
+	rom ( name "Pengoinscape Navigator (19xx)(-).p" size 2281 crc 9c15ccba md5 0d162e2c8ad11c665d3888bdea901dda sha1 7ff753f56b5c89964f1ae275d2cd6af833e42698 )
+)
+
+game (
+	name "Perilous Swamp (1981)(Psion Software - Sinclair Research)[16K]"
+	description "Perilous Swamp (1981)(Psion Software - Sinclair Research)[16K]"
+	rom ( name "Perilous Swamp (1981)(Psion Software - Sinclair Research)[16K].p" size 10199 crc ff25fb71 md5 d0d4de6814276b20df5d596603c2ec26 sha1 611f4ba2dc8bf40952213d49ede8ea552bd2bf71 )
+)
+
+game (
+	name "Perilous Swamp (1981)(Psion Software - Sinclair Research)[a2][16K]"
+	description "Perilous Swamp (1981)(Psion Software - Sinclair Research)[a2][16K]"
+	rom ( name "Perilous Swamp (1981)(Psion Software - Sinclair Research)[a2][16K].p" size 10229 crc 1c2f931d md5 78be0d2c31835736247337fe8ca4bda9 sha1 c719f23b86a37b881dec6e75024734c72b643ba5 )
+)
+
+game (
+	name "Perilous Swamp (1981)(Psion Software - Sinclair Research)[a][16K]"
+	description "Perilous Swamp (1981)(Psion Software - Sinclair Research)[a][16K]"
+	rom ( name "Perilous Swamp (1981)(Psion Software - Sinclair Research)[a][16K].p" size 10229 crc fc9d8086 md5 ec918baffcd12f2b88e7bc6a22f110b6 sha1 a4bbe6585264d55a8b64b49fdb71dbcd166f1ab5 )
+)
+
+game (
+	name "Periodic Table, The (19xx)(-)"
+	description "Periodic Table, The (19xx)(-)"
+	rom ( name "Periodic Table, The (19xx)(-).p" size 4366 crc 172adc44 md5 ff5b9b8f0c2a6eb2f1853482a47872ef sha1 fee94ffef2bff2c4b90757c00282d1ad348676d8 )
+)
+
+game (
+	name "Perpetua (19xx)(-)"
+	description "Perpetua (19xx)(-)"
+	rom ( name "Perpetua (19xx)(-).p" size 1189 crc 898a9f1f md5 18e28bb02a2dc78e04f02cbe470870fa sha1 154cbebe6554c59ac866e89bcf3b2b6058ae8f90 )
+)
+
+game (
+	name "Personal Affair (1985)(-)"
+	description "Personal Affair (1985)(-)"
+	rom ( name "Personal Affair (1985)(-).p" size 3580 crc 7847c589 md5 aaa1a406989d00c36bb14b97ca58e139 sha1 5800e1a2857be386b4fcba3507f5c4b4db25a6af )
+)
+
+game (
+	name "Pert-cpm (19xx)(-)"
+	description "Pert-cpm (19xx)(-)"
+	rom ( name "Pert-cpm (19xx)(-).p" size 3216 crc cbb96230 md5 2fd9312aa7753834f58f52f7ef0db13e sha1 15da5d680b5e92b56f657fcace437d41813df931 )
+)
+
+game (
+	name "Pharaos Tomb, The (1982)(Phipps Associates)"
+	description "Pharaos Tomb, The (1982)(Phipps Associates)"
+	rom ( name "Pharaos Tomb, The (1982)(Phipps Associates).p" size 16154 crc 153dd680 md5 32ac3f2a51bec4475b701a2e5224950b sha1 35cee859b6b3b4f215f0963466de15235925ca14 )
+)
+
+game (
+	name "Phoenix Attack (19xx)(-)"
+	description "Phoenix Attack (19xx)(-)"
+	rom ( name "Phoenix Attack (19xx)(-).p" size 5186 crc 65dba545 md5 0672b370fca879f48b27d529cbb0074a sha1 a06a93249f674e6caa9b9e5c7a3c0731b7071d5f )
+)
+
+game (
+	name "Pickdraw (1985)(JSKOSoft)(nl)"
+	description "Pickdraw (1985)(JSKOSoft)(nl)"
+	rom ( name "Pickdraw (1985)(JSKOSoft)(nl).p" size 3739 crc 0d5362ed md5 8c30ff8fb498cdf5d0975a2da536a79f sha1 f276d82f7b73a5964ecad3fe7e5c539182ddff27 )
+)
+
+game (
+	name "Pickdraw (1985)(JSKOSoft)(nl)[a]"
+	description "Pickdraw (1985)(JSKOSoft)(nl)[a]"
+	rom ( name "Pickdraw (1985)(JSKOSoft)(nl)[a].p" size 3684 crc fc6df6dd md5 9671269c73f12cfa7adfcabcdf8d92fa sha1 5b419aecdad59c5638a9a868fd1337e793bbc4b6 )
+)
+
+game (
+	name "Pilot (1982)(M. Male)"
+	description "Pilot (1982)(M. Male)"
+	rom ( name "Pilot (1982)(M. Male).p" size 14880 crc 3c18456b md5 d664135e3a67ed5be48bb2d7c1ddf9d4 sha1 698e8b3aab9b1c134927805a6211913aad2fc75b )
+)
+
+game (
+	name "Pilot (1982)(M. Male)[a]"
+	description "Pilot (1982)(M. Male)[a]"
+	rom ( name "Pilot (1982)(M. Male)[a].p" size 13096 crc 522d64b5 md5 c8d871040c153408496af14afaf08da4 sha1 dcf4319ddc15d859dfa6722002e2d73ed6f094bf )
+)
+
+game (
+	name "Pinball (19xx)(-)"
+	description "Pinball (19xx)(-)"
+	rom ( name "Pinball (19xx)(-).p" size 2931 crc b3ac3a06 md5 45b65241e5bf99ea782a9c956c27548d sha1 3444fb8d5afb1f12abff7c0b59e9b029245329a6 )
+)
+
+game (
+	name "Pinball 2 (19xx)(Timex)"
+	description "Pinball 2 (19xx)(Timex)"
+	rom ( name "Pinball 2 (19xx)(Timex).p" size 4733 crc 5332410b md5 e8b0d53eae8623d9e8f91b24c5cfd00f sha1 38ae2f2b742ad41164dc10579b914a80a78ad58b )
+)
+
+game (
+	name "Pinball 2 (19xx)(Timex)(nl)"
+	description "Pinball 2 (19xx)(Timex)(nl)"
+	rom ( name "Pinball 2 (19xx)(Timex)(nl).p" size 4790 crc d322661e md5 637288bcac58002940bfb3cffb962296 sha1 1e098e6162a56d379ddf40cdcf20b0906804c82f )
+)
+
+game (
+	name "Pinball Basic (19xx)(-)"
+	description "Pinball Basic (19xx)(-)"
+	rom ( name "Pinball Basic (19xx)(-).p" size 3153 crc b331d99d md5 b331ad941b741ed65f9d0a87ab54e688 sha1 c9fe5513f989e80fb88a3f5fa83fca607fcf9254 )
+)
+
+game (
+	name "Pinbat (1984)(J. Dave Rogers - Colin Hogg)"
+	description "Pinbat (1984)(J. Dave Rogers - Colin Hogg)"
+	rom ( name "Pinbat (1984)(J. Dave Rogers - Colin Hogg).p" size 10128 crc 6acd97fe md5 58db2fb45e421960c808ec78cfe2f5c0 sha1 31d80af3317465d953f85180034c07e16bf25351 )
+)
+
+game (
+	name "Pit (19xx)(Jim Enness)"
+	description "Pit (19xx)(Jim Enness)"
+	rom ( name "Pit (19xx)(Jim Enness).p" size 14235 crc 271c8946 md5 7cddd6ffd3116163f96f2914ce109d5b sha1 df550ba9d75d6d1d7852d8f1af97dc7888f568df )
+)
+
+game (
+	name "Pit with Monsters (19xx)(Jim Enness)"
+	description "Pit with Monsters (19xx)(Jim Enness)"
+	rom ( name "Pit with Monsters (19xx)(Jim Enness).p" size 12536 crc 52072bff md5 905b57b41c971f5c8762520bf21e3636 sha1 362e442c7fc44c810f65502b0b2c0ed0c3069499 )
+)
+
+game (
+	name "Pit with Monsters (19xx)(Jim Enness)[a]"
+	description "Pit with Monsters (19xx)(Jim Enness)[a]"
+	rom ( name "Pit with Monsters (19xx)(Jim Enness)[a].p" size 14225 crc 5bebe353 md5 bf6647022380fe5c35538d4043c9551b sha1 7d2353bb1c7907b9124413fdc18e37f94aa0f093 )
+)
+
+game (
+	name "Plane Annoying (19xx)(-)"
+	description "Plane Annoying (19xx)(-)"
+	rom ( name "Plane Annoying (19xx)(-).p" size 4363 crc a888958f md5 7fd3615250cfdd7d856a2d57782b92ee sha1 91cc51da3dd9681b805a21f152f4e3c4a3dee5e2 )
+)
+
+game (
+	name "Planetoids (19xx)(Macronics Systems)"
+	description "Planetoids (19xx)(Macronics Systems)"
+	rom ( name "Planetoids (19xx)(Macronics Systems).p" size 4923 crc 1538b432 md5 15d1e7b07edd76014799e1338d398a5b sha1 80f607b373f762cb08caee940dd17869e417df5d )
+)
+
+game (
+	name "Platinen Editor (19xx)(Markus Schinhaerl)(de)"
+	description "Platinen Editor (19xx)(Markus Schinhaerl)(de)"
+	rom ( name "Platinen Editor (19xx)(Markus Schinhaerl)(de).p" size 4588 crc 536eb1d4 md5 01f6f5c5a8d898d8f2c2d58902dc0f99 sha1 886289158dd60b632f18228668c38b078f29a5cb )
+)
+
+game (
+	name "Playback (19xx)(-)"
+	description "Playback (19xx)(-)"
+	rom ( name "Playback (19xx)(-).p" size 1395 crc a2535e47 md5 c0542415af25be1995f1f9e04ead256d sha1 e727c38f913a013331254dac0a3ee12f102951a3 )
+)
+
+game (
+	name "Pleiaden (19xx)(Solidware)"
+	description "Pleiaden (19xx)(Solidware)"
+	rom ( name "Pleiaden (19xx)(Solidware).p" size 3481 crc a0bb9fec md5 c25fbc46feb5a157e2840be8aff6c860 sha1 46174b926959b439b62106f2686874db548b45a3 )
+)
+
+game (
+	name "Plot (19xx)(-)(nl)"
+	description "Plot (19xx)(-)(nl)"
+	rom ( name "Plot (19xx)(-)(nl).p" size 1015 crc 327424db md5 6a23f99bb0f2c24dac606ba0f866dd3f sha1 58464e38b8de4719c52bd6202f1ae824d747c1ac )
+)
+
+game (
+	name "Plot 1 (19xx)(-)"
+	description "Plot 1 (19xx)(-)"
+	rom ( name "Plot 1 (19xx)(-).p" size 1072 crc 05c9e1b7 md5 10b404ae9553a3278d556c2def248f7b sha1 eb7b45e4ba46bace826fc9f0d1dcc779fc06f506 )
+)
+
+game (
+	name "Plus (19xx)(-)"
+	description "Plus (19xx)(-)"
+	rom ( name "Plus (19xx)(-).p" size 1001 crc b6fcc7c7 md5 ffabe302d5df8f699f30b7681618fe10 sha1 9d17e9e6d2b1c9e20475b99ab3ec4592237bf3b6 )
+)
+
+game (
+	name "Poke REM (19xx)(-)"
+	description "Poke REM (19xx)(-)"
+	rom ( name "Poke REM (19xx)(-).p" size 601 crc 5836397a md5 30f497ebbb0ef1206aa4d2050163b2de sha1 95b182e08c0d0564fde6f574eb39bdeb40452566 )
+)
+
+game (
+	name "Poker (1984)(John Ancona)(nl)"
+	description "Poker (1984)(John Ancona)(nl)"
+	rom ( name "Poker (1984)(John Ancona)(nl).p" size 14378 crc fd3d9a67 md5 483cab346f720e6c6f670465a68221ad sha1 b783ba16da6dbde743663fde34b18c090a21c7ea )
+)
+
+game (
+	name "Poker (1984)(John Ancona)(nl)[a]"
+	description "Poker (1984)(John Ancona)(nl)[a]"
+	rom ( name "Poker (1984)(John Ancona)(nl)[a].p" size 14415 crc d3127603 md5 4f76fb989c2a90d806b8a828618193f9 sha1 d2274de687adc069f55336576cfdbd90b4dc8e19 )
+)
+
+game (
+	name "Poker (19xx)(-)(de)"
+	description "Poker (19xx)(-)(de)"
+	rom ( name "Poker (19xx)(-)(de).p" size 2865 crc 6bc0fc15 md5 5acf3eead9acd19b428b77560f9445e2 sha1 2d8b8f62543f0b4e976873b1f00b8acad6c4ba5b )
+)
+
+game (
+	name "Polar-Kartesische (19xx)(-)(de)"
+	description "Polar-Kartesische (19xx)(-)(de)"
+	rom ( name "Polar-Kartesische (19xx)(-)(de).p" size 2051 crc 8ec573c1 md5 a36c29698183c487c24be6095c68c8e1 sha1 cf697373e2d4351a2753d6ae1d7a5e957e060de2 )
+)
+
+game (
+	name "Pongy (1985)(Miquel van Smoorenburg)"
+	description "Pongy (1985)(Miquel van Smoorenburg)"
+	rom ( name "Pongy (1985)(Miquel van Smoorenburg).p" size 5285 crc 009deb58 md5 8f8316ceb21bd1ce7f45c5598daa5f4f sha1 e9411ceb57fe304c0555df058a22d7e788b54518 )
+)
+
+game (
+	name "Pontoon (1981)(Vortex Software)"
+	description "Pontoon (1981)(Vortex Software)"
+	rom ( name "Pontoon (1981)(Vortex Software).p" size 7761 crc b24e39c9 md5 fe32b8bea58ecf948042f438e98cb553 sha1 c32e58d5a5d66d1d0107518489016fe302776b9d )
+)
+
+game (
+	name "Pontoon (1983)(Sinclair User)"
+	description "Pontoon (1983)(Sinclair User)"
+	rom ( name "Pontoon (1983)(Sinclair User).p" size 1525 crc 14cabbb3 md5 53ab9ccaa9f951dbbc498b5ef56f21da sha1 56b710b93b42bf3d91b4c1307e5e9ddc57995b91 )
+)
+
+game (
+	name "Pookah Partial Pascal (1983)(Semper Software)"
+	description "Pookah Partial Pascal (1983)(Semper Software)"
+	rom ( name "Pookah Partial Pascal (1983)(Semper Software).p" size 11858 crc 0f89efff md5 746ed96ac1c52f5ce79f157c99a91532 sha1 a908f63c59fcac6a550f492f755c6f9a3e89954b )
+)
+
+game (
+	name "Possesed (19xx)(VVP Software)(nl)"
+	description "Possesed (19xx)(VVP Software)(nl)"
+	rom ( name "Possesed (19xx)(VVP Software)(nl).p" size 2582 crc 6cd5cb68 md5 014a76ab8a8322418935b55c1df96c10 sha1 444078390bcc68000a7615f720654a7f1beaadc0 )
+)
+
+game (
+	name "Postage Rates (19xx)(-)"
+	description "Postage Rates (19xx)(-)"
+	rom ( name "Postage Rates (19xx)(-).p" size 1545 crc 1eb2247b md5 e84eaed77aae6e4553887710f91fad4f sha1 155ee93c6028c1623e70962e9e4b4031b460cd98 )
+)
+
+game (
+	name "Prime Numbers (19xx)(-)"
+	description "Prime Numbers (19xx)(-)"
+	rom ( name "Prime Numbers (19xx)(-).p" size 1415 crc 6c7c0ad5 md5 a17942343c16e431baf89ed914f55ba8 sha1 5769acea7b149a7c20f27ee653bd2b7fbad5320e )
+)
+
+game (
+	name "Princess of Kraal, The (19xx)(N. Streeter)"
+	description "Princess of Kraal, The (19xx)(N. Streeter)"
+	rom ( name "Princess of Kraal, The (19xx)(N. Streeter).p" size 13263 crc 3a1691b5 md5 4a05d31d14beb6d668a5d0f8b4653b50 sha1 f07637637bf9536eaf2933837258959816ba159d )
+)
+
+game (
+	name "Progmerge v004 (1983)(J.C. van Leijden)"
+	description "Progmerge v004 (1983)(J.C. van Leijden)"
+	rom ( name "Progmerge v004 (1983)(J.C. van Leijden).p" size 3635 crc 00c53c31 md5 bf6de63471d82c8a6bcacaa5e6bb9255 sha1 45a6ced7200807db3ac7668ff89a22c03c54b0d8 )
+)
+
+game (
+	name "Program Aid (1985)(-)(nl)[8K]"
+	description "Program Aid (1985)(-)(nl)[8K]"
+	rom ( name "Program Aid (1985)(-)(nl)[8K].p" size 12836 crc 95f11ce5 md5 dffe136fe756f49111f185969a4988d9 sha1 6b68dcd093b1988572939a85bcc487050040daa8 )
+)
+
+game (
+	name "Protector (19xx)(Abacus Programs)"
+	description "Protector (19xx)(Abacus Programs)"
+	rom ( name "Protector (19xx)(Abacus Programs).p" size 7601 crc 17c4a35b md5 3666b35962a87bf4851ab854abe8649d sha1 0f0417551cc0716b69e93cd5eda7dec4e90fc0f4 )
+)
+
+game (
+	name "Protector (19xx)(Abacus Programs)[a]"
+	description "Protector (19xx)(Abacus Programs)[a]"
+	rom ( name "Protector (19xx)(Abacus Programs)[a].p" size 7632 crc eb807093 md5 3efa915084c9ec6c828c6494ee19ba7a sha1 9fcab79c625d07d4b881ec3f23f4076c30d8a071 )
+)
+
+game (
+	name "Psion Backgammon (1981)(Psion Software)[16K]"
+	description "Psion Backgammon (1981)(Psion Software)[16K]"
+	rom ( name "Psion Backgammon (1981)(Psion Software)[16K].p" size 14374 crc 58b55770 md5 141e6da7f2e3b73b85bae70d4d8dcd4f sha1 ca2aa2acd6a86a605c11e2d75aad88227eb6baf4 )
+)
+
+game (
+	name "Psion Dice (1981)(Psion Software)"
+	description "Psion Dice (1981)(Psion Software)"
+	rom ( name "Psion Dice (1981)(Psion Software).p" size 1751 crc e85c0c96 md5 4b2e23db5246e3efd36f0cdd7d7fe3fd sha1 d050f6783b492b82d1c21122d3a4e974e3dc85da )
+)
+
+game (
+	name "Pulga, La (1983)(Indescomp)(es)"
+	description "Pulga, La (1983)(Indescomp)(es)"
+	rom ( name "Pulga, La (1983)(Indescomp)(es).p" size 10370 crc 827d5ef6 md5 e05795a782e05312311d809585f9e7de sha1 41a2cd1d49a21901f5b26d6ae2d0ea8c52e86622 )
+)
+
+game (
+	name "Pulga, La (1983)(Indescomp)(es)[a]"
+	description "Pulga, La (1983)(Indescomp)(es)[a]"
+	rom ( name "Pulga, La (1983)(Indescomp)(es)[a].p" size 9995 crc 4adfc78a md5 f05ff23f0db1567337ec7aaf74cdf3b5 sha1 a18663d20f725fa108afce81f08907d971ee998d )
+)
+
+game (
+	name "Pyramid (1981)(J.K. Greye Software)"
+	description "Pyramid (1981)(J.K. Greye Software)"
+	rom ( name "Pyramid (1981)(J.K. Greye Software).p" size 4752 crc 7784faff md5 9a5d27d4ee57c530c2bf2e992af09bec sha1 2cd6ad29a607c39366cce82313789fedafdc5458 )
+)
+
+game (
+	name "Pyramid (1981)(J.K. Greye Software)[a]"
+	description "Pyramid (1981)(J.K. Greye Software)[a]"
+	rom ( name "Pyramid (1981)(J.K. Greye Software)[a].p" size 4591 crc ca519ec0 md5 dd080db8e38738123386792e6960106f sha1 85853f9f9c2f64d1031d7f7b98579dd34b79ff97 )
+)
+
+game (
+	name "Pyramid (19xx)(-)"
+	description "Pyramid (19xx)(-)"
+	rom ( name "Pyramid (19xx)(-).p" size 1095 crc 2550c34a md5 7156a2c141bd331428f86bc5c885f379 sha1 ca4e5e66a2d4132b7b9fed433a013d51665febed )
+)
+
+game (
+	name "Pyramide (19xx)(Synacroop Software)"
+	description "Pyramide (19xx)(Synacroop Software)"
+	rom ( name "Pyramide (19xx)(Synacroop Software).p" size 9229 crc 40dd3c28 md5 af239746f34b0cce4460eaca199f94c6 sha1 0b0be603fa04efdbf71998f32cc0d72b19bb3a2b )
+)
+
+game (
+	name "Pythagoras im Urlaub (19xx)(-)(de)"
+	description "Pythagoras im Urlaub (19xx)(-)(de)"
+	rom ( name "Pythagoras im Urlaub (19xx)(-)(de).p" size 6906 crc b598838f md5 6824cc701ce9ffdc30d541df8640aa53 sha1 8dd8ec0fd91f95c10e9d2566cdf2bd52bdb4549b )
+)
+
+game (
+	name "Q Bert! (19xx)(Simon Software)"
+	description "Q Bert! (19xx)(Simon Software)"
+	rom ( name "Q Bert! (19xx)(Simon Software).p" size 12191 crc dca73283 md5 2f22468f7c9d1ab1acdfe6a4aa48e328 sha1 c875ec0b96ed6add4e2cba036c7a6c868d92407b )
+)
+
+game (
+	name "QTH - Afstanden Door (1983)(L. Kusters)(nl)"
+	description "QTH - Afstanden Door (1983)(L. Kusters)(nl)"
+	rom ( name "QTH - Afstanden Door (1983)(L. Kusters)(nl).p" size 5451 crc f5404f83 md5 7f527fe1a618772524c9ccd48528958c sha1 efba9031eb221b614b4843d8c96aec6a2971fe14 )
+)
+
+game (
+	name "Quadratische Gleichung (19xx)(-)(de)"
+	description "Quadratische Gleichung (19xx)(-)(de)"
+	rom ( name "Quadratische Gleichung (19xx)(-)(de).p" size 3155 crc 9cc1d551 md5 dd02cd370c79c84a9931a88f1cb7bf93 sha1 cf119672e37f3c7724f42479522820e1dc6e85a5 )
+)
+
+game (
+	name "Quadratische Gleichung (19xx)(-)(de)[a]"
+	description "Quadratische Gleichung (19xx)(-)(de)[a]"
+	rom ( name "Quadratische Gleichung (19xx)(-)(de)[a].p" size 3133 crc c19d0407 md5 df1a4a3ea0a545b8c66d8c0318a29d2e sha1 20fc2eb534e125b43d8d0add4c50af9aa28c7872 )
+)
+
+game (
+	name "Quadratische Gleichung (19xx)(-)(de)[different]"
+	description "Quadratische Gleichung (19xx)(-)(de)[different]"
+	rom ( name "Quadratische Gleichung (19xx)(-)(de)[different].p" size 1652 crc 4e272aea md5 4ae930f6cb2679e7f303e9a93608bc4e sha1 27d5e3fbac54cbabff5a33ec21537e7ee5381f61 )
+)
+
+game (
+	name "Rabbits (1983)(Fontana Publishing)"
+	description "Rabbits (1983)(Fontana Publishing)"
+	rom ( name "Rabbits (1983)(Fontana Publishing).p" size 4949 crc acce31a4 md5 6b3f12fccd1750a0e2511bf373971df5 sha1 17584301a5863e2438479f7a5c88a79907ab7954 )
+)
+
+game (
+	name "Race (19xx)(-)"
+	description "Race (19xx)(-)"
+	rom ( name "Race (19xx)(-).p" size 1266 crc 42ec56df md5 c6adb4d5c48ec2468886bd5c6c0e6088 sha1 398d1c63aa9be4d1a1251879699b2f5381d6691a )
+)
+
+game (
+	name "Race Track (19xx)(-)"
+	description "Race Track (19xx)(-)"
+	rom ( name "Race Track (19xx)(-).p" size 16151 crc 8bc595fb md5 8305be6568648be17de136a5a0f47b81 sha1 a49993fcac9e35406e6bc25035cf792c3e8ca92c )
+)
+
+game (
+	name "Race Track (19xx)(-)[a]"
+	description "Race Track (19xx)(-)[a]"
+	rom ( name "Race Track (19xx)(-)[a].p" size 16185 crc 3da2f215 md5 a5f323c7488bd9fe2efaad173174d0c3 sha1 84a1cdbcb6afea173335e8d286f448b38de256e6 )
+)
+
+game (
+	name "Raider (19xx)(-)"
+	description "Raider (19xx)(-)"
+	rom ( name "Raider (19xx)(-).p" size 15125 crc 7a1b6f5e md5 1fcb1e9b7686948c0da658d54e785042 sha1 9ca4c844bead627cc0b30aa965b44a51558424cc )
+)
+
+game (
+	name "Raiders (19xx)(-)"
+	description "Raiders (19xx)(-)"
+	rom ( name "Raiders (19xx)(-).p" size 2877 crc e2de9c26 md5 43ccd67271e929aaed542e134e64263c sha1 af33a903172eed7d7de6891f98c7102e65b846cb )
+)
+
+game (
+	name "RAM Runner (19xx)(-)"
+	description "RAM Runner (19xx)(-)"
+	rom ( name "RAM Runner (19xx)(-).p" size 13305 crc 119fb1b0 md5 d6892cf3e07cdf56c8537c26175d07f2 sha1 6c362ff43f89f1f5db005ad42c73529b829f2e22 )
+)
+
+game (
+	name "Ramtop (19xx)(-)"
+	description "Ramtop (19xx)(-)"
+	rom ( name "Ramtop (19xx)(-).p" size 598 crc d45d3ba9 md5 bc8d78917261200e5420f41ea9d62036 sha1 82f2fb820d7eec83a2017260905c0a9129ebea85 )
+)
+
+game (
+	name "Random Dots 1 (19xx)(-)"
+	description "Random Dots 1 (19xx)(-)"
+	rom ( name "Random Dots 1 (19xx)(-).p" size 1184 crc ef45deb2 md5 f3def921b9dc064b2288b2e6abb0ffaa sha1 34c422851f6e86170ab766333225fb735b304d61 )
+)
+
+game (
+	name "Random Dots 2 (19xx)(-)"
+	description "Random Dots 2 (19xx)(-)"
+	rom ( name "Random Dots 2 (19xx)(-).p" size 2202 crc 2b225d20 md5 f756eea21fa7154f75415c6f1a11c54e sha1 bc833eeaaeae06748bdb89274edfeaf96e40c78a )
+)
+
+game (
+	name "Random Dots 3 (19xx)(-)"
+	description "Random Dots 3 (19xx)(-)"
+	rom ( name "Random Dots 3 (19xx)(-).p" size 2197 crc 1c6b499c md5 8e42c7db77828688c8c40ae09e52bc1d sha1 2e813cd03e99601a32e29d990819768e88331f9f )
+)
+
+game (
+	name "Random Squares (19xx)(-)"
+	description "Random Squares (19xx)(-)"
+	rom ( name "Random Squares (19xx)(-).p" size 1563 crc 7381a068 md5 bff5c79146e293f1e5e6d0b0b9aea590 sha1 7bad06d7eee04ee5fbbc2fec1efa7e428913c957 )
+)
+
+game (
+	name "Rank Order Program (19xx)(-)"
+	description "Rank Order Program (19xx)(-)"
+	rom ( name "Rank Order Program (19xx)(-).p" size 2622 crc fb664f7c md5 b010589f59763ad75ca6e08fb3e77efa sha1 4242634628cf6d88de71c6ed97b98c75dc60519a )
+)
+
+game (
+	name "Ravenous Reptile (19xx)(-)"
+	description "Ravenous Reptile (19xx)(-)"
+	rom ( name "Ravenous Reptile (19xx)(-).p" size 3033 crc e8f993a1 md5 444b1d2450ae1bc3dbafac446a11ec22 sha1 88ad4ebe4225e5c69b5f9f7673186e3042c891a2 )
+)
+
+game (
+	name "Reactie (19xx)(-)(nl)"
+	description "Reactie (19xx)(-)(nl)"
+	rom ( name "Reactie (19xx)(-)(nl).p" size 3114 crc 40b9a3f6 md5 38e7186d9527ada3329ea15c881f0478 sha1 3a30401e64c50b163a6417f444e4f011f8afdead )
+)
+
+game (
+	name "Reactie + Master Mind + Fruit Machine + Dubbel Dobbel (19xx)(RL Producties)(nl)"
+	description "Reactie + Master Mind + Fruit Machine + Dubbel Dobbel (19xx)(RL Producties)(nl)"
+	rom ( name "Reactie + Master Mind + Fruit Machine + Dubbel Dobbel (19xx)(RL Producties)(nl).p" size 8871 crc 15f727cd md5 6ed9e9fefc80733fde7521fba1f05a90 sha1 03b01b3894903b53f5e8f9d25716bdc335dad592 )
+)
+
+game (
+	name "Reactietest (19xx)(Peter V.D. Woude)(nl)"
+	description "Reactietest (19xx)(Peter V.D. Woude)(nl)"
+	rom ( name "Reactietest (19xx)(Peter V.D. Woude)(nl).p" size 2382 crc 5925e487 md5 c02cba09d800350a37e80a4ad3415dd6 sha1 6e1ae4fd076684197cc10e966c0789e3064cadac )
+)
+
+game (
+	name "Rechthoek Berekeningen (19xx)(-)(nl)"
+	description "Rechthoek Berekeningen (19xx)(-)(nl)"
+	rom ( name "Rechthoek Berekeningen (19xx)(-)(nl).p" size 1895 crc 1215bd1f md5 98ef78657c722cd1f7ce1765430bc68b sha1 f89db50366b5f51e8df4d60a26c8f67b311be2b5 )
+)
+
+game (
+	name "Reconnaissance Alert (19xx)(-)"
+	description "Reconnaissance Alert (19xx)(-)"
+	rom ( name "Reconnaissance Alert (19xx)(-).p" size 6131 crc 455c79c6 md5 5398c08ca09f682c23cda6cbc592ed7d sha1 04ef61a7fd956b9274d1f7d15f6088faa19a36c5 )
+)
+
+game (
+	name "Rectangles (19xx)(-)"
+	description "Rectangles (19xx)(-)"
+	rom ( name "Rectangles (19xx)(-).p" size 14285 crc 0490b639 md5 68198ba862fd7029ae8232653db40602 sha1 5b8175ca5c0b2c20febf79b272424aefe8607f97 )
+)
+
+game (
+	name "Red Alert (19xx)(-)"
+	description "Red Alert (19xx)(-)"
+	rom ( name "Red Alert (19xx)(-).p" size 4037 crc 4fbde0d8 md5 254af31e576f405beafa4ae7f3c035db sha1 e336f11a822235e06cb36389e727bd41549533f5 )
+)
+
+game (
+	name "Red Alert (19xx)(-)[a]"
+	description "Red Alert (19xx)(-)[a]"
+	rom ( name "Red Alert (19xx)(-)[a].p" size 4235 crc 7e7618f7 md5 1ba26ca542467892597a8fb086b3acce sha1 7add6e3691e2567a7281d3a7c5de2e37cc9e3e77 )
+)
+
+game (
+	name "Red Ants (1984)(Carlo Delhez)"
+	description "Red Ants (1984)(Carlo Delhez)"
+	rom ( name "Red Ants (1984)(Carlo Delhez).p" size 6215 crc 536d7ab6 md5 e2df8f8a21ac9eb7d948158a8a063f53 sha1 3452b1bf9d736c08b53417a42737d5ea60a25354 )
+)
+
+game (
+	name "Red Ants (1984)(Carlo Delhez)[a2]"
+	description "Red Ants (1984)(Carlo Delhez)[a2]"
+	rom ( name "Red Ants (1984)(Carlo Delhez)[a2].p" size 6156 crc 30957419 md5 157049bd79c4bbf970dfd9abb347a2ba sha1 8e315f66064ae74b10bfdd2dd9de0c5fbfc81145 )
+)
+
+game (
+	name "Red Ants (1984)(Carlo Delhez)[a]"
+	description "Red Ants (1984)(Carlo Delhez)[a]"
+	rom ( name "Red Ants (1984)(Carlo Delhez)[a].p" size 5982 crc 625ac95a md5 bbcc3d62ba01f403d07f88bd2e28d107 sha1 4db5f3cdbe0f2dbf8827b3877b9ecfc066f33f97 )
+)
+
+game (
+	name "Red Baron (1985)(VDS)"
+	description "Red Baron (1985)(VDS)"
+	rom ( name "Red Baron (1985)(VDS).p" size 4061 crc caefed67 md5 c5f4ea244643e2861fa0457c08ee7141 sha1 0d2e13b5a244baf47f00b5353789a6caec0f1355 )
+)
+
+game (
+	name "Rekenen (19xx)(-)(nl)"
+	description "Rekenen (19xx)(-)(nl)"
+	rom ( name "Rekenen (19xx)(-)(nl).p" size 8143 crc 09765f02 md5 d223fea7bdc3e5da2a94eca7c02fe981 sha1 0d9cb690dcd1def3a108fdfa705d18fcb38a465a )
+)
+
+game (
+	name "Relocate 2 - HEX LDR - Procaid Toolkit 1 (19xx)(-)(nl)"
+	description "Relocate 2 - HEX LDR - Procaid Toolkit 1 (19xx)(-)(nl)"
+	rom ( name "Relocate 2 - HEX LDR - Procaid Toolkit 1 (19xx)(-)(nl).p" size 4612 crc 9647ef3b md5 890d83ecb1069fcec04f25d7b6751877 sha1 f5e7ab7e35b392dc8e8d4d8d650d58470dec84b2 )
+)
+
+game (
+	name "REM Kill (19xx)(-)(nl)"
+	description "REM Kill (19xx)(-)(nl)"
+	rom ( name "REM Kill (19xx)(-)(nl).p" size 1817 crc 5b15f889 md5 f7e3a9f7ec5811f8d7460c2f057daad1 sha1 52407cb14f14042fbe95958e27416f8380a86bda )
+)
+
+game (
+	name "Rem Lader (19xx)(-)(de)"
+	description "Rem Lader (19xx)(-)(de)"
+	rom ( name "Rem Lader (19xx)(-)(de).p" size 1945 crc bdf54a50 md5 ae3018e8b7b27410e8dc137585fab81f sha1 cb144bc0311572ae40e76a84ef570bfd0b56360c )
+)
+
+game (
+	name "Renumber (19xx)(-)"
+	description "Renumber (19xx)(-)"
+	rom ( name "Renumber (19xx)(-).p" size 1176 crc 7de003fb md5 2d6862facde74ea23e5e4921aa13559c sha1 54ade2f88863092ae62494e0a1c9358396529dd1 )
+)
+
+game (
+	name "Return of the Galaxians (19xx)(-)"
+	description "Return of the Galaxians (19xx)(-)"
+	rom ( name "Return of the Galaxians (19xx)(-).p" size 3351 crc e404461c md5 98265bbdf44b535b866dde042ab49dcd sha1 e187bcc49ef1975bc018ea81b28c795a9f3dbb86 )
+)
+
+game (
+	name "Return of the Galaxians (19xx)(-)[a]"
+	description "Return of the Galaxians (19xx)(-)[a]"
+	rom ( name "Return of the Galaxians (19xx)(-)[a].p" size 3343 crc c3ad6079 md5 5d46290ad08cdb3a76e77eca49827489 sha1 bc6e99e739099fdd0f7c07705be57c5363b8a27b )
+)
+
+game (
+	name "Reverse Strings (19xx)(-)"
+	description "Reverse Strings (19xx)(-)"
+	rom ( name "Reverse Strings (19xx)(-).p" size 1079 crc 77b94e50 md5 3d89b606e3536b105736cc48754768fa sha1 03a3bc92e449c2d3429e89e994de4b2755c7245b )
+)
+
+game (
+	name "Reverse-Esrever Routine (19xx)(-)"
+	description "Reverse-Esrever Routine (19xx)(-)"
+	rom ( name "Reverse-Esrever Routine (19xx)(-).p" size 1462 crc f4489129 md5 927675acaa1c063a76c9190b43a2a34c sha1 cb10e8bb9eac208a42acb20dce2bacdc88dc7844 )
+)
+
+game (
+	name "Reversi (1982)(MOI)"
+	description "Reversi (1982)(MOI)"
+	rom ( name "Reversi (1982)(MOI).p" size 11249 crc b1fb4adc md5 d1c9fd3bae19d010a4b4738927bf1b38 sha1 a12cab64dc1143b2c7b50fa4da5fe47dd67bbe45 )
+)
+
+game (
+	name "Reversi (1982)(MOI)[a]"
+	description "Reversi (1982)(MOI)[a]"
+	rom ( name "Reversi (1982)(MOI)[a].p" size 11281 crc 33cefea4 md5 d27d975f83c943611286268d81cf51b1 sha1 2212cc0c65d4b9d62a93cccb525da07cc26befe7 )
+)
+
+game (
+	name "Reversi (19xx)(-)"
+	description "Reversi (19xx)(-)"
+	rom ( name "Reversi (19xx)(-).p" size 783 crc 4df061b3 md5 ff2d585652590577ffc63b5b84ede111 sha1 370e30047002537e6afb1056988622fc79bf0fe5 )
+)
+
+game (
+	name "Reversi (19xx)(-)(nl)"
+	description "Reversi (19xx)(-)(nl)"
+	rom ( name "Reversi (19xx)(-)(nl).p" size 7406 crc a2d4f1be md5 9823ca179d951bf32cccd8a62c174ead sha1 84792dd7a4181942803766da6948a1809a82293e )
+)
+
+game (
+	name "Reversi (19xx)(-)(nl)[different]"
+	description "Reversi (19xx)(-)(nl)[different]"
+	rom ( name "Reversi (19xx)(-)(nl)[different].p" size 4797 crc 8bb8e6d7 md5 7e38d1d91e4ba6cf85d30be04443b7fc sha1 7d800a1e67660c1badbec9b40207f938421f66e5 )
+)
+
+game (
+	name "Rhytm (19xx)(-)"
+	description "Rhytm (19xx)(-)"
+	rom ( name "Rhytm (19xx)(-).p" size 1473 crc e8776d25 md5 40e7a1badf8062e38b54975e4d4baf17 sha1 5cb2a837137d8c0958e94585218a979835fc313b )
+)
+
+game (
+	name "Road Racer (1983)(H. Dursch)(de)"
+	description "Road Racer (1983)(H. Dursch)(de)"
+	rom ( name "Road Racer (1983)(H. Dursch)(de).p" size 2028 crc 6dd8cea3 md5 aa3eb12d51fe05f22f873d7cae2ee930 sha1 c407b48edd4dc7288001ddef44ca29ccd92927c0 )
+)
+
+game (
+	name "Robot (1982)(P. du Plessis)"
+	description "Robot (1982)(P. du Plessis)"
+	rom ( name "Robot (1982)(P. du Plessis).p" size 8202 crc 9ddb15d4 md5 66021db26f838e3c8cdbfe6bea023f3d sha1 cc36507f9599d1a6788b991e88acb49290e7e3c7 )
+)
+
+game (
+	name "Robot War (19xx)(-)"
+	description "Robot War (19xx)(-)"
+	rom ( name "Robot War (19xx)(-).p" size 8829 crc 4f30ff6f md5 5a2aa96008fff05bb84f57c5d9753df0 sha1 f680fe8e2603c0b8c8f5f049981475b5be484190 )
+)
+
+game (
+	name "Robot War (19xx)(-)[a2]"
+	description "Robot War (19xx)(-)[a2]"
+	rom ( name "Robot War (19xx)(-)[a2].p" size 8862 crc 676b6668 md5 688c9ebf1921a66c37f2c9f8228b75b9 sha1 ffd93dd3f982a22bca4159ed5727c085ad62f9f4 )
+)
+
+game (
+	name "Robot War (19xx)(-)[a]"
+	description "Robot War (19xx)(-)[a]"
+	rom ( name "Robot War (19xx)(-)[a].p" size 8852 crc 0280c97a md5 b26469fa379dd3005ff0a706533e2427 sha1 de5c614f186caeee4ddd3a3eb49f92c8c9718493 )
+)
+
+game (
+	name "Rock Crush (1985)(Steven Mc Donald)"
+	description "Rock Crush (1985)(Steven Mc Donald)"
+	rom ( name "Rock Crush (1985)(Steven Mc Donald).p" size 10892 crc 82c7d737 md5 c40f2f276f0daefaf87acaf66152c137 sha1 245ae37f4e4ddb31952916974a79236fe4ea52eb )
+)
+
+game (
+	name "Rocker Pilot (19xx)(Ivan Matusik)(de)"
+	description "Rocker Pilot (19xx)(Ivan Matusik)(de)"
+	rom ( name "Rocker Pilot (19xx)(Ivan Matusik)(de).p" size 4526 crc d32b8e40 md5 303e280ee57bb8e65ed0dbd8e4bfc47a sha1 096bb3ba8d4945f0b6660408c4027b046d135915 )
+)
+
+game (
+	name "Rocket Man (19xx)(Cosmic Cockerel)"
+	description "Rocket Man (19xx)(Cosmic Cockerel)"
+	rom ( name "Rocket Man (19xx)(Cosmic Cockerel).p" size 15355 crc 846eca31 md5 87f79078c7a91022f3995fcb655b8b19 sha1 9979f84a0c6ef8e4cab17cd935fcb5127594cc31 )
+)
+
+game (
+	name "Rocket Man (19xx)(Cosmic Cockerel)[a]"
+	description "Rocket Man (19xx)(Cosmic Cockerel)[a]"
+	rom ( name "Rocket Man (19xx)(Cosmic Cockerel)[a].p" size 15344 crc 3cac8e6f md5 69a65756719d4fe07d3f9a39df346015 sha1 e0f483de46d8c927ddc740150ef62caa796f16a0 )
+)
+
+game (
+	name "Roman Empire (1982)(MC Lothlorien)"
+	description "Roman Empire (1982)(MC Lothlorien)"
+	rom ( name "Roman Empire (1982)(MC Lothlorien).p" size 15810 crc 52f70401 md5 f83ae304104fed482d1dd52d1c809fc8 sha1 6aaabe93e9cc62c463bafc41928ed2ca898c1e57 )
+)
+
+game (
+	name "Roman Empire (1982)(MC Lothlorien)[a]"
+	description "Roman Empire (1982)(MC Lothlorien)[a]"
+	rom ( name "Roman Empire (1982)(MC Lothlorien)[a].p" size 15847 crc fc9dcafb md5 8a028d9766b9154ab59ff848ad17a2ff sha1 b48a32650ba8bfd0a7fbe3fb31025a76cfe07da4 )
+)
+
+game (
+	name "Romeo and Juliet (19xx)(-)"
+	description "Romeo and Juliet (19xx)(-)"
+	rom ( name "Romeo and Juliet (19xx)(-).p" size 8150 crc 76782c70 md5 268b5fa5dc9192186577509f2219aebb sha1 1f4b5a3c3337015f468df82a7ee609b8f37d8926 )
+)
+
+game (
+	name "Rotary Combustion Engine (1982)(B. Horsfield)"
+	description "Rotary Combustion Engine (1982)(B. Horsfield)"
+	rom ( name "Rotary Combustion Engine (1982)(B. Horsfield).p" size 6071 crc 1a466161 md5 7962f0e7f7bdee5fbc834c25101f42bd sha1 eb452cdf880bc8fe080a56320c38b4fa492964f7 )
+)
+
+game (
+	name "Roulette (19xx)(-)"
+	description "Roulette (19xx)(-)"
+	rom ( name "Roulette (19xx)(-).p" size 4703 crc 8ce2a624 md5 59c311822388c8392d3902de630de4d9 sha1 ed5b6b1823b1a0081a46f586a0c5f6e96b71147c )
+)
+
+game (
+	name "RTTY Rx (19xx)(G40IK - G40IL)"
+	description "RTTY Rx (19xx)(G40IK - G40IL)"
+	rom ( name "RTTY Rx (19xx)(G40IK - G40IL).p" size 1279 crc 3090c7b8 md5 af86e0ae356674c9254d6fef786e4d03 sha1 bb5a14c4130614cf546004a9ee1456da151e5215 )
+)
+
+game (
+	name "RTTY Rx (19xx)(G40IK - G40IL)[16K]"
+	description "RTTY Rx (19xx)(G40IK - G40IL)[16K]"
+	rom ( name "RTTY Rx (19xx)(G40IK - G40IL)[16K].p" size 2559 crc 906bb98e md5 3eca2a0523778f7d1fd0a21ffdb2be59 sha1 a8a36a81f453ceb3d166bdb8629632c200425a1f )
+)
+
+game (
+	name "Rubik Cube Simulator (1982)(Mike Lee)"
+	description "Rubik Cube Simulator (1982)(Mike Lee)"
+	rom ( name "Rubik Cube Simulator (1982)(Mike Lee).p" size 13653 crc f600e4e6 md5 040a7d7772f67578297bd2b231161224 sha1 a414950008ccdf9f1d3794f5f553cfa27fadb3ac )
+)
+
+game (
+	name "Ruimte Oorlog (19xx)(Alpha Software)(nl)"
+	description "Ruimte Oorlog (19xx)(Alpha Software)(nl)"
+	rom ( name "Ruimte Oorlog (19xx)(Alpha Software)(nl).p" size 14819 crc de1d8c81 md5 5fc9d40f505e2d3eed96191cb32fa504 sha1 db91c99acc7f4f7cfc7479a58a85af66896bc14f )
+)
+
+game (
+	name "Ruimte Reis - Machine-Taal Versie (19xx)(-)(nl)"
+	description "Ruimte Reis - Machine-Taal Versie (19xx)(-)(nl)"
+	rom ( name "Ruimte Reis - Machine-Taal Versie (19xx)(-)(nl).p" size 2824 crc 312cbd05 md5 deea653c6d0e8e19de4e868b9449aa5a sha1 b5c29f78cca12758c567c7ac278ba1a303097b43 )
+)
+
+game (
+	name "Run Test (19xx)(-)"
+	description "Run Test (19xx)(-)"
+	rom ( name "Run Test (19xx)(-).p" size 941 crc ece36191 md5 2022d0074ba8da163fa740150a933354 sha1 fa7c6f943ff151af811215e2db57e8cac351ec0e )
+)
+
+game (
+	name "Russian Roulette (1980)(Tim Hartnell)"
+	description "Russian Roulette (1980)(Tim Hartnell)"
+	rom ( name "Russian Roulette (1980)(Tim Hartnell).p" size 1656 crc 1ccb1238 md5 4140135f049070bd8689a2615d211aae sha1 ef4120a6d9921e04293a522daca0897dd06eb910 )
+)
+
+game (
+	name "Russian Roulette (1983)(Sinclair User)[16K]"
+	description "Russian Roulette (1983)(Sinclair User)[16K]"
+	rom ( name "Russian Roulette (1983)(Sinclair User)[16K].p" size 3353 crc 292c0e2a md5 ab64790a9fc45b12de9ee8da7e60932e sha1 0619884fa9f8bb577d7045c363403403169ed312 )
+)
+
+game (
+	name "Russisch Roulette (19xx)(Theo van Otterlo)(nl)"
+	description "Russisch Roulette (19xx)(Theo van Otterlo)(nl)"
+	rom ( name "Russisch Roulette (19xx)(Theo van Otterlo)(nl).p" size 3958 crc 81994453 md5 6692067e751fa09585965d4fe9ea5958 sha1 296294169b97a372bda806eb2b85a7c551e19c77 )
+)
+
+game (
+	name "Sabotage (1982)(Don Priestley)"
+	description "Sabotage (1982)(Don Priestley)"
+	rom ( name "Sabotage (1982)(Don Priestley).p" size 8492 crc 949aad6e md5 7b399de4b6f517b031e2cf9314da42e7 sha1 91cfe1fdb1670425d5b76053d26edab5b7ab40ae )
+)
+
+game (
+	name "Sabotage (1982)(Don Priestley)[a]"
+	description "Sabotage (1982)(Don Priestley)[a]"
+	rom ( name "Sabotage (1982)(Don Priestley)[a].p" size 7960 crc 4d80b03c md5 555ed35ad8023f69755a8a421c895ef6 sha1 cc0c1d03a020c9afa70b78ab78eccd23c5333f27 )
+)
+
+game (
+	name "Saurer Regen (19xx)(-)(de)"
+	description "Saurer Regen (19xx)(-)(de)"
+	rom ( name "Saurer Regen (19xx)(-)(de).p" size 2572 crc c495d426 md5 b7fb6f6c675950f3e492f24c774eed63 sha1 9570f75b05e451761ed9a2eda89e6cc4c7c5551a )
+)
+
+game (
+	name "Saurer Regen (19xx)(-)(de)[a]"
+	description "Saurer Regen (19xx)(-)(de)[a]"
+	rom ( name "Saurer Regen (19xx)(-)(de)[a].p" size 2550 crc 8364a22c md5 cc54ef9e6f593c1713eef47c609ea20e sha1 666033fa9ea747421c65f74d9efcba43fad30506 )
+)
+
+game (
+	name "Saver (19xx)(-)"
+	description "Saver (19xx)(-)"
+	rom ( name "Saver (19xx)(-).p" size 6176 crc 10185b29 md5 1990fc45e30d882ecf4179fa70bbb393 sha1 bbdabbfb3c7e2a49c5f5edeb1cf3e4bc31bc5fd1 )
+)
+
+game (
+	name "Savings Plan (19xx)(-)"
+	description "Savings Plan (19xx)(-)"
+	rom ( name "Savings Plan (19xx)(-).p" size 1929 crc 1449dadc md5 191692ac81639aa400d5f82e0b9c89a0 sha1 3bd1bfacd96a8fcbd7795c58381463cdb4e1211f )
+)
+
+game (
+	name "Schatzoeken (19xx)(-)(nl)"
+	description "Schatzoeken (19xx)(-)(nl)"
+	rom ( name "Schatzoeken (19xx)(-)(nl).p" size 7084 crc 610831e7 md5 7bcbed2f8fc5ee34f57f521e7caa5335 sha1 97f8b3ef38b784f756a58b4e18acaa6b8921178d )
+)
+
+game (
+	name "Schatzsuche (19xx)(-)(de)"
+	description "Schatzsuche (19xx)(-)(de)"
+	rom ( name "Schatzsuche (19xx)(-)(de).p" size 6780 crc 51a2805c md5 3023f3566f060d6516d1bec148ec7360 sha1 6be92c351b20afa69821409579a4943ba8c061a8 )
+)
+
+game (
+	name "Scherm Vulling (19xx)(Logical Computers)(nl)"
+	description "Scherm Vulling (19xx)(Logical Computers)(nl)"
+	rom ( name "Scherm Vulling (19xx)(Logical Computers)(nl).p" size 1874 crc 5d507ecd md5 86243523f1c4ffc11f4b6c35527d6192 sha1 17184d86b97ec12cc9e1a54faf2f704871fb0747 )
+)
+
+game (
+	name "Scramble (19xx)(-)"
+	description "Scramble (19xx)(-)"
+	rom ( name "Scramble (19xx)(-).p" size 4912 crc 505bf55f md5 3d6a14163cdcfbd51cd899b665b3828b sha1 9b07d707928085183ad692d980f97268dd015e33 )
+)
+
+game (
+	name "Scramble 81 (19xx)(-)"
+	description "Scramble 81 (19xx)(-)"
+	rom ( name "Scramble 81 (19xx)(-).p" size 7471 crc d7ecc485 md5 be4c051cea71d8ae947d4893fc7871be sha1 e0ebdb6d4ba6575d00d645d18c4b5cf3de43a4ea )
+)
+
+game (
+	name "Scramble 81 (19xx)(-)[a]"
+	description "Scramble 81 (19xx)(-)[a]"
+	rom ( name "Scramble 81 (19xx)(-)[a].p" size 7634 crc 751368f2 md5 3692716900a218c97ea1677969c4d827 sha1 7f6deebc65eb2e7b32a011b2efd0e13a20263579 )
+)
+
+game (
+	name "Scroll X (19xx)(-)"
+	description "Scroll X (19xx)(-)"
+	rom ( name "Scroll X (19xx)(-).p" size 1323 crc b8fc9c35 md5 4492471cf22715315d3307f501f970db sha1 3e69393c8b00f5d0812df7c40aab538f88a85f06 )
+)
+
+game (
+	name "Sea Mines (19xx)(G.S.P. Computer Software)"
+	description "Sea Mines (19xx)(G.S.P. Computer Software)"
+	rom ( name "Sea Mines (19xx)(G.S.P. Computer Software).p" size 8944 crc 572fde32 md5 a86172480161fcb4d1147e81c43dc057 sha1 a0641355611454ae9e1ee03d7489968978091aa7 )
+)
+
+game (
+	name "Sea Mines (19xx)(G.S.P. Computer Software)[a]"
+	description "Sea Mines (19xx)(G.S.P. Computer Software)[a]"
+	rom ( name "Sea Mines (19xx)(G.S.P. Computer Software)[a].p" size 9405 crc 23d714b1 md5 05ed808c83524d4dcaad862dc628ebab sha1 78bd2b90894639e9957133c48c5d99be1c5ca59e )
+)
+
+game (
+	name "Sea War (19xx)(Panda Software)"
+	description "Sea War (19xx)(Panda Software)"
+	rom ( name "Sea War (19xx)(Panda Software).p" size 6888 crc 3329ba9e md5 13840143a6b67f3bf83ce6f7cef59399 sha1 8f4d0a5aa2cc2f2c32c1796c92330362d2b44331 )
+)
+
+game (
+	name "Sea Wolf (1983)(Stephen Hartley Software)"
+	description "Sea Wolf (1983)(Stephen Hartley Software)"
+	rom ( name "Sea Wolf (1983)(Stephen Hartley Software).p" size 10359 crc 02ed0c47 md5 c0af8bd3124219da91853207ae1e028c sha1 eddaab90ee6dd58bbea94ce3f24462253d72f41b )
+)
+
+game (
+	name "Secret (19xx)(-)"
+	description "Secret (19xx)(-)"
+	rom ( name "Secret (19xx)(-).p" size 8109 crc 75241ad5 md5 0094d3a7b17910c62328329cf7708ca6 sha1 06d86a1f36a7716f255881282e8f70f9204c2417 )
+)
+
+game (
+	name "Shift (19xx)(-)(de)"
+	description "Shift (19xx)(-)(de)"
+	rom ( name "Shift (19xx)(-)(de).p" size 3216 crc 23bb3a8b md5 ba0dcdad966d9688b5f52f9a91a4ee65 sha1 c3f9fd1b650e37816c458c2f3681907cc1c4fadf )
+)
+
+game (
+	name "Shoot (19xx)(-)(de)"
+	description "Shoot (19xx)(-)(de)"
+	rom ( name "Shoot (19xx)(-)(de).p" size 2036 crc fcb42a86 md5 35b7f2730f6986c327024777f68c967a sha1 417f4ed8509e56709a5122733699fa7e639ba8ae )
+)
+
+game (
+	name "Shoot Out (19xx)(-)"
+	description "Shoot Out (19xx)(-)"
+	rom ( name "Shoot Out (19xx)(-).p" size 785 crc 19a98a07 md5 ae29b0d6b432c3fb893d0defcd38c828 sha1 7d00d44a319fb7420f391624c98d14b60a53a276 )
+)
+
+game (
+	name "Short Circuit (1985)(High Tech Soft)"
+	description "Short Circuit (1985)(High Tech Soft)"
+	rom ( name "Short Circuit (1985)(High Tech Soft).p" size 5162 crc 4fd0a950 md5 4ebf6ec2f94bd0c4394dc5577fd71076 sha1 417c5ea7e13f1cddaf176f423413a0f1c245c0d4 )
+)
+
+game (
+	name "Silverstone (1982)(Peter Davis)[m David Buttery]"
+	description "Silverstone (1982)(Peter Davis)[m David Buttery]"
+	rom ( name "Silverstone (1982)(Peter Davis)[m David Buttery].p" size 2164 crc c4824cd0 md5 e66c9ae3323d88f9e750c9bca017f028 sha1 c0ec227dca4737a1988d62431787bb828dc3bc7d )
+)
+
+game (
+	name "Simplex (19xx)(-)(de)"
+	description "Simplex (19xx)(-)(de)"
+	rom ( name "Simplex (19xx)(-)(de).p" size 2880 crc f284ced7 md5 5baa1168b4f9ba029684eb4382004d73 sha1 bf2d1f293b310dc120a8bf06c95faff40835f2df )
+)
+
+game (
+	name "Sinclair Snooker (19xx)(Leo Moll)"
+	description "Sinclair Snooker (19xx)(Leo Moll)"
+	rom ( name "Sinclair Snooker (19xx)(Leo Moll).p" size 7782 crc 39666368 md5 c483f64109cec08e4799d4438d658eb8 sha1 5d33fcbb1b6ef32370b9462eb27dacc9986a4e30 )
+)
+
+game (
+	name "Sinewave (19xx)(-)"
+	description "Sinewave (19xx)(-)"
+	rom ( name "Sinewave (19xx)(-).p" size 1181 crc 4e41dd73 md5 efb301f497bae3adea5dda22baa00116 sha1 51ef966a0dec13067ea65c4b58cae435c88434b3 )
+)
+
+game (
+	name "Ski (19xx)(-)"
+	description "Ski (19xx)(-)"
+	rom ( name "Ski (19xx)(-).p" size 1951 crc fd49ad61 md5 a7d7dc8cdcd170beba36f2cc66f6f3ea sha1 417e58a2c6a4b8a448972f17aa8dc76f14ecb34f )
+)
+
+game (
+	name "Slot Machine (19xx)(-)"
+	description "Slot Machine (19xx)(-)"
+	rom ( name "Slot Machine (19xx)(-).p" size 4853 crc 70ec27ef md5 637a6d778f4e9a1e01ae8a14536bc7bf sha1 45d416fcb345d084e9ca5b39f7bf6f695e8d5103 )
+)
+
+game (
+	name "Slot Machine - The Gambler Tape (19xx)(-)"
+	description "Slot Machine - The Gambler Tape (19xx)(-)"
+	rom ( name "Slot Machine - The Gambler Tape (19xx)(-).p" size 7004 crc 613fb78e md5 ed837d87b4ce3bc8a981fa2ef51f1964 sha1 a02391c549fb4b6ad7c37baf58bb8a95df7e72eb )
+)
+
+game (
+	name "Slot Machine - The Gambler Tape (19xx)(-)[a]"
+	description "Slot Machine - The Gambler Tape (19xx)(-)[a]"
+	rom ( name "Slot Machine - The Gambler Tape (19xx)(-)[a].p" size 6932 crc 9cf071ac md5 d7d9e48461a75d617fc31c65365a3536 sha1 f779ef4b9fd6d709142229b758ef2bb9004afc4d )
+)
+
+game (
+	name "Slurpslurfmonster (19xx)(-)(nl)"
+	description "Slurpslurfmonster (19xx)(-)(nl)"
+	rom ( name "Slurpslurfmonster (19xx)(-)(nl).p" size 8804 crc 5ad6f536 md5 b958ce1aebb32c0cc0af6a7a2d05eeed sha1 562d3efa9b8f573bf6fd911431685ef07ac1e37e )
+)
+
+game (
+	name "Smaugs Lair (19xx)(VVP Software)"
+	description "Smaugs Lair (19xx)(VVP Software)"
+	rom ( name "Smaugs Lair (19xx)(VVP Software).p" size 10829 crc 24e6e55c md5 f939f33added204dfd1277ddde9d30d9 sha1 74a7b5f54fa4febfe330ae3c6c767d261079352b )
+)
+
+game (
+	name "Snake (19xx)(-)"
+	description "Snake (19xx)(-)"
+	rom ( name "Snake (19xx)(-).p" size 3862 crc d23bebfa md5 1af95f23a9682af134bc013d98191e26 sha1 1a6bdb073ad928a0e14e7ef5ec6815961036db68 )
+)
+
+game (
+	name "Snakebite (1982)(Frank Sierowski)"
+	description "Snakebite (1982)(Frank Sierowski)"
+	rom ( name "Snakebite (1982)(Frank Sierowski).p" size 14583 crc 3595777a md5 d2574026f538887f690100061af8b99b sha1 36dc6126f83236da765ee2e96d962cbc338874bd )
+)
+
+game (
+	name "Solid Sinwave (19xx)(-)"
+	description "Solid Sinwave (19xx)(-)"
+	rom ( name "Solid Sinwave (19xx)(-).p" size 1143 crc 03394aed md5 8c770d510dc4cc3fb670e1357965cc5e sha1 70fdefda11ae0dc42fd9cf523a0df40807c032fa )
+)
+
+game (
+	name "Solitaire (19xx)(-)(nl)[16K]"
+	description "Solitaire (19xx)(-)(nl)[16K]"
+	rom ( name "Solitaire (19xx)(-)(nl)[16K].p" size 2690 crc 6f8abf4b md5 00f61cdb867fd8a84d3ccc8ae9d63c33 sha1 701641dc6d322ddee489ac9f090d530caf3890c4 )
+)
+
+game (
+	name "Sorcerer's Island (19xx)(-)"
+	description "Sorcerer's Island (19xx)(-)"
+	rom ( name "Sorcerer's Island (19xx)(-).p" size 15580 crc 8adab366 md5 b53805d55ecfee561bf69663f89be15b sha1 9517e4db879ba14895ace010fe0f4ef380fd2aeb )
+)
+
+game (
+	name "Sorcerer's Lair (19xx)(-)"
+	description "Sorcerer's Lair (19xx)(-)"
+	rom ( name "Sorcerer's Lair (19xx)(-).p" size 13776 crc b7296b60 md5 bd7b688b2a2667620d9067cd46a2aa8f sha1 657ecdb33d98baf2037d97287e3a8ef7dc791442 )
+)
+
+game (
+	name "Sorteer (19xx)(-)"
+	description "Sorteer (19xx)(-)"
+	rom ( name "Sorteer (19xx)(-).p" size 11280 crc 158873cb md5 8892ad982944d70957dedba2b1e34844 sha1 af3d0013bcc5f5fba6ecdf07712a75dfa3f2c1e9 )
+)
+
+game (
+	name "Sorteren (19xx)(-)(de)"
+	description "Sorteren (19xx)(-)(de)"
+	rom ( name "Sorteren (19xx)(-)(de).p" size 11816 crc 457376f6 md5 4a7ced44373ac9e5595400d152038403 sha1 c72090e1de9ca105e581b55676c8068bbfc62cfd )
+)
+
+game (
+	name "Sound (19xx)(-)(nl)"
+	description "Sound (19xx)(-)(nl)"
+	rom ( name "Sound (19xx)(-)(nl).p" size 1510 crc 8e93cf97 md5 0c796f61f0db896e708f789196bf9263 sha1 78438439df71ef00eb33fb0bc23cd529cab83c87 )
+)
+
+game (
+	name "Sound - Orgel (19xx)(-)"
+	description "Sound - Orgel (19xx)(-)"
+	rom ( name "Sound - Orgel (19xx)(-).p" size 1331 crc 3f435574 md5 cf6df65ceee52b8f5e9c8273c7511405 sha1 b73a15656a5d77821a55317b133f1111cbbe2090 )
+)
+
+game (
+	name "Space (19xx)(-)(nl)"
+	description "Space (19xx)(-)(nl)"
+	rom ( name "Space (19xx)(-)(nl).p" size 3367 crc 7d2c9ee2 md5 3a0da56719bbaf3d6f567909cc266761 sha1 b002dbd5a221700a1b89c0b522c451a0a5a7ffea )
+)
+
+game (
+	name "Space Cavern (1984)(G. de Ruiter Products)(nl)"
+	description "Space Cavern (1984)(G. de Ruiter Products)(nl)"
+	rom ( name "Space Cavern (1984)(G. de Ruiter Products)(nl).p" size 4891 crc 700612d3 md5 db43b8e4d960270dfd43cc6a4d3fd342 sha1 2d6c76739603a0f1f41e2c9c56ca8077f397f9bf )
+)
+
+game (
+	name "Space Cavern (19xx)(G. de Ruiter Products)"
+	description "Space Cavern (19xx)(G. de Ruiter Products)"
+	rom ( name "Space Cavern (19xx)(G. de Ruiter Products).p" size 4907 crc 5b8218d8 md5 c5b8819063b28f4fa0c1a30da7b34757 sha1 c64297e5a3a7edf4508b5773b9b67ae71f19e0ca )
+)
+
+game (
+	name "Space Commando (1982)(TY-Soft)"
+	description "Space Commando (1982)(TY-Soft)"
+	rom ( name "Space Commando (1982)(TY-Soft).p" size 16150 crc 853c339f md5 cfaae1bb14d9f5f6e3568dcb486c3c24 sha1 08600e08a5441bd23fb689460c88a85489292bee )
+)
+
+game (
+	name "Space Crisis (19xx)(-)"
+	description "Space Crisis (19xx)(-)"
+	rom ( name "Space Crisis (19xx)(-).p" size 9243 crc 8ac32afb md5 059752c3fc59f5e2b67a8e29297a6582 sha1 77c34d1282470e9734b40980832558a8f252b185 )
+)
+
+game (
+	name "Space Invader (19xx)(-)(de)"
+	description "Space Invader (19xx)(-)(de)"
+	rom ( name "Space Invader (19xx)(-)(de).p" size 2689 crc 0aba330a md5 c33121665ac79bd4325fed83feeade85 sha1 227bf6d4b01c39b3f111cee5d48aff9997f0e725 )
+)
+
+game (
+	name "Space Invaders (19xx)(-)"
+	description "Space Invaders (19xx)(-)"
+	rom ( name "Space Invaders (19xx)(-).p" size 1780 crc 55127aab md5 a37c304eeda105cd5eaa2537ce006fb7 sha1 43ac5893220217ada8f1b3f4498ca748cdc43975 )
+)
+
+game (
+	name "Space Invaders (19xx)(Logical Computers)"
+	description "Space Invaders (19xx)(Logical Computers)"
+	rom ( name "Space Invaders (19xx)(Logical Computers).p" size 3067 crc 000e2ac3 md5 f99e723769e853ae0ec26e5924c75750 sha1 5a13a019b465bf5ea41f7c9f985aafe51cc73d0c )
+)
+
+game (
+	name "Space Invaders (19xx)(Psion Software)"
+	description "Space Invaders (19xx)(Psion Software)"
+	rom ( name "Space Invaders (19xx)(Psion Software).p" size 3072 crc 66e266ab md5 5d415adb7ac315a28033fc64c31a4cee sha1 941c29f9ca6195c895ecbdb6125d13b7164164ac )
+)
+
+game (
+	name "Space Mining (19xx)(-)(nl)"
+	description "Space Mining (19xx)(-)(nl)"
+	rom ( name "Space Mining (19xx)(-)(nl).p" size 2581 crc 38b18cf9 md5 0e38c722d657c925cc50e5eaea86e0c2 sha1 c3b4e15be1878ea2c24def9a7cfef55927f07ef8 )
+)
+
+game (
+	name "Space Pirate (19xx)(-)"
+	description "Space Pirate (19xx)(-)"
+	rom ( name "Space Pirate (19xx)(-).p" size 724 crc 31850218 md5 cd676a44e68654272305e163a6f240a3 sha1 062d30a39bf5a9ddc12fcf7b93c38f08ee41e0b6 )
+)
+
+game (
+	name "Space Raid (19xx)(-)"
+	description "Space Raid (19xx)(-)"
+	rom ( name "Space Raid (19xx)(-).p" size 1952 crc a315562d md5 de8b6a48d73c49abee2be596aa5ee6d6 sha1 690e01b1ebdb5ccac834d12e0cb75bba265ffb67 )
+)
+
+game (
+	name "Space Rescue (19xx)(-)"
+	description "Space Rescue (19xx)(-)"
+	rom ( name "Space Rescue (19xx)(-).p" size 6416 crc c666f862 md5 36fac9f781947c703e4e23983b8907fc sha1 78467889ebd33835012ef0b3674be1fc02f3d059 )
+)
+
+game (
+	name "Space Taxi (1988)(Level III)[m]"
+	description "Space Taxi (1988)(Level III)[m]"
+	rom ( name "Space Taxi (1988)(Level III)[m].p" size 4096 crc 7c6986fe md5 936b39cc1ea8778c9b85491c68f23576 sha1 bb416349cbd97ad2d821bdc601a42f9526cabb7e )
+)
+
+game (
+	name "Spacetravel (19xx)(-)"
+	description "Spacetravel (19xx)(-)"
+	rom ( name "Spacetravel (19xx)(-).p" size 2740 crc 8de16f03 md5 c5def0c43acb8d2e94d11ccf090458bd sha1 37d1a41f612da8c034acb2740aef0ef769bbf486 )
+)
+
+game (
+	name "Spacetravel Hi-Res (19xx)(-)"
+	description "Spacetravel Hi-Res (19xx)(-)"
+	rom ( name "Spacetravel Hi-Res (19xx)(-).p" size 3087 crc b2100621 md5 8e58ee304557a9074ba0fc94c981801e sha1 e689a62c2ff96e0ba76ca3624d3f56aedfa16493 )
+)
+
+game (
+	name "Spectrum (1983)(J.R. Paton)"
+	description "Spectrum (1983)(J.R. Paton)"
+	rom ( name "Spectrum (1983)(J.R. Paton).p" size 5273 crc 85ca53a7 md5 cfb293bb97cc7ac46ae43aae96477ac8 sha1 cee8d25bf9ba5932e1808346a737848cb26639dd )
+)
+
+game (
+	name "Speedball (19xx)(-)(nl)"
+	description "Speedball (19xx)(-)(nl)"
+	rom ( name "Speedball (19xx)(-)(nl).p" size 2411 crc 6d554374 md5 c4392e381b05aaa18b2aa56b3d990067 sha1 a1a372c8288fa5d6dafafd22f7cadfba873570b4 )
+)
+
+game (
+	name "Speeldoos (19xx)(-)(de)"
+	description "Speeldoos (19xx)(-)(de)"
+	rom ( name "Speeldoos (19xx)(-)(de).p" size 4904 crc 3a35d95f md5 b8f1e8a38a1b33e1bc3511a809a5c719 sha1 618370d8ee2e24d5b33ad09d13df8d97bad29410 )
+)
+
+game (
+	name "Spelletjes 1 (19xx)(-)(nl)"
+	description "Spelletjes 1 (19xx)(-)(nl)"
+	rom ( name "Spelletjes 1 (19xx)(-)(nl).p" size 13648 crc e38b2d29 md5 0c428657e06ae230436869841c68de1f sha1 56d265f75b6aff038d27ad17cafa02812fb5a9d8 )
+)
+
+game (
+	name "Spelletjes 2 (19xx)(-)(nl)"
+	description "Spelletjes 2 (19xx)(-)(nl)"
+	rom ( name "Spelletjes 2 (19xx)(-)(nl).p" size 13571 crc 448634f8 md5 2dc2971582b40524f346f9b664777434 sha1 913bd682e0ea5df8177cb1797c71c00fea2c8fb1 )
+)
+
+game (
+	name "Spelletjes 3 (19xx)(-)(nl)"
+	description "Spelletjes 3 (19xx)(-)(nl)"
+	rom ( name "Spelletjes 3 (19xx)(-)(nl).p" size 13972 crc 6f41e94f md5 2b4f55c4165c12a2fcf8668e5201909c sha1 7dc6c9153180443b0186c3716efc29faacb20633 )
+)
+
+game (
+	name "Speltape 4 (19xx)(-)(de)"
+	description "Speltape 4 (19xx)(-)(de)"
+	rom ( name "Speltape 4 (19xx)(-)(de).p" size 15599 crc e7eb011a md5 61bb9ea3bf3c54c263f8cc29c44fbc1f sha1 4ce20c252d1cf17bd184b3c00f235a2cad0720ae )
+)
+
+game (
+	name "Speltape 5 (19xx)(-)(de)"
+	description "Speltape 5 (19xx)(-)(de)"
+	rom ( name "Speltape 5 (19xx)(-)(de).p" size 5803 crc f7b0e67a md5 9d7b7578b8d1cbb9d6c109463cf7868c sha1 831a3a75073efb755d37719d1c210d0c55b3c8a5 )
+)
+
+game (
+	name "Spider (19xx)(-)"
+	description "Spider (19xx)(-)"
+	rom ( name "Spider (19xx)(-).p" size 9248 crc a611d3f5 md5 73a0fffc73cba00a62173003a90895d3 sha1 8c479d21cbe6921334021115046ac6ff99967545 )
+)
+
+game (
+	name "Spider (19xx)(-)[a]"
+	description "Spider (19xx)(-)[a]"
+	rom ( name "Spider (19xx)(-)[a].p" size 8999 crc 72a4e663 md5 54b66328508ad80c4927cd9420675e12 sha1 2104c69f9ba16aec716bcda3b423903a7c84a3ca )
+)
+
+game (
+	name "Spider Chase (19xx)(-)"
+	description "Spider Chase (19xx)(-)"
+	rom ( name "Spider Chase (19xx)(-).p" size 3308 crc 8c5b0ff2 md5 d8fc952465d3f9f81d71b7106acc2844 sha1 4e24cd072cbeeaf6008828ad29ba9cc85343508b )
+)
+
+game (
+	name "Spiraal Spel (19xx)(Logical Computers)(nl)"
+	description "Spiraal Spel (19xx)(Logical Computers)(nl)"
+	rom ( name "Spiraal Spel (19xx)(Logical Computers)(nl).p" size 2275 crc edb95f2d md5 5239a256a31fbf2fb4f4362c228c63ae sha1 b0c7787e68a80c0d80777dba790a1e6481a210b0 )
+)
+
+game (
+	name "Spirograph (1987)(SMC)"
+	description "Spirograph (1987)(SMC)"
+	rom ( name "Spirograph (1987)(SMC).p" size 10090 crc acbc89ea md5 202d2fe74dbd7c72ee0d6acff6bc3cb1 sha1 0e9a69c9ab8fed16c7ca3329f2159991412b85c9 )
+)
+
+game (
+	name "Sports Day (1987)(The Poort)"
+	description "Sports Day (1987)(The Poort)"
+	rom ( name "Sports Day (1987)(The Poort).p" size 13291 crc 8c322256 md5 5ddfd9a783480ae05f82fceb84822db5 sha1 3ef4428ebfc012c37905a85a019f505df11ef9bb )
+)
+
+game (
+	name "Stadhouder van Flipflopland (1983)(Kluwer Technische Boeken)(nl)"
+	description "Stadhouder van Flipflopland (1983)(Kluwer Technische Boeken)(nl)"
+	rom ( name "Stadhouder van Flipflopland (1983)(Kluwer Technische Boeken)(nl).p" size 7872 crc a037a7df md5 b4e4c2c23874d565409cb1aab1a75eb8 sha1 e9721972e72b4c72e020c52bfd9e8a1abc7fd32a )
+)
+
+game (
+	name "Star Trail (19xx)(-)"
+	description "Star Trail (19xx)(-)"
+	rom ( name "Star Trail (19xx)(-).p" size 15009 crc ef7ccfc9 md5 d0cd8f9a02a06c7386f37a3a7192f9e6 sha1 733deaf33ef5d8318e3a4f06203a57e555ff08ac )
+)
+
+game (
+	name "Star Trail (19xx)(-)[a]"
+	description "Star Trail (19xx)(-)[a]"
+	rom ( name "Star Trail (19xx)(-)[a].p" size 16129 crc b5eb3c6f md5 9632882beac258c0839ccacfa6dcc5aa sha1 880f063bc7b557499186ec35d23e61d219bb838d )
+)
+
+game (
+	name "Star Trek (19xx)(-)"
+	description "Star Trek (19xx)(-)"
+	rom ( name "Star Trek (19xx)(-).p" size 13867 crc cdcad902 md5 dc0a4e7eeb6b07ddd4cb94cb548aab89 sha1 008eb4e9aca18bbb19033dd07024092707433c8a )
+)
+
+game (
+	name "Star Trek (19xx)(Gemini Marketing)"
+	description "Star Trek (19xx)(Gemini Marketing)"
+	rom ( name "Star Trek (19xx)(Gemini Marketing).p" size 15867 crc 5e5716c3 md5 0fa0610a1d9eadcd8a91c47b95e207d1 sha1 67d9bdff3c016c63c6ffc7740a7bf6510d0ac094 )
+)
+
+game (
+	name "Star Trek (19xx)(Michael Florey)"
+	description "Star Trek (19xx)(Michael Florey)"
+	rom ( name "Star Trek (19xx)(Michael Florey).p" size 15160 crc 7839d997 md5 b5b658ec4ff0c90f5365cff7eed63ba9 sha1 d3db76e4b0247c4a971eefe235ca96a8af18468b )
+)
+
+game (
+	name "Star-Way (19xx)(P.J.R.R. Lechanteur)"
+	description "Star-Way (19xx)(P.J.R.R. Lechanteur)"
+	rom ( name "Star-Way (19xx)(P.J.R.R. Lechanteur).p" size 6438 crc 0e761dec md5 9c8f758b229d5440288428db688eeed2 sha1 442af8cd79c50636f9288e6f3cdaac33d65e484d )
+)
+
+game (
+	name "Starfight (2001)(Martin Korth)"
+	description "Starfight (2001)(Martin Korth)"
+	rom ( name "Starfight (2001)(Martin Korth).p" size 5201 crc 19c88e63 md5 fd98e24a7015485ee45d34ff7740cdc8 sha1 ae29d3694866fefbb0820baedf1d548445dbc36b )
+)
+
+game (
+	name "Starfighter (1981)(J.K. Greye Software)"
+	description "Starfighter (1981)(J.K. Greye Software)"
+	rom ( name "Starfighter (1981)(J.K. Greye Software).p" size 5780 crc e71c2742 md5 353c82d709e19f90eb6c926b71a32132 sha1 569abfbf775f10f839accfb9fd673872e1b664f7 )
+)
+
+game (
+	name "Starfighter (1981)(J.K. Greye Software)[a]"
+	description "Starfighter (1981)(J.K. Greye Software)[a]"
+	rom ( name "Starfighter (1981)(J.K. Greye Software)[a].p" size 5744 crc e9efb817 md5 3a8b12d24960509949327af8b01ed1b4 sha1 f098f72471261b27481de232cf757ef24d58b617 )
+)
+
+game (
+	name "Stars (19xx)(-)"
+	description "Stars (19xx)(-)"
+	rom ( name "Stars (19xx)(-).p" size 979 crc c7a10485 md5 6c1d08af261b1b20e65723af447a5993 sha1 035f8d5e72722595f6f6f1e753bd4ad5cd46ed94 )
+)
+
+game (
+	name "Starship Epsilon (1984)(Sinclair User)[16K]"
+	description "Starship Epsilon (1984)(Sinclair User)[16K]"
+	rom ( name "Starship Epsilon (1984)(Sinclair User)[16K].p" size 8187 crc 01b69a44 md5 49a0d92b84a3f49ded9463f3c011bdd9 sha1 10f4496322344225f06200864fc4d8abc7b4e1cf )
+)
+
+game (
+	name "Starwars (19xx)(R.V.D. Steen - K. Jurkuhn)(nl)"
+	description "Starwars (19xx)(R.V.D. Steen - K. Jurkuhn)(nl)"
+	rom ( name "Starwars (19xx)(R.V.D. Steen - K. Jurkuhn)(nl).p" size 3353 crc fdcc7356 md5 e2b42c39b73faf4cb0e2f22062146361 sha1 f3acaa250d48ad55e345a0fa3fa5786290fc12cc )
+)
+
+game (
+	name "Statistics (19xx)(-)"
+	description "Statistics (19xx)(-)"
+	rom ( name "Statistics (19xx)(-).p" size 2220 crc ea52d910 md5 ce8dcf0f6fad15f31cadca1d7275a673 sha1 f52c7b9d9d66f5b45563f87f8a25b509be5e14d6 )
+)
+
+game (
+	name "Steinschlag (19xx)(-)(de)"
+	description "Steinschlag (19xx)(-)(de)"
+	rom ( name "Steinschlag (19xx)(-)(de).p" size 2982 crc e4fd883c md5 a09267872e0d0aef760b70738cfd478a sha1 711819ca079ab05ee1946d3549a0fb0b8cb34006 )
+)
+
+game (
+	name "Sterrenbeelden (19xx)(-)"
+	description "Sterrenbeelden (19xx)(-)"
+	rom ( name "Sterrenbeelden (19xx)(-).p" size 15628 crc 308db791 md5 925dd81d5e94fbd83ad9dc3876712bfc sha1 309e5612cb1d52047211588171f11927784615c8 )
+)
+
+game (
+	name "Stock-Market (1981)(Video Software)"
+	description "Stock-Market (1981)(Video Software)"
+	rom ( name "Stock-Market (1981)(Video Software).p" size 11775 crc dbf660ba md5 32492cd3832f770c41913bc23e661589 sha1 f92145fbfe8e3db0926567276c188d21ea626984 )
+)
+
+game (
+	name "Stonehenge Simulation (19xx)(Gil Aldea)"
+	description "Stonehenge Simulation (19xx)(Gil Aldea)"
+	rom ( name "Stonehenge Simulation (19xx)(Gil Aldea).p" size 5515 crc fe1b9e33 md5 b9c94e7d98b4368fd8af0d09fcaf1b64 sha1 f846a6d3088acd4882a9e0c4d89c75acd867d7a2 )
+)
+
+game (
+	name "Street Fighter (1983)(H. Dursch)(de)"
+	description "Street Fighter (1983)(H. Dursch)(de)"
+	rom ( name "Street Fighter (1983)(H. Dursch)(de).p" size 2056 crc 1c772dd4 md5 966c5d76e9fb1c5b94e865c5b3c87d2e sha1 d38dcf0a696beaddc331128d9c2ba9eaa076b6cd )
+)
+
+game (
+	name "Street Racer (19xx)(-)"
+	description "Street Racer (19xx)(-)"
+	rom ( name "Street Racer (19xx)(-).p" size 8569 crc 603e1cca md5 08eb33613af860099a134e8dc90bbde7 sha1 d6a7fec846d5e359e6fd8eb1f46845f98f10a79f )
+)
+
+game (
+	name "Submarine (19xx)(-)"
+	description "Submarine (19xx)(-)"
+	rom ( name "Submarine (19xx)(-).p" size 11435 crc 4b153a2a md5 bf3c0d6bf0ca3d563c3dbdc58a03e190 sha1 852d1ab7a5aa38177de70432d4d36bf6fe34e6a1 )
+)
+
+game (
+	name "Submarine Strike (19xx)(-)"
+	description "Submarine Strike (19xx)(-)"
+	rom ( name "Submarine Strike (19xx)(-).p" size 2985 crc ef00de29 md5 0c9b867de804b30fc1031e25d0e08a30 sha1 940e3832a09faa568457cf86ffafa38894d4332a )
+)
+
+game (
+	name "Sultan's Tower (19xx)(-)"
+	description "Sultan's Tower (19xx)(-)"
+	rom ( name "Sultan's Tower (19xx)(-).p" size 3572 crc af414213 md5 831ab913458f63f0c7c10d79458bfcf5 sha1 037a4de4e8ce7be091fc1417eaafb9a5cf2617b3 )
+)
+
+game (
+	name "Sultans Tower (19xx)(-)"
+	description "Sultans Tower (19xx)(-)"
+	rom ( name "Sultans Tower (19xx)(-).p" size 3483 crc 009e59ed md5 75ed22bd378a924f8b7f47bcc2a654b6 sha1 f3cf33c6fa1248307fa3c0ca9df53f010d9fa606 )
+)
+
+game (
+	name "Super Bee Spelling Game (19xx)(-)"
+	description "Super Bee Spelling Game (19xx)(-)"
+	rom ( name "Super Bee Spelling Game (19xx)(-).p" size 11345 crc cda662d9 md5 e4cb045fe297052e235e2cf473bc9247 sha1 202cd19dec95865205cba96cc7aaf0386f061d8d )
+)
+
+game (
+	name "Super Blitzer (1983)(H. Dursch)(de)"
+	description "Super Blitzer (1983)(H. Dursch)(de)"
+	rom ( name "Super Blitzer (1983)(H. Dursch)(de).p" size 2052 crc 4aa7ca4b md5 94ed281009e14bd2d238715ab437a32c sha1 5c5c4b9ad23fb4312e43b0ee8f5a95fffa79f912 )
+)
+
+game (
+	name "Super Lotto (19xx)(Viel Glueck)(de)"
+	description "Super Lotto (19xx)(Viel Glueck)(de)"
+	rom ( name "Super Lotto (19xx)(Viel Glueck)(de).p" size 2002 crc acf434cd md5 ca549d5350ad762b50330a48aafe6742 sha1 60c2a125de28e6cc61854c79d2c787a12393fae2 )
+)
+
+game (
+	name "Super Wumpus (19xx)(Silversoft)"
+	description "Super Wumpus (19xx)(Silversoft)"
+	rom ( name "Super Wumpus (19xx)(Silversoft).p" size 15807 crc 729a8cd8 md5 61fb8242d019568f88d3279f63a8aa76 sha1 ae62d466069013e40ac6d4427b0411cdbc4ac60f )
+)
+
+game (
+	name "Super-Drawer (1985)(Fielt Software)(nl)"
+	description "Super-Drawer (1985)(Fielt Software)(nl)"
+	rom ( name "Super-Drawer (1985)(Fielt Software)(nl).p" size 4102 crc 314a3b7e md5 0e8816bb18f22dee3f43224c59fd39a5 sha1 3c59646f3edf00bd186ec2a5ff24742fea927ca9 )
+)
+
+game (
+	name "Super-Math (19xx)(-)"
+	description "Super-Math (19xx)(-)"
+	rom ( name "Super-Math (19xx)(-).p" size 8110 crc 1e36d3e9 md5 815574c8581e97ca568ab9c7c8721122 sha1 587158c12e17d4e1caa3555afe63a200e5d00e0d )
+)
+
+game (
+	name "Super-Math (19xx)(-)[a]"
+	description "Super-Math (19xx)(-)[a]"
+	rom ( name "Super-Math (19xx)(-)[a].p" size 8075 crc b02be5f5 md5 fc1be8c01a109935e2ad4cec47f8d7e4 sha1 58fcf08663a2e4f5ce463e8d7d85a801fe982728 )
+)
+
+game (
+	name "Super-Rechner (19xx)(-)(de)"
+	description "Super-Rechner (19xx)(-)(de)"
+	rom ( name "Super-Rechner (19xx)(-)(de).p" size 1183 crc 2be62d69 md5 8befdb16f0a2c6e3b7e2147e080cc38d sha1 e6111a8d82e90f6ea772efaab84f4514e405fc3e )
+)
+
+game (
+	name "Superhirn (19xx)(-)(de)"
+	description "Superhirn (19xx)(-)(de)"
+	rom ( name "Superhirn (19xx)(-)(de).p" size 2203 crc 3449d8c8 md5 89b3bf57daacc73d4de1c4242066f429 sha1 4d90ab88f4d065f6d3f83a174944b1eacff6388d )
+)
+
+game (
+	name "Supermaze (19xx)(J.K. Greye Software)"
+	description "Supermaze (19xx)(J.K. Greye Software)"
+	rom ( name "Supermaze (19xx)(J.K. Greye Software).p" size 16196 crc b552a5e1 md5 f5aa5b5c2fea6fc23dab23160027123f sha1 5b1d76cf7010b96df0dcafbf0d0142e6ef38c7b8 )
+)
+
+game (
+	name "Supermaze (19xx)(J.K. Greye Software)[a]"
+	description "Supermaze (19xx)(J.K. Greye Software)[a]"
+	rom ( name "Supermaze (19xx)(J.K. Greye Software)[a].p" size 16168 crc f516c522 md5 d53c27e1f4ccfa831cfefde9ba9abf13 sha1 ffa266fbd372d1455309a64e5115b0708b85d5a5 )
+)
+
+game (
+	name "Suprmind - Game Bag 2 (19xx)(-)"
+	description "Suprmind - Game Bag 2 (19xx)(-)"
+	rom ( name "Suprmind - Game Bag 2 (19xx)(-).p" size 2252 crc 286fccd1 md5 bfaf0a209cfcbfe8f27bfd1648b344d7 sha1 54af9cd9fdc58b44c12018d8194da1eac6436942 )
+)
+
+game (
+	name "Survivor, De (19xx)(D. Spriddell)(nl)"
+	description "Survivor, De (19xx)(D. Spriddell)(nl)"
+	rom ( name "Survivor, De (19xx)(D. Spriddell)(nl).p" size 6723 crc a8209c09 md5 a74afebf8e25ae1987d51d9c515843ea sha1 4395e88a87940c70dbd7d946e3ffb8921a1b5c03 )
+)
+
+game (
+	name "Survivor, The (19xx)(Your Computer)"
+	description "Survivor, The (19xx)(Your Computer)"
+	rom ( name "Survivor, The (19xx)(Your Computer).p" size 6807 crc 26b68744 md5 928467ff68fa79cbc6187117b72d0a1f sha1 53fbe5b42e02c9da522b5e7a012bde7d9ae51137 )
+)
+
+game (
+	name "Swamp Fever & Lost in the Swamp (1982)(Linda Kuever)"
+	description "Swamp Fever & Lost in the Swamp (1982)(Linda Kuever)"
+	rom ( name "Swamp Fever & Lost in the Swamp (1982)(Linda Kuever).p" size 13730 crc 4f8a1899 md5 733df08038ccb340a1171039660687e8 sha1 d1421c2ac9cf70c6fd509d2b692b79201544873d )
+)
+
+game (
+	name "Swamp Fever & Lost in the Swamp (1982)(Linda Kuever)[a]"
+	description "Swamp Fever & Lost in the Swamp (1982)(Linda Kuever)[a]"
+	rom ( name "Swamp Fever & Lost in the Swamp (1982)(Linda Kuever)[a].p" size 14216 crc 446b0a8c md5 d827fcfdb8addc9fb7a31c71fc136741 sha1 76fe2675b8ec7eabb53c22e7dd890c1929c29c16 )
+)
+
+game (
+	name "Swopper - Reverse a String (19xx)(-)"
+	description "Swopper - Reverse a String (19xx)(-)"
+	rom ( name "Swopper - Reverse a String (19xx)(-).p" size 1246 crc 46562aca md5 cd610b120ce70b3c0a925c7b0b5aa49e sha1 1d8b598d7f3f6e3988c039c640531de05aede2d8 )
+)
+
+game (
+	name "Sword of Peace, The (19xx)(-)"
+	description "Sword of Peace, The (19xx)(-)"
+	rom ( name "Sword of Peace, The (19xx)(-).p" size 8532 crc 17ceaac7 md5 43120aa712230a8cc182688fe800ba50 sha1 a5080352ca889d7938dafd1e0c527d75ff8502bb )
+)
+
+game (
+	name "Sword of Peace, The (19xx)(-)[a]"
+	description "Sword of Peace, The (19xx)(-)[a]"
+	rom ( name "Sword of Peace, The (19xx)(-)[a].p" size 8581 crc 9848c4b1 md5 c7347091138bfca7179367bc34c6be57 sha1 f9867a01027c4af7aae7a938db0205b43ed0f093 )
+)
+
+game (
+	name "Tafel Naar Wens (19xx)(Logical Computers)(nl)"
+	description "Tafel Naar Wens (19xx)(Logical Computers)(nl)"
+	rom ( name "Tafel Naar Wens (19xx)(Logical Computers)(nl).p" size 2273 crc 267435e9 md5 dd5a037b13d6928875bef7751bab91a4 sha1 565e0a9b0b9cc884a29f12d8c49bcd0bda04866b )
+)
+
+game (
+	name "Tafels van Vermenigvuldiging, De (1984)(Uitgverij Macos)(nl)"
+	description "Tafels van Vermenigvuldiging, De (1984)(Uitgverij Macos)(nl)"
+	rom ( name "Tafels van Vermenigvuldiging, De (1984)(Uitgverij Macos)(nl).p" size 9137 crc c3cb064c md5 e57a5a7327362c0a986803fad6753887 sha1 f31f9733977f04234b0e695ef4d44c70286fa4a5 )
+)
+
+game (
+	name "Tai (1983)(PSS)"
+	description "Tai (1983)(PSS)"
+	rom ( name "Tai (1983)(PSS).p" size 14015 crc f15d8ca4 md5 6cd9a9e3123ab5856116940017ba7a6e sha1 98ce0f33e1657299be685abbbd06c70ac50509ad )
+)
+
+game (
+	name "Tai (1983)(PSS)[a]"
+	description "Tai (1983)(PSS)[a]"
+	rom ( name "Tai (1983)(PSS)[a].p" size 14015 crc 94e63b3f md5 9b51de761ececa414bd6433feb24c26f sha1 ca7f7f62c97acc502041dc5e21f15043dc4af4c9 )
+)
+
+game (
+	name "Tank Attack (19xx)(-)"
+	description "Tank Attack (19xx)(-)"
+	rom ( name "Tank Attack (19xx)(-).p" size 6145 crc c8c2a22a md5 acb6c7135210c683d95cbc947d9d2bca sha1 5ec4292c41a0a5559d2c986f19bec4a14c63a776 )
+)
+
+game (
+	name "Tasword (1982)(Tasman Software)"
+	description "Tasword (1982)(Tasman Software)"
+	rom ( name "Tasword (1982)(Tasman Software).p" size 15684 crc 69a17741 md5 cf1d4fc97d17c9fcea4233864374ede8 sha1 bad8afb817da53433bf5faeb170a846d092dd3ba )
+)
+
+game (
+	name "Tasword (1982)(Tasman Software)(nl)"
+	description "Tasword (1982)(Tasman Software)(nl)"
+	rom ( name "Tasword (1982)(Tasman Software)(nl).p" size 12608 crc 979f8979 md5 b70d391f2045b363322f0f2932a85c57 sha1 768e2a274f1bf668af58a0c2185d36647cd4bb3e )
+)
+
+game (
+	name "Tasword (1982)(Tasman Software)(nl)[a]"
+	description "Tasword (1982)(Tasman Software)(nl)[a]"
+	rom ( name "Tasword (1982)(Tasman Software)(nl)[a].p" size 12608 crc cb29d997 md5 37270f4be2e861f2fe57a4a0748921ee sha1 947a46f4db583e7a1532821335803dea33d2a474 )
+)
+
+game (
+	name "Tekenen (19xx)(-)"
+	description "Tekenen (19xx)(-)"
+	rom ( name "Tekenen (19xx)(-).p" size 9442 crc 52c42801 md5 197290f3bd00599a6afe339e649873f9 sha1 873d7725d689bcff6c08fdc68c2386e62c89ddaa )
+)
+
+game (
+	name "Tempest (19xx)(S.P. Kelly)"
+	description "Tempest (19xx)(S.P. Kelly)"
+	rom ( name "Tempest (19xx)(S.P. Kelly).p" size 3404 crc 0b8144a4 md5 e0ef6c3edf25265cec072e49843c082c sha1 8866b954f30f8cd6519aa7aa10a8b4a241f77c09 )
+)
+
+game (
+	name "Ten Pin (19xx)(-)"
+	description "Ten Pin (19xx)(-)"
+	rom ( name "Ten Pin (19xx)(-).p" size 2463 crc bfb722a6 md5 81200900b7063028e128980188150041 sha1 d85834ec9a5a0f8da9a3e7bf9998f5fd404958d0 )
+)
+
+game (
+	name "Ten Pin Bowling (1982)(Phipps Associates)"
+	description "Ten Pin Bowling (1982)(Phipps Associates)"
+	rom ( name "Ten Pin Bowling (1982)(Phipps Associates).p" size 9916 crc e0297425 md5 f703b165178c1797515d7bacce519653 sha1 7237681f9f3735a6226281e1d4bfc871f1ec28df )
+)
+
+game (
+	name "Tennis (19xx)(-)(nl)[a]"
+	description "Tennis (19xx)(-)(nl)[a]"
+	rom ( name "Tennis (19xx)(-)(nl)[a].p" size 2834 crc 8ea01905 md5 c3d250b718360e4a04f91d9e643c7974 sha1 e264d61c10afa360e5db5e628a8c9c7726cfb420 )
+)
+
+game (
+	name "Tennis (19xx)(Ch. Zwerschke)(de)"
+	description "Tennis (19xx)(Ch. Zwerschke)(de)"
+	rom ( name "Tennis (19xx)(Ch. Zwerschke)(de).p" size 2904 crc 07210436 md5 3276a5b951d1faef6568e911ec5a9e45 sha1 682eb5b46f5ea48474a019650834a5aafa48cb8b )
+)
+
+game (
+	name "Tennis (19xx)(Ch. Zwerschke)(de)[a]"
+	description "Tennis (19xx)(Ch. Zwerschke)(de)[a]"
+	rom ( name "Tennis (19xx)(Ch. Zwerschke)(de)[a].p" size 2856 crc a13f0f0b md5 072c3b2428f3c31da660dc582b17535b sha1 afe88b1594ef1fce399f8deec3b8a00baa3a4eb1 )
+)
+
+game (
+	name "Terminal (19xx)(-)"
+	description "Terminal (19xx)(-)"
+	rom ( name "Terminal (19xx)(-).p" size 2340 crc 592023e1 md5 6c8713f1a555694a8751440cc17e8f3c sha1 07f05a3fa8c3052697436733eddc725cd8a4353b )
+)
+
+game (
+	name "Things (19xx)(-)"
+	description "Things (19xx)(-)"
+	rom ( name "Things (19xx)(-).p" size 13598 crc e74bb60d md5 3b3ddb943c4f0cbd0e1f3930d4befbbb sha1 47aeb0410743a93f1e2c63721f098f10a0d4a749 )
+)
+
+game (
+	name "THT Sim (1983)(-)(nl)"
+	description "THT Sim (1983)(-)(nl)"
+	rom ( name "THT Sim (1983)(-)(nl).p" size 10114 crc 74dc40a8 md5 27119997d3b0d2458d803ab569444a08 sha1 227d4970b9a6af2fb68497759d7adcfba37fb51c )
+)
+
+game (
+	name "Thyristor (1983)(MTS)"
+	description "Thyristor (1983)(MTS)"
+	rom ( name "Thyristor (1983)(MTS).p" size 3782 crc dcfadab4 md5 e9578dfe4d72c2f103fecf2afee699d4 sha1 67f6c4be75fe2b7ab7bf389142ecd7522dc9f924 )
+)
+
+game (
+	name "Tic Tac Toe (19xx)(-)"
+	description "Tic Tac Toe (19xx)(-)"
+	rom ( name "Tic Tac Toe (19xx)(-).p" size 1964 crc 0dcabaaf md5 271c099c83652399393409e94ee1394e sha1 04a6adfec20a2ec5646e741db1c272536d6f57ca )
+)
+
+game (
+	name "Tic Tac Toe (19xx)(-)[a]"
+	description "Tic Tac Toe (19xx)(-)[a]"
+	rom ( name "Tic Tac Toe (19xx)(-)[a].p" size 1963 crc 98465cba md5 3c56041f6a815d6a0d7c82d3fcd39d91 sha1 b174b99cac27631666c2086980d6f4bc0592e3f2 )
+)
+
+game (
+	name "Time Bandits, The (19xx)(-)"
+	description "Time Bandits, The (19xx)(-)"
+	rom ( name "Time Bandits, The (19xx)(-).p" size 15957 crc 3587b27e md5 029ad152f54939e9ad6261ac7f9de0c7 sha1 ae4c9c70a54fc6e95198790343f478758826d3be )
+)
+
+game (
+	name "Time Bomb (19xx)(-)(nl)"
+	description "Time Bomb (19xx)(-)(nl)"
+	rom ( name "Time Bomb (19xx)(-)(nl).p" size 7855 crc a97e69e7 md5 4eae5abc43bdc6687c1d46b7308b26f4 sha1 48c237e3d862c89eb5a3f285b78f37d444c7fe84 )
+)
+
+game (
+	name "Timex Trap (19xx)(-)"
+	description "Timex Trap (19xx)(-)"
+	rom ( name "Timex Trap (19xx)(-).p" size 2633 crc 258c0878 md5 57060c7c8a812022a24bda86c36d81df sha1 29390066141c8499fe35d0be3440f2dc581198d5 )
+)
+
+game (
+	name "Timex Trap (19xx)(-)[a]"
+	description "Timex Trap (19xx)(-)[a]"
+	rom ( name "Timex Trap (19xx)(-)[a].p" size 3523 crc c432e820 md5 7121e168157854af09d7679b5d2c7ca7 sha1 f73724f4e6d2d04d0d7667e861afa68177969fb2 )
+)
+
+game (
+	name "Titanic (19xx)(Bert van Oortmarssen)(nl)"
+	description "Titanic (19xx)(Bert van Oortmarssen)(nl)"
+	rom ( name "Titanic (19xx)(Bert van Oortmarssen)(nl).p" size 5240 crc 998cdcd9 md5 37a1cef343b446eacb969e382e7f3f70 sha1 26c01bf5702d46ff13cc7a03cd4923400c2df2fd )
+)
+
+game (
+	name "Tomb of Dracula, The (19xx)(Felix Software)"
+	description "Tomb of Dracula, The (19xx)(Felix Software)"
+	rom ( name "Tomb of Dracula, The (19xx)(Felix Software).p" size 16095 crc 865c5dd7 md5 3151a77bad3e2661b9cbf8f068102c34 sha1 a33df059f1b5b2839d8497b2c74110daa3bcca02 )
+)
+
+game (
+	name "Tombe van Dracula, De (19xx)(Felix Software)(nl)"
+	description "Tombe van Dracula, De (19xx)(Felix Software)(nl)"
+	rom ( name "Tombe van Dracula, De (19xx)(Felix Software)(nl).p" size 15547 crc f407ee15 md5 b930253cdd85c161fa9a504bf67fbc28 sha1 5da8e6211f076bb602835e3f8062485e2351c485 )
+)
+
+game (
+	name "Torens van Hanoi (19xx)(D.J. de Korte)(nl)"
+	description "Torens van Hanoi (19xx)(D.J. de Korte)(nl)"
+	rom ( name "Torens van Hanoi (19xx)(D.J. de Korte)(nl).p" size 3634 crc 40971f59 md5 ccb96cf49e734787daa5b4036de8d795 sha1 cbe851ef875be7107362f9e448d3138b8be895a0 )
+)
+
+game (
+	name "Totomaat (1983)(Kluwer Technische Boeken)(nl)"
+	description "Totomaat (1983)(Kluwer Technische Boeken)(nl)"
+	rom ( name "Totomaat (1983)(Kluwer Technische Boeken)(nl).p" size 3780 crc 7cd35fa8 md5 898a722bb60498a42e464f7dc9a0261f sha1 774e5efcc807f6f29a92d368f49773b55cc0712f )
+)
+
+game (
+	name "Tower (19xx)(-)(nl)"
+	description "Tower (19xx)(-)(nl)"
+	rom ( name "Tower (19xx)(-)(nl).p" size 5243 crc 2d617824 md5 f856888c9bd6017a3b32136f1dd4edd5 sha1 584f10c128e6bae502652558f0e694bf8cc8c60a )
+)
+
+game (
+	name "Tower of Hanoi, The (1983)(Kenneth Baker)"
+	description "Tower of Hanoi, The (1983)(Kenneth Baker)"
+	rom ( name "Tower of Hanoi, The (1983)(Kenneth Baker).p" size 2286 crc c5eef710 md5 257829cb15dfb2ee6c252c8f293199d1 sha1 e73f8790c215be5f905820f6afe8c8e7fcd791c8 )
+)
+
+game (
+	name "Towers of Hanoi (19xx)(Logical Computers)"
+	description "Towers of Hanoi (19xx)(Logical Computers)"
+	rom ( name "Towers of Hanoi (19xx)(Logical Computers).p" size 3628 crc 8d90f5a2 md5 8fa88e3ff7d34f85d40c646d371a8e5d sha1 06887faa2ba4c3b0fb62ccd141ceffd337f73329 )
+)
+
+game (
+	name "Trace (19xx)(-)"
+	description "Trace (19xx)(-)"
+	rom ( name "Trace (19xx)(-).p" size 1410 crc 117e80f9 md5 aea20127a9dbaaea432ac6bd0f11fb81 sha1 8c82960e8e9e0c1e04897a11eb8a37682977fb88 )
+)
+
+game (
+	name "Traffic - River (19xx)(-)"
+	description "Traffic - River (19xx)(-)"
+	rom ( name "Traffic - River (19xx)(-).p" size 6000 crc e5eeeb1a md5 b6922d744e9bd5cfc0055b9913a20c88 sha1 0b4e79e08329aa89ca0615d5b087490651fc67e8 )
+)
+
+game (
+	name "Train Race (19xx)(-)"
+	description "Train Race (19xx)(-)"
+	rom ( name "Train Race (19xx)(-).p" size 2370 crc c3a0bc12 md5 c81e074e9452f9bdafdf5958b73fec45 sha1 d7211fccf499c559eda5af6a09f0791098f7d5e6 )
+)
+
+game (
+	name "Trajectory (19xx)(-)"
+	description "Trajectory (19xx)(-)"
+	rom ( name "Trajectory (19xx)(-).p" size 1409 crc fec35d0d md5 6d2a9dd412470504d0acfba855079668 sha1 68fba8f367c7b8dbd7cdcb6a60cb7ecde565cdae )
+)
+
+game (
+	name "Trap (19xx)(-)(de)"
+	description "Trap (19xx)(-)(de)"
+	rom ( name "Trap (19xx)(-)(de).p" size 3317 crc 8f2a485d md5 69a7874199e4359540f8654322eac92f sha1 e00bd0ef883db651e067e47ca32b218a86e17b45 )
+)
+
+game (
+	name "Trap (19xx)(-)(de)[a]"
+	description "Trap (19xx)(-)(de)[a]"
+	rom ( name "Trap (19xx)(-)(de)[a].p" size 3271 crc efacf8f8 md5 825135500848d0b0dfe68e829e1f9ed7 sha1 610bd3118544c94d1a6a15bd237266a540f7b1d4 )
+)
+
+game (
+	name "Trapped (19xx)(-)"
+	description "Trapped (19xx)(-)"
+	rom ( name "Trapped (19xx)(-).p" size 2090 crc 2fee7f66 md5 a16dddc5d65c03f6f9128ec8de671340 sha1 86d8e7758f51603f9a619b82bb6af7a305df64d4 )
+)
+
+game (
+	name "Treibjagd (19xx)(-)(de)"
+	description "Treibjagd (19xx)(-)(de)"
+	rom ( name "Treibjagd (19xx)(-)(de).p" size 1815 crc d2221e18 md5 8d107462831f122576e086d809f61f85 sha1 ff22e19ada69be077a6e32e9ec19e19dbbc3062c )
+)
+
+game (
+	name "Trein Race (19xx)(-)(nl)"
+	description "Trein Race (19xx)(-)(nl)"
+	rom ( name "Trein Race (19xx)(-)(nl).p" size 2662 crc b9b0f76b md5 02011a8a10b656be5b8229937e2cd694 sha1 a8b54b6d03e19f0b6dd032510445b2d0c9c78184 )
+)
+
+game (
+	name "Triangle Numbers (1987)(Peter Davis)[m David Buttery]"
+	description "Triangle Numbers (1987)(Peter Davis)[m David Buttery]"
+	rom ( name "Triangle Numbers (1987)(Peter Davis)[m David Buttery].p" size 1489 crc d638e485 md5 a3254bf431bc6a5422d81ca70aef8a67 sha1 8426b8d652a5f2c6748c50c9332989b2c0d8b4d9 )
+)
+
+game (
+	name "Triangles (19xx)(-)"
+	description "Triangles (19xx)(-)"
+	rom ( name "Triangles (19xx)(-).p" size 15996 crc 3ff91d02 md5 b9606072aa1e6cd1e64e8e9c8afc0f07 sha1 11754fe22b5818e1c29bc2bda274d0a6cc695634 )
+)
+
+game (
+	name "Trickfilmmenue (19xx)(-)(de)"
+	description "Trickfilmmenue (19xx)(-)(de)"
+	rom ( name "Trickfilmmenue (19xx)(-)(de).p" size 7431 crc 4c6ce971 md5 f0a538a5c495dc3ccfd75a07f6221c7d sha1 fc81f71b26b21bd829aedc2099ec86f57b1163f4 )
+)
+
+game (
+	name "Trojan (19xx)(-)"
+	description "Trojan (19xx)(-)"
+	rom ( name "Trojan (19xx)(-).p" size 15859 crc cf628959 md5 d25ee3da90ca79a3eb498dd124e8a18a sha1 3aeb584a7e84dd63c5ba7a63e712e9f5ce60868a )
+)
+
+game (
+	name "Trojan Dragon (1983)(S. Fawkes)"
+	description "Trojan Dragon (1983)(S. Fawkes)"
+	rom ( name "Trojan Dragon (1983)(S. Fawkes).p" size 9116 crc df935d97 md5 73cbf1be8e42493bfd8921cb78334147 sha1 08518db2057a60ffd4e256333c485efa57fbd4d2 )
+)
+
+game (
+	name "Tugboat (19xx)(-)"
+	description "Tugboat (19xx)(-)"
+	rom ( name "Tugboat (19xx)(-).p" size 1753 crc cea898f7 md5 c1fd5cb5695d941f4004543e8348913f sha1 57ea2db65f80b5e97dd3229f0b13f63f92fb7940 )
+)
+
+game (
+	name "Tuin der Angst (19xx)(Alpha Software)(nl)"
+	description "Tuin der Angst (19xx)(Alpha Software)(nl)"
+	rom ( name "Tuin der Angst (19xx)(Alpha Software)(nl).p" size 15064 crc 9ce3cf1f md5 c047a617d9e05efb0ff5c4e8f54d3650 sha1 ec3219d929e305c87ff6e19c00201158251f3798 )
+)
+
+game (
+	name "Tunnel (19xx)(-)"
+	description "Tunnel (19xx)(-)"
+	rom ( name "Tunnel (19xx)(-).p" size 4881 crc 0c0a0169 md5 60a37d8c32b3c3f9d0bc177030579727 sha1 0d39654be895d2c4c3c19275e8ac07ad7696bb9a )
+)
+
+game (
+	name "Turbo (19xx)(-)(nl)"
+	description "Turbo (19xx)(-)(nl)"
+	rom ( name "Turbo (19xx)(-)(nl).p" size 2162 crc cd8375fe md5 63afd35247b18be7f3ffd04ebcfc64cb sha1 c2c187c99ec10f19753a276bc461619eedb36166 )
+)
+
+game (
+	name "Turbo (19xx)(D. Green)"
+	description "Turbo (19xx)(D. Green)"
+	rom ( name "Turbo (19xx)(D. Green).p" size 2071 crc f6987c5f md5 6ae96852e574486e948e0091250814c5 sha1 e10823399168e4dfba0f6a7ef0b7875c9142d7ac )
+)
+
+game (
+	name "Twenty One (19xx)(-)"
+	description "Twenty One (19xx)(-)"
+	rom ( name "Twenty One (19xx)(-).p" size 2917 crc 86c59164 md5 89dc051f80c29c77f4d9f1be52278fe8 sha1 416e51c3aa0eb002ead1f0ccbb2ae084f2774193 )
+)
+
+game (
+	name "Twenty One (19xx)(-)[a]"
+	description "Twenty One (19xx)(-)[a]"
+	rom ( name "Twenty One (19xx)(-)[a].p" size 2948 crc 9687f525 md5 043f1aac50627198413b9a0e718b3d15 sha1 5d1ab5796c51d3429200efb36f123850e1de0213 )
+)
+
+game (
+	name "Twister 1 (19xx)(-)"
+	description "Twister 1 (19xx)(-)"
+	rom ( name "Twister 1 (19xx)(-).p" size 2529 crc 8f667671 md5 0765b0675cefde43c2fb5d0a7879f910 sha1 019fedda61de58109518c0422103f87c6007002e )
+)
+
+game (
+	name "Two Player Game - Strategy Only (19xx)(-)"
+	description "Two Player Game - Strategy Only (19xx)(-)"
+	rom ( name "Two Player Game - Strategy Only (19xx)(-).p" size 1315 crc 7f752d24 md5 7abb29ca8fbea36fa9ec30623e942388 sha1 46fab0c8b3c368a1fc9048a34e2ac2a4332dd913 )
+)
+
+game (
+	name "Two Stroke Engine, The (1982)(B. Horsfield)"
+	description "Two Stroke Engine, The (1982)(B. Horsfield)"
+	rom ( name "Two Stroke Engine, The (1982)(B. Horsfield).p" size 3137 crc a38ee836 md5 8e12517de164d41ae652361ce6fb9ff2 sha1 c45c3eabebca9dfb77933b96b63206f57863d070 )
+)
+
+game (
+	name "U-Boot (19xx)(-)"
+	description "U-Boot (19xx)(-)"
+	rom ( name "U-Boot (19xx)(-).p" size 1511 crc 84412648 md5 42cd2c04a536853d9596e95d793969ac sha1 9fac90977f42c013fd8dd4589b9bbf879e01971a )
+)
+
+game (
+	name "U.S. Presidents Quiz, The (1982)(Timex)"
+	description "U.S. Presidents Quiz, The (1982)(Timex)"
+	rom ( name "U.S. Presidents Quiz, The (1982)(Timex).p" size 5072 crc 07c9eca5 md5 fd08336de8202603dde05af6ac4365b1 sha1 bdeecb3d9e6a045dc11c6c9ff5e8d8f108f8ed2d )
+)
+
+game (
+	name "UFO (19xx)(-)"
+	description "UFO (19xx)(-)"
+	rom ( name "UFO (19xx)(-).p" size 3546 crc 5430dd52 md5 74f282e6f6fd46b9e782c26a222d4bf0 sha1 dc5d64ef5fc927a3b2e80c2c30cd1a2e9fb0a37b )
+)
+
+game (
+	name "UFO Invasie (19xx)(Alpha Software)(nl)"
+	description "UFO Invasie (19xx)(Alpha Software)(nl)"
+	rom ( name "UFO Invasie (19xx)(Alpha Software)(nl).p" size 4209 crc 726d58fb md5 ca3449d35a70db10d827e4c14330b85e sha1 f9ce847fc5ff9ed93e63fbbf70776c550eec058e )
+)
+
+game (
+	name "Uhr (19xx)(-)(de)"
+	description "Uhr (19xx)(-)(de)"
+	rom ( name "Uhr (19xx)(-)(de).p" size 2184 crc 41997832 md5 f844d7a5af06b5560eeaf34c68ac2d71 sha1 86fe5410dd0393ffc7f311ee8e531ccd439c697e )
+)
+
+game (
+	name "Umzingelung (1982)(H. Stamm)(de)"
+	description "Umzingelung (1982)(H. Stamm)(de)"
+	rom ( name "Umzingelung (1982)(H. Stamm)(de).p" size 2546 crc cdd18cea md5 09592c680c76474271167e37506fbdbe sha1 fa370911e89238e83653fa21155a6127eb6a1a53 )
+)
+
+game (
+	name "Umzingelung (1982)(H. Stamm)(de)[a]"
+	description "Umzingelung (1982)(H. Stamm)(de)[a]"
+	rom ( name "Umzingelung (1982)(H. Stamm)(de)[a].p" size 2524 crc d283b3a3 md5 b6e9e5c52dab1a2ffe7462be9d5ae37a sha1 d6c89322a41fdf1b6aead2a65cdee1c245b89d78 )
+)
+
+game (
+	name "Vabanque (19xx)(-)(de)"
+	description "Vabanque (19xx)(-)(de)"
+	rom ( name "Vabanque (19xx)(-)(de).p" size 1777 crc fe18173b md5 794ed42a4a02ea6b9c3701d2a33bee1c sha1 89d27f1c2284aa97e54df9d41c58d9da79081c86 )
+)
+
+game (
+	name "Vallende Sterren (19xx)(-)(nl)"
+	description "Vallende Sterren (19xx)(-)(nl)"
+	rom ( name "Vallende Sterren (19xx)(-)(nl).p" size 2911 crc db7642ca md5 cc614e7c29beb07315572545386a0460 sha1 8c0f141e63bdf2b41ba4ff4046dfff428ac83ad1 )
+)
+
+game (
+	name "Valley of Death, The (19xx)(-)"
+	description "Valley of Death, The (19xx)(-)"
+	rom ( name "Valley of Death, The (19xx)(-).p" size 6002 crc 6eed9701 md5 9c15b3091dc3c6b4a7994206033834fc sha1 8ab7d064eca650912d0fc682a20572641cd146ef )
+)
+
+game (
+	name "Van 5 Naar 0 (19xx)(-)(nl)"
+	description "Van 5 Naar 0 (19xx)(-)(nl)"
+	rom ( name "Van 5 Naar 0 (19xx)(-)(nl).p" size 2330 crc 0b3abb18 md5 b17da624a7e7a18f400341a229f6b3e5 sha1 31b8e2284888c9e1dc2a4ef211e8827d40b0e342 )
+)
+
+game (
+	name "Vapours on Venus (1983)(Fontana Publishing)"
+	description "Vapours on Venus (1983)(Fontana Publishing)"
+	rom ( name "Vapours on Venus (1983)(Fontana Publishing).p" size 2695 crc d9e61973 md5 2d25649b9609c54f7c41076a41011218 sha1 510d8155a17d16c2d9e35deef2bc33659026b19c )
+)
+
+game (
+	name "Venture (19xx)(-)"
+	description "Venture (19xx)(-)"
+	rom ( name "Venture (19xx)(-).p" size 14313 crc 6ac976dd md5 b090395fce9fe8f379f359e46bebdbbc sha1 f4fc2230bd1831d9adc6a6ae8a267580eb1556f4 )
+)
+
+game (
+	name "Vergiss Mein Nicht (19xx)(-)(de)"
+	description "Vergiss Mein Nicht (19xx)(-)(de)"
+	rom ( name "Vergiss Mein Nicht (19xx)(-)(de).p" size 3611 crc fb738ded md5 8d36206abedd112c43a4b90fd85c3370 sha1 d53d5f70b9759a923f1bd78a72840cb8220f8250 )
+)
+
+game (
+	name "Verstaerker (19xx)(-)(de)"
+	description "Verstaerker (19xx)(-)(de)"
+	rom ( name "Verstaerker (19xx)(-)(de).p" size 3789 crc f9d862e6 md5 19d9883f2ee9091154461a27bbf2943a sha1 5577ae893afb21b764d41def59f810ee87287e74 )
+)
+
+game (
+	name "Vier Gewinnt (19xx)(-)(de)"
+	description "Vier Gewinnt (19xx)(-)(de)"
+	rom ( name "Vier Gewinnt (19xx)(-)(de).p" size 5086 crc b568cad1 md5 c7bc68051651dd4446fc00961408f488 sha1 18bc7ef84124e94d7b17a06b9ec02e77d1a29f91 )
+)
+
+game (
+	name "Vier Gewinnt (19xx)(-)(de)[different 1]"
+	description "Vier Gewinnt (19xx)(-)(de)[different 1]"
+	rom ( name "Vier Gewinnt (19xx)(-)(de)[different 1].p" size 4326 crc 73c674cd md5 b47f52ca4b461c61af35c965133e848f sha1 d6ffa1fdab448e5fd55e70dfcbf541df439aae32 )
+)
+
+game (
+	name "Vier Gewinnt (19xx)(-)(de)[different 2]"
+	description "Vier Gewinnt (19xx)(-)(de)[different 2]"
+	rom ( name "Vier Gewinnt (19xx)(-)(de)[different 2].p" size 2555 crc 32a8cb05 md5 87dbfe70051880306f206a5bf945d308 sha1 2a01bc6a30b33644d5264512e4148a5607cb97c5 )
+)
+
+game (
+	name "Vier op een Rij (19xx)(-)(nl)"
+	description "Vier op een Rij (19xx)(-)(nl)"
+	rom ( name "Vier op een Rij (19xx)(-)(nl).p" size 1838 crc be20f31d md5 af0aa446cabccaeda928858933d3ef43 sha1 bc0a554c52ce70097b153514e2746c58ff9300aa )
+)
+
+game (
+	name "Viper (1982)(Vegagak)"
+	description "Viper (1982)(Vegagak)"
+	rom ( name "Viper (1982)(Vegagak).p" size 1479 crc 358612d9 md5 a5663ba029a9f6cdc109e8aef3456ee6 sha1 d5619d8ed2b20297913bb76e66389ba47ffd68db )
+)
+
+game (
+	name "Visser, De (19xx)(Logical Computers)(nl)"
+	description "Visser, De (19xx)(Logical Computers)(nl)"
+	rom ( name "Visser, De (19xx)(Logical Computers)(nl).p" size 3577 crc 63e74042 md5 c780a9c3b064dac80609b425e343db04 sha1 468eab416526146acbb8a99c949d8660623223ed )
+)
+
+game (
+	name "Wall (19xx)(Mark Deenik)"
+	description "Wall (19xx)(Mark Deenik)"
+	rom ( name "Wall (19xx)(Mark Deenik).p" size 4763 crc 0773aa81 md5 9b5765ff968c4adeeea0f437a1587153 sha1 50a84ca5833e5a35b15d6fd27d0b17bb9f4077d2 )
+)
+
+game (
+	name "Warlord (19xx)(-)(nl)"
+	description "Warlord (19xx)(-)(nl)"
+	rom ( name "Warlord (19xx)(-)(nl).p" size 15467 crc 78320467 md5 8b1e1157515cb6e3d7f134934bda6852 sha1 88e1c5f640acd7a100388877a4742a663b869f91 )
+)
+
+game (
+	name "Water Tap (19xx)(-)"
+	description "Water Tap (19xx)(-)"
+	rom ( name "Water Tap (19xx)(-).p" size 3103 crc 63d8926f md5 1dc2b277c7efaf8aac258e699f0259f3 sha1 86337f3416d372581fe40e1e332e5cbbe7b1b806 )
+)
+
+game (
+	name "Weirdo Zapping (1983)(Peter Davis)[m David Buttery]"
+	description "Weirdo Zapping (1983)(Peter Davis)[m David Buttery]"
+	rom ( name "Weirdo Zapping (1983)(Peter Davis)[m David Buttery].p" size 2489 crc a3dcf913 md5 da1d6d26642b5c99a1362a6b64e80f96 sha1 09697c1b494051d6185c26f320ddddab6d3264a3 )
+)
+
+game (
+	name "Wereld-Hoofdsteden, De (19xx)(-)(nl)"
+	description "Wereld-Hoofdsteden, De (19xx)(-)(nl)"
+	rom ( name "Wereld-Hoofdsteden, De (19xx)(-)(nl).p" size 4572 crc e7a8c899 md5 4012a6e48f4920d41ef033d682007d45 sha1 2195e78ad950e3b08b21844f4098879bb4614d25 )
+)
+
+game (
+	name "Wereldhandel (1984)(R. Kamer)"
+	description "Wereldhandel (1984)(R. Kamer)"
+	rom ( name "Wereldhandel (1984)(R. Kamer).p" size 14023 crc b306ac8d md5 821fc57ab258ff9ed6891e8301378523 sha1 77a5a35df79631e3b7ba1b4938f84990b8ff8bb9 )
+)
+
+game (
+	name "Wetter (19xx)(-)(de)"
+	description "Wetter (19xx)(-)(de)"
+	rom ( name "Wetter (19xx)(-)(de).p" size 14806 crc 8dac574c md5 cbea564c2b5d9a626148340bb4168ee1 sha1 f67d861d0e196fcfd92845204f07146576377023 )
+)
+
+game (
+	name "Whale Attack (19xx)(Whitethorn Software)"
+	description "Whale Attack (19xx)(Whitethorn Software)"
+	rom ( name "Whale Attack (19xx)(Whitethorn Software).p" size 1924 crc ab65a616 md5 22a505125ce3ef018d5cc3851015cfb8 sha1 e39ecb9ed59d82630bf418cd1ccecf9bd59b1fc1 )
+)
+
+game (
+	name "Wild West (1982)(Ch. Zwerschke)"
+	description "Wild West (1982)(Ch. Zwerschke)"
+	rom ( name "Wild West (1982)(Ch. Zwerschke).p" size 3608 crc 64179347 md5 d1e85c8a5a5ad9e4cb6996a751e96df4 sha1 83be95b99802c7150be19affc74610aa39fe935a )
+)
+
+game (
+	name "Wild West (1982)(Ch. Zwerschke)[a]"
+	description "Wild West (1982)(Ch. Zwerschke)[a]"
+	rom ( name "Wild West (1982)(Ch. Zwerschke)[a].p" size 3586 crc f1218c14 md5 adfd0306d0d0e3a556b92c172fc46a91 sha1 9f0f80cc1e3b1cab9de6bf044ffcc7a0ec7afbaf )
+)
+
+game (
+	name "Windmills (19xx)(-)"
+	description "Windmills (19xx)(-)"
+	rom ( name "Windmills (19xx)(-).p" size 5463 crc 82a36670 md5 11a62c0ac149e60177e9cefd5c718726 sha1 d54461af37db98d97a59eb1efd430cf591348044 )
+)
+
+game (
+	name "Wlander (1996)(Walid Maalouli)"
+	description "Wlander (1996)(Walid Maalouli)"
+	rom ( name "Wlander (1996)(Walid Maalouli).p" size 8352 crc 2f754a18 md5 8c9c72ba19a64e8bc2b15d97a3bbbb04 sha1 a06199af2006dba6f062273ce827a4fe641b3008 )
+)
+
+game (
+	name "Word Mastermind (1981)(Vortex Software)"
+	description "Word Mastermind (1981)(Vortex Software)"
+	rom ( name "Word Mastermind (1981)(Vortex Software).p" size 6275 crc 11283a2d md5 8d2b2fa195641bed3b9fd32c6046d8d2 sha1 954ab9f5f655ad8c54916df0f54020bffa36d30b )
+)
+
+game (
+	name "Word Mastermind (1981)(Vortex Software)[a]"
+	description "Word Mastermind (1981)(Vortex Software)[a]"
+	rom ( name "Word Mastermind (1981)(Vortex Software)[a].p" size 6994 crc a78c325e md5 af1b441f08fa3a7acc99dcf8d6482361 sha1 b5400e3da676adc3637fd4fd8dd429eed88880c4 )
+)
+
+game (
+	name "Wrace (1996)(Walid Maalouli)"
+	description "Wrace (1996)(Walid Maalouli)"
+	rom ( name "Wrace (1996)(Walid Maalouli).p" size 4792 crc af83ead9 md5 da95508d7abb6073498962b173b87947 sha1 22367fc71a934f18bd7eba3e9ab80bbbd86a73ed )
+)
+
+game (
+	name "WSII.3 (1983)(P. Hargrave)"
+	description "WSII.3 (1983)(P. Hargrave)"
+	rom ( name "WSII.3 (1983)(P. Hargrave).p" size 7937 crc c8fc7cc0 md5 2c6fa1edd87bd95c10057133478e7d39 sha1 10b2a86cdcba26daae86709dbd9b9a634f7bee19 )
+)
+
+game (
+	name "Wurm (1984)(Michael Engelhard)(de)"
+	description "Wurm (1984)(Michael Engelhard)(de)"
+	rom ( name "Wurm (1984)(Michael Engelhard)(de).p" size 13941 crc ad4caf7b md5 0a27b5251ea293b826a6d6fa5f7a18f4 sha1 29387cc3c0a225ea6784816e5848baf687d76fdd )
+)
+
+game (
+	name "Yahtzee (1983)(Carlo Delhez)(nl)"
+	description "Yahtzee (1983)(Carlo Delhez)(nl)"
+	rom ( name "Yahtzee (1983)(Carlo Delhez)(nl).p" size 8154 crc 45e98b85 md5 1dac82fd4085333fe7e201c28540a1af sha1 b0d4738bbfee84f9162faccb7ee9a36f921ced8e )
+)
+
+game (
+	name "Yahtzee (1983)(Carlo Delhez)(nl)[a]"
+	description "Yahtzee (1983)(Carlo Delhez)(nl)[a]"
+	rom ( name "Yahtzee (1983)(Carlo Delhez)(nl)[a].p" size 8154 crc b3ebe759 md5 8053a081f2811073cf59b6069ebff727 sha1 46406234d511ff0f2ae073f1c9b8e95bbcdfd8aa )
+)
+
+game (
+	name "Yorics Revenge (1984)(Simon Barnett)"
+	description "Yorics Revenge (1984)(Simon Barnett)"
+	rom ( name "Yorics Revenge (1984)(Simon Barnett).p" size 15408 crc d372d60d md5 7f8661f4f0aa7a6601e49c279b48ae44 sha1 5cc10cb4a2a1d7270443ea61632accea1f87dbcc )
+)
+
+game (
+	name "Yorics Revenge (1984)(Simon Barnett)[a]"
+	description "Yorics Revenge (1984)(Simon Barnett)[a]"
+	rom ( name "Yorics Revenge (1984)(Simon Barnett)[a].p" size 15443 crc 13aa1501 md5 4d1d283b1310e5d80522a8506bce5424 sha1 5c464dab828f78d05d15474c62311a5a0279d263 )
+)
+
+game (
+	name "Zahlen (19xx)(-)(de)"
+	description "Zahlen (19xx)(-)(de)"
+	rom ( name "Zahlen (19xx)(-)(de).p" size 1272 crc 49602978 md5 56418d036febbe0b9c62e4cbfce399ea sha1 9cc8d7880dc4480afcdf894f15e7edb589967b12 )
+)
+
+game (
+	name "Zeeslag (19xx)(-)(nl)"
+	description "Zeeslag (19xx)(-)(nl)"
+	rom ( name "Zeeslag (19xx)(-)(nl).p" size 3099 crc eaff8c1b md5 a105d27df50424370d0a01106a0e2722 sha1 31471f97e7b47b56881053891d49439c7abdc441 )
+)
+
+game (
+	name "Zombies (1981)(Artic Computing)"
+	description "Zombies (1981)(Artic Computing)"
+	rom ( name "Zombies (1981)(Artic Computing).p" size 3585 crc 28e4eece md5 fc8198dc39fdcb44034a230508bab0de sha1 e6d241cfa7a1a2706e466f9d6ebe87fb5c5ea74c )
+)
+
+game (
+	name "Zombies (19xx)(D. Green)"
+	description "Zombies (19xx)(D. Green)"
+	rom ( name "Zombies (19xx)(D. Green).p" size 2464 crc b1ecd1fe md5 20fd3417ac968ed4d6e40b2ecc48162c sha1 c71b36036a08f4e68467c56ef965efac3d90f5e0 )
+)
+
+game (
+	name "Zombies (19xx)(M. Buitenhuis)(nl)"
+	description "Zombies (19xx)(M. Buitenhuis)(nl)"
+	rom ( name "Zombies (19xx)(M. Buitenhuis)(nl).p" size 3263 crc ac16b831 md5 202faf3104afe6e8d255bf4b59712317 sha1 4dc32b5942bb7b40d109e5792e6f7d41f2b9e15b )
+)
+
+game (
+	name "Zombies (19xx)(VVP Software)"
+	description "Zombies (19xx)(VVP Software)"
+	rom ( name "Zombies (19xx)(VVP Software).p" size 2047 crc 89554a83 md5 4ead021ad8adc7f5bc562a14d6e65591 sha1 20608fc28a5f107171e9a45887d388a0d5ffab84 )
+)
+
+game (
+	name "Zonk (19xx)(-)(de)"
+	description "Zonk (19xx)(-)(de)"
+	rom ( name "Zonk (19xx)(-)(de).p" size 5372 crc e7b72e9b md5 3cdb51534b62065bf5f79f8a0319c774 sha1 97a23bd426ea5ea20401e39286c1a9c01e59e577 )
+)
+
+game (
+	name "Zor - Battle of the Robots (1982)(Pixel Productions)"
+	description "Zor - Battle of the Robots (1982)(Pixel Productions)"
+	rom ( name "Zor - Battle of the Robots (1982)(Pixel Productions).p" size 15669 crc a091c7a3 md5 5b82f90ef870ed6c50d7fbf86e1509b1 sha1 b70100b7e2232756284384e7d34346a9f4f57157 )
+)
+
+game (
+	name "Zor - Battle of the Robots (1982)(Pixel Productions)[a]"
+	description "Zor - Battle of the Robots (1982)(Pixel Productions)[a]"
+	rom ( name "Zor - Battle of the Robots (1982)(Pixel Productions)[a].p" size 15664 crc cec41e99 md5 da4761ddea90ef655304bef27998909d sha1 be3305030daa70d7007e01bfd077cdcd6657dad2 )
+)
+
+game (
+	name "Zor - Battle of the Robots - Intro (1982)(Pixel Productions)"
+	description "Zor - Battle of the Robots - Intro (1982)(Pixel Productions)"
+	rom ( name "Zor - Battle of the Robots - Intro (1982)(Pixel Productions).p" size 1700 crc 5dd7f844 md5 76bf4bc8af44dbb1a17a216a348ad8c6 sha1 ce4a5876a752a2f602bf0114ff783338b4770494 )
+)
+
+game (
+	name "Zuckman (1982)(David & John Looker)"
+	description "Zuckman (1982)(David & John Looker)"
+	rom ( name "Zuckman (1982)(David & John Looker).p" size 9939 crc 6d5c5765 md5 875df533473db10883228b05ecbdd811 sha1 e475c39f7b54fc04f333be409dcf16e649d64c10 )
+)
+
+game (
+	name "ZX Asteroids (19xx)(-)"
+	description "ZX Asteroids (19xx)(-)"
+	rom ( name "ZX Asteroids (19xx)(-).p" size 5407 crc 9cc0caa5 md5 4c70046623c13bb7fe527d74e47a5c07 sha1 fe9b32784fecae16e3f3c90ee16b9214dde16c8e )
+)
+
+game (
+	name "ZX Asteroids (19xx)(-)[a]"
+	description "ZX Asteroids (19xx)(-)[a]"
+	rom ( name "ZX Asteroids (19xx)(-)[a].p" size 5335 crc 3cb36a67 md5 3305080181940ce79a95e80a4aced0f0 sha1 d4e5e0f7e601ff2be6f6bc2376351b2976f3d0a7 )
+)
+
+game (
+	name "ZX Banners (19xx)(-)"
+	description "ZX Banners (19xx)(-)"
+	rom ( name "ZX Banners (19xx)(-).p" size 2030 crc 1d5046c8 md5 d284a1d0be88a9257e85d4d7aca506de sha1 3e77ae9db96429f748967de9c0ba30007b0b1e85 )
+)
+
+game (
+	name "ZX Bug (19xx)(-)"
+	description "ZX Bug (19xx)(-)"
+	rom ( name "ZX Bug (19xx)(-).p" size 5380 crc 1104158a md5 fb255c8b4c69b42c1e8793d9bd8fecbc sha1 c7f984e0ca40e0a8314dcaededbc58f4f0da56e2 )
+)
+
+game (
+	name "ZX Centipede (19xx)(Jeff Minter)"
+	description "ZX Centipede (19xx)(Jeff Minter)"
+	rom ( name "ZX Centipede (19xx)(Jeff Minter).p" size 9750 crc f8e1dc0a md5 6bfe59178b64f499f3913b91dada4bf5 sha1 2cd8c0d26900d19e9cd6170bfdb7b132b5edbe54 )
+)
+
+game (
+	name "ZX Draw (1983)(S. Collyer)"
+	description "ZX Draw (1983)(S. Collyer)"
+	rom ( name "ZX Draw (1983)(S. Collyer).p" size 4163 crc 7949d987 md5 a8a4a45f243bbe89f7ab528094e1291f sha1 3d4b29c2d3f8708c656e79599dd1c289619b6c71 )
+)
+
+game (
+	name "ZX Profile (19xx)(-)"
+	description "ZX Profile (19xx)(-)"
+	rom ( name "ZX Profile (19xx)(-).p" size 16124 crc 3b28355d md5 fdbd0af9ef0fd1033cde954e16a59600 sha1 62a9c8868d4a8901ee748fa1e2f63bbba0d358f7 )
+)
+
+game (
+	name "ZX Scramble (19xx)(-)"
+	description "ZX Scramble (19xx)(-)"
+	rom ( name "ZX Scramble (19xx)(-).p" size 4536 crc f532ea00 md5 48dd3d74ebbd948362d384789abed280 sha1 7fb5b924c03f2479222a1faf1a9966e795cba343 )
+)
+
+game (
+	name "ZX Screen-Lasso (19xx)(-)(nl)"
+	description "ZX Screen-Lasso (19xx)(-)(nl)"
+	rom ( name "ZX Screen-Lasso (19xx)(-)(nl).p" size 2622 crc 3986ca77 md5 2b8a7c07c3ecf5f0edd7265dc0aac101 sha1 b8efbf91a7a65fac9baa7f34421d7550b4672f0a )
+)
+
+game (
+	name "ZX Stuff (19xx)(H. Stamm - Ch. Zwerschke)(de)"
+	description "ZX Stuff (19xx)(H. Stamm - Ch. Zwerschke)(de)"
+	rom ( name "ZX Stuff (19xx)(H. Stamm - Ch. Zwerschke)(de).p" size 1980 crc c7d7ade4 md5 1c0ed2de05f66d3989b8d3e40db22f8e sha1 cc347364ddd5600c9c9a26f09431f9b3041babe8 )
+)
+
+game (
+	name "ZX-81 Sinusoide (19xx)(VVP Software)(nl)"
+	description "ZX-81 Sinusoide (19xx)(VVP Software)(nl)"
+	rom ( name "ZX-81 Sinusoide (19xx)(VVP Software)(nl).p" size 6964 crc 52f173b2 md5 f1a8a1eba30ec7e2104a8d027b5b274d sha1 5d9142b85fb2b98ef4246ea35b4048fd239a8b9a )
+)
+
+game (
+	name "ZX-81 Tetris (19xx)(Russel Marks)"
+	description "ZX-81 Tetris (19xx)(Russel Marks)"
+	rom ( name "ZX-81 Tetris (19xx)(Russel Marks).p" size 4403 crc 33729781 md5 fc2930232c66d8abceaba8f4d9a60deb sha1 75dad35859eb0305807170b59c491226fbdda18d )
+)
+
+game (
+	name "ZX-Chess II (1981)(Artic Computing)"
+	description "ZX-Chess II (1981)(Artic Computing)"
+	rom ( name "ZX-Chess II (1981)(Artic Computing).p" size 14096 crc dc91bfc3 md5 c517b6fd2e0c3e654d8a630e9e7c7732 sha1 05e1a83d536eb81c6a8da45900e7266ec58d622d )
+)
+
+game (
+	name "ZX-Chess II (1981)(Artic Computing)[a]"
+	description "ZX-Chess II (1981)(Artic Computing)[a]"
+	rom ( name "ZX-Chess II (1981)(Artic Computing)[a].p" size 14184 crc 93368cc6 md5 f86f16499db6c02f9042f10428fbd9be sha1 b70d4ded0d0e4c5b55bfc4444b0c6c70cc398396 )
+)
+
+game (
+	name "ZX-Galaxians (1982)(Artic Computing)"
+	description "ZX-Galaxians (1982)(Artic Computing)"
+	rom ( name "ZX-Galaxians (1982)(Artic Computing).p" size 3602 crc 0c63a7d7 md5 bc28c0f127755b9a85e256a1b6cc822b sha1 5a63e669231085945a859a6fadb4cb2510224bc7 )
+)
+
+game (
+	name "ZX-Galaxians (1982)(Artic Computing)[a]"
+	description "ZX-Galaxians (1982)(Artic Computing)[a]"
+	rom ( name "ZX-Galaxians (1982)(Artic Computing)[a].p" size 3562 crc b5fc1488 md5 ef30971ad58c33fe200bb36f95470350 sha1 190a30b1b54c09e681b8f07c196999e80105da98 )
+)
+
+game (
+	name "Zxiatrist (19xx)(-)"
+	description "Zxiatrist (19xx)(-)"
+	rom ( name "Zxiatrist (19xx)(-).p" size 4958 crc b5e9590b md5 8cd16e9b7908e57e3dbcb32dedd4e8b8 sha1 5c1633b94dbbc90a780f8690933e01bb25cb2d60 )
+)
+
+game (
+	name ZZZ-UNK-10
+	description "ZZZ-UNK-10"
+	rom ( name ZZZ-UNK-10.p size 675 crc 1f60f7d7 md5 78776f038effde6ac35928f95e2aaf6e sha1 3e7d1225a731f2b89dd07e1bde524f34f4ae4eba )
+)
+
+game (
+	name ZZZ-UNK-11
+	description "ZZZ-UNK-11"
+	rom ( name ZZZ-UNK-11.p size 777 crc 78a42416 md5 f7b78915102e8ea11767fabd98654cac sha1 0904014013e72681f58597a2d37791b6c1dad301 )
+)
+
+game (
+	name ZZZ-UNK-2
+	description "ZZZ-UNK-2"
+	rom ( name ZZZ-UNK-2.p size 446 crc f07e888f md5 7b7208b7d0298b36152d0c0c834243fb sha1 d0f02a41df5b02609f4d0d70c9acb18a2cb31818 )
+)
+
+game (
+	name ZZZ-UNK-3
+	description "ZZZ-UNK-3"
+	rom ( name ZZZ-UNK-3.p size 473 crc e0032615 md5 93ee26404efdc7d013b2a7d5971ccb2f sha1 d1dd73f7830ffcffde32381e8a743cd7793424eb )
+)
+
+game (
+	name ZZZ-UNK-4
+	description "ZZZ-UNK-4"
+	rom ( name ZZZ-UNK-4.p size 734 crc cc15aec9 md5 5f92def53373de48424864794074edea sha1 3b61cbc52f27f9124478936a3efce40a731ddeb0 )
+)
+
+game (
+	name ZZZ-UNK-6
+	description "ZZZ-UNK-6"
+	rom ( name ZZZ-UNK-6.p size 695 crc 3da13640 md5 08c602cf2be181f7404dfd56e4acb26f sha1 41c131d3041f137b4aaed17017eb7224dfb689db )
+)
+
+game (
+	name ZZZ-UNK-7
+	description "ZZZ-UNK-7"
+	rom ( name ZZZ-UNK-7.p size 759 crc 3318d71d md5 329b9428aef1ec946ef63d10d8fe9daa sha1 dfbf0eb9182b3513c7650059e4a7268e708eb09e )
+)
+
+game (
+	name ZZZ-UNK-8
+	description "ZZZ-UNK-8"
+	rom ( name ZZZ-UNK-8.p size 630 crc 8b1aa97c md5 3efc3911aa2863bedc3d703d716a4433 sha1 9100eacc62dc3cbd76d744152f5a64ad62b3cf7f )
+)
+
+game (
+	name ZZZ-UNK-9
+	description "ZZZ-UNK-9"
+	rom ( name ZZZ-UNK-9.p size 579 crc f935652c md5 6c8267c6e69eab147a56a325c7d0788e sha1 1ef191bbbea3cf9d198343184b644c40ee2341e7 )
+)
+
+game (
+	name ZZZ-UNK-assem
+	description "ZZZ-UNK-assem"
+	rom ( name ZZZ-UNK-assem.p size 6807 crc f8c07849 md5 7297775b8bef69be4e6abd4a7c43f107 sha1 01935ee50b90846956d0a42986270f7ab2320887 )
+)
+
+game (
+	name ZZZ-UNK-breakout
+	description "ZZZ-UNK-breakout"
+	rom ( name ZZZ-UNK-breakout.p size 1415 crc 0190138d md5 1a0372372628f3d418ef8e4b808a8dd5 sha1 613c9b0668869ee295ba24f0710be8e10c9879a5 )
+)
+
+game (
+	name ZZZ-UNK-chess
+	description "ZZZ-UNK-chess"
+	rom ( name ZZZ-UNK-chess.p size 8303 crc 91bbcfed md5 c3e64cd80e390328e9cbd9c612c66a92 sha1 39e39d88c544229b332f8ff252a4d166c7cbd7f3 )
+)
+
+game (
+	name ZZZ-UNK-eeuwkalender1
+	description "ZZZ-UNK-eeuwkalender1"
+	rom ( name ZZZ-UNK-eeuwkalender1.p size 1779 crc f2de048e md5 eea3d3e407274dce93fbb70e65e94975 sha1 b3c8aec37e09b026aa16e2f35f39b10a8374de7b )
+)
+
+game (
+	name ZZZ-UNK-game-two
+	description "ZZZ-UNK-game-two"
+	rom ( name ZZZ-UNK-game-two.p size 6720 crc eeb941a0 md5 22e77afe203395fdf333ac9f87a30262 sha1 90750dae5662709a228df0d641ceff3ef728e1dc )
+)
+
+game (
+	name ZZZ-UNK-game4
+	description "ZZZ-UNK-game4"
+	rom ( name ZZZ-UNK-game4.p size 1802 crc 6a6f048e md5 0231dba3d7f3b777854812c0563589a7 sha1 cbcc5d71806c39ac73f7267c5b4b84645003f3d2 )
+)
+
+game (
+	name ZZZ-UNK-game5
+	description "ZZZ-UNK-game5"
+	rom ( name ZZZ-UNK-game5.p size 1765 crc 7f6b158b md5 9799b48b260862c34b7cdb3f19018c33 sha1 4ebcf209ce58b891a0bdead9f19a6df17b10163f )
+)
+
+game (
+	name ZZZ-UNK-game6
+	description "ZZZ-UNK-game6"
+	rom ( name ZZZ-UNK-game6.p size 1700 crc c25e00e7 md5 87911742442565d097ac1e858b5c5c95 sha1 30d03d509251d36e50899f15feffb878cc1be92d )
+)
+
+game (
+	name ZZZ-UNK-gobblema
+	description "ZZZ-UNK-gobblema"
+	rom ( name ZZZ-UNK-gobblema.p size 1833 crc 06e8e8a9 md5 8fcc80840b2f5522969f25795130a324 sha1 ffc99cb4e10a111c6eb6c9170e9f9d192104287c )
+)
+
+game (
+	name ZZZ-UNK-gp_(nl)
+	description "ZZZ-UNK-gp_(nl)"
+	rom ( name ZZZ-UNK-gp_(nl).p size 3961 crc 38efb7e8 md5 ff21ab5011a2bf2907f11e699d903ffa sha1 57424b673f83908b656b029a79db7342d176d42a )
+)
+
+game (
+	name ZZZ-UNK-hex_i
+	description "ZZZ-UNK-hex_i"
+	rom ( name ZZZ-UNK-hex_i.p size 1203 crc b329e1c2 md5 5889109a6a467b43586997a22015e71b sha1 89e0878a7ced4a292df985fdb0f2c766daaa40b9 )
+)
+
+game (
+	name ZZZ-UNK-hex_ii
+	description "ZZZ-UNK-hex_ii"
+	rom ( name ZZZ-UNK-hex_ii.p size 1392 crc 52a3dad7 md5 313359a8a1b9534c78b82af0949599ec sha1 86802be5dd6539442c3627a84697f3769ceb8c05 )
+)
+
+game (
+	name ZZZ-UNK-hires-dr
+	description "ZZZ-UNK-hires-dr"
+	rom ( name ZZZ-UNK-hires-dr.p size 7526 crc eff0b6c0 md5 671d4fa7fca37451b57cfb7b805d911a sha1 4186ee8e04be05a59f26810b70d67a9ba57901ae )
+)
+
+game (
+	name ZZZ-UNK-huntmc
+	description "ZZZ-UNK-huntmc"
+	rom ( name ZZZ-UNK-huntmc.p size 3538 crc 69c93228 md5 8fec85bbd74ed93b595fe39091a518b1 sha1 14fce6a3b5983ebbdeb385b2ef92a7d8b4646483 )
+)
+
+game (
+	name ZZZ-UNK-invaders
+	description "ZZZ-UNK-invaders"
+	rom ( name ZZZ-UNK-invaders.p size 1686 crc ab85345d md5 7b38996b195091a3f603ab0cd3d8c775 sha1 389ab5d4059950f1c2fa8d357503af419654d8c0 )
+)
+
+game (
+	name ZZZ-UNK-jumpbc_(nl)
+	description "ZZZ-UNK-jumpbc_(nl)"
+	rom ( name ZZZ-UNK-jumpbc_(nl).p size 1095 crc 47808646 md5 1fbb334c882a44817ead72c50b1eda6a sha1 2ab2b73f0d0cefcba2ce5fbbdbf13a9a7e6a5e8e )
+)
+
+game (
+	name ZZZ-UNK-karset1
+	description "ZZZ-UNK-karset1"
+	rom ( name ZZZ-UNK-karset1.p size 512 crc 67d599d3 md5 0c78d261b48a307891ffe50f846d87d3 sha1 4e2a31f5c4e525b5e5cd790f487a5a5bb7815e0b )
+)
+
+game (
+	name ZZZ-UNK-karset2
+	description "ZZZ-UNK-karset2"
+	rom ( name ZZZ-UNK-karset2.p size 512 crc d0125149 md5 53516f4ff02e564330d63f18cc2d2c13 sha1 2e5495b397bbfd50bc1a280ad442fa8b915021fb )
+)
+
+game (
+	name ZZZ-UNK-karset3
+	description "ZZZ-UNK-karset3"
+	rom ( name ZZZ-UNK-karset3.p size 512 crc f35c62f6 md5 338c8367110c359cdbc10368aa646916 sha1 2f9b519b49557b5a7213ba48987eeae7e82b3d75 )
+)
+
+game (
+	name ZZZ-UNK-karset4
+	description "ZZZ-UNK-karset4"
+	rom ( name ZZZ-UNK-karset4.p size 512 crc c39069b6 md5 3d35c4221e60bed5c99518d84f990a6a sha1 2a1589a9c51118dd4a56f1c0b2497305c0b0e376 )
+)
+
+game (
+	name ZZZ-UNK-kubol_(nl)
+	description "ZZZ-UNK-kubol_(nl)"
+	rom ( name ZZZ-UNK-kubol_(nl).p size 3946 crc 0ed187fc md5 4caf6aa691db7df5b1746e56b2f54ef0 sha1 fe49109d886d65aac942495745fec88d09ce09fd )
+)
+
+game (
+	name ZZZ-UNK-level-ii
+	description "ZZZ-UNK-level-ii"
+	rom ( name ZZZ-UNK-level-ii.p size 6768 crc 7707fbd0 md5 bce2528136324632b206ac91ae90c4da sha1 0e32a82bc6af899e9d248636492ef3cb83e99706 )
+)
+
+game (
+	name ZZZ-UNK-lichtkrant_1984_bert_van_oortmarssen_(nl)
+	description "ZZZ-UNK-lichtkrant_1984_bert_van_oortmarssen_(nl)"
+	rom ( name ZZZ-UNK-lichtkrant_1984_bert_van_oortmarssen_(nl).p size 2665 crc fd4fde11 md5 c7242152558b3acdba58068ab01c14b3 sha1 24efe49a7979f52ad0a3c858315eb1cef5b267d2 )
+)
+
+game (
+	name ZZZ-UNK-memory-m
+	description "ZZZ-UNK-memory-m"
+	rom ( name ZZZ-UNK-memory-m.p size 1621 crc d020df73 md5 154c2ab613716db2268e8586d34b8202 sha1 9f7e84db6103924762bf3393bed024a42c80c3a7 )
+)
+
+game (
+	name ZZZ-UNK-mondri3_(nl)
+	description "ZZZ-UNK-mondri3_(nl)"
+	rom ( name ZZZ-UNK-mondri3_(nl).p size 2959 crc 12628fad md5 1258c5c77f9166a77c1b763317b62f1e sha1 1fdd99a2ed3bf10ff84c648f779b18d561bee32c )
+)
+
+game (
+	name ZZZ-UNK-morse-on_b.h.baily_1984
+	description "ZZZ-UNK-morse-on_b.h.baily_1984"
+	rom ( name ZZZ-UNK-morse-on_b.h.baily_1984.p size 1435 crc ba53a356 md5 f5f4dbce21ac98e7de2cc501458dba34 sha1 09314cd06d8cfc2d2585a006ead7302aab111ee6 )
+)
+
+game (
+	name ZZZ-UNK-mrg2_(nl)
+	description "ZZZ-UNK-mrg2_(nl)"
+	rom ( name ZZZ-UNK-mrg2_(nl).p size 1411 crc ea58dc94 md5 ac0057a88f9c954a0a72ff78eeeb3524 sha1 eed3b331100b90e47be80d63313c482f5d8019ec )
+)
+
+game (
+	name ZZZ-UNK-music
+	description "ZZZ-UNK-music"
+	rom ( name ZZZ-UNK-music.p size 1588 crc 68c4f19f md5 65cfcd384ee29ce15c8f8a73fe7c59cc sha1 754173b3d8097a0a95ae2257d9e508774dfda0bb )
+)
+
+game (
+	name ZZZ-UNK-pacman-k
+	description "ZZZ-UNK-pacman-k"
+	rom ( name ZZZ-UNK-pacman-k.p size 1831 crc 2eb5cf12 md5 1c99891adca6fd47c8baa74e22965990 sha1 00b1428b84c69e438404c1384abe9873ccda0733 )
+)
+
+game (
+	name ZZZ-UNK-pakmc_(nl)
+	description "ZZZ-UNK-pakmc_(nl)"
+	rom ( name ZZZ-UNK-pakmc_(nl).p size 3739 crc 636ebaac md5 a1ea49c8bd18e08d1a2f11cd46aaef97 sha1 3319e504b6af43ab6373459b0fa7d9414a5eed22 )
+)
+
+game (
+	name ZZZ-UNK-qs-defen
+	description "ZZZ-UNK-qs-defen"
+	rom ( name ZZZ-UNK-qs-defen.p size 2968 crc b0299340 md5 a2aae9bc9be2d62717e66746446b16d8 sha1 9e8c3022a91c871bf592dcc581809fc2da0d19db )
+)
+
+game (
+	name ZZZ-UNK-queen8b_(nl)
+	description "ZZZ-UNK-queen8b_(nl)"
+	rom ( name ZZZ-UNK-queen8b_(nl).p size 3905 crc a0a2944b md5 6dee7d1b7fdf4f381fa6464798f4e5a8 sha1 3eea594a001d2ebed15d92bf39fb935586692499 )
+)
+
+game (
+	name ZZZ-UNK-rambug_(nl)
+	description "ZZZ-UNK-rambug_(nl)"
+	rom ( name ZZZ-UNK-rambug_(nl).p size 4068 crc c9ed74e9 md5 98d1edd189fff33a447efed8d1e41d33 sha1 f40c9b86068d4525cd726226ead962551eaf845a )
+)
+
+game (
+	name ZZZ-UNK-rembug_(nl)
+	description "ZZZ-UNK-rembug_(nl)"
+	rom ( name ZZZ-UNK-rembug_(nl).p size 2344 crc 774d1c20 md5 d813ece4a1b86c4cadc2c5a0d1858fdc sha1 ccf8a72570f84736ed47094dd9639789c0511f7e )
+)
+
+game (
+	name ZZZ-UNK-ry4mc2_(nl)
+	description "ZZZ-UNK-ry4mc2_(nl)"
+	rom ( name ZZZ-UNK-ry4mc2_(nl).p size 5143 crc 95c61afd md5 61823fed60e4db80dabda827282c21ef sha1 1a85d92984a71ceb8a8aaa7dee29e2b0c3581d2f )
+)
+
+game (
+	name ZZZ-UNK-ry4mc_(nl)
+	description "ZZZ-UNK-ry4mc_(nl)"
+	rom ( name ZZZ-UNK-ry4mc_(nl).p size 5143 crc 345c188e md5 51a95d3380a02507f05ab4bc57fbf6af sha1 ee275b032e5bf3d563f22250072581e6003bc618 )
+)
+
+game (
+	name ZZZ-UNK-shopwind
+	description "ZZZ-UNK-shopwind"
+	rom ( name ZZZ-UNK-shopwind.p size 6193 crc 7af5c7d8 md5 33dd1696616c1836a57749de8bde54b8 sha1 8479f2edd7c088e5f9876457f804487549c8e152 )
+)
+
+game (
+	name ZZZ-UNK-short
+	description "ZZZ-UNK-short"
+	rom ( name ZZZ-UNK-short.p size 162 crc 2d06ba7c md5 03140318394caf217837d39f1ea0f759 sha1 33e9c25538d74031e046f5ef5957c74a01393876 )
+)
+
+game (
+	name ZZZ-UNK-sketchpa
+	description "ZZZ-UNK-sketchpa"
+	rom ( name ZZZ-UNK-sketchpa.p size 2208 crc f408b84a md5 44b518c0a5df487cadd0349bfe90531c sha1 3815704a575dc4a0f6bade4be9887f5a0ef7f874 )
+)
+
+game (
+	name ZZZ-UNK-sq_(nl)
+	description "ZZZ-UNK-sq_(nl)"
+	rom ( name ZZZ-UNK-sq_(nl).p size 4316 crc 40ffb27e md5 9f5b01c5431a9b94705ab2cb9bcb687b sha1 c9cc6c94c6588a2620bcbaac2fdfce179103d45f )
+)
+
+game (
+	name ZZZ-UNK-startrk
+	description "ZZZ-UNK-startrk"
+	rom ( name ZZZ-UNK-startrk.p size 6719 crc ebb49762 md5 9cbe160cc84c6767a12f478dfc498678 sha1 ef069a319b44b8561c758c20376f1010621ee731 )
+)
+
+game (
+	name ZZZ-UNK-stringlo
+	description "ZZZ-UNK-stringlo"
+	rom ( name ZZZ-UNK-stringlo.p size 1714 crc df4d1522 md5 c610f8c294813c7c371ff61b98807f5c sha1 4aab731e1d0b97ab52230751d2f66afc793b46b2 )
+)
+
+game (
+	name ZZZ-UNK-tic-tac
+	description "ZZZ-UNK-tic-tac"
+	rom ( name ZZZ-UNK-tic-tac.p size 8803 crc 54cb1518 md5 4fc13aaff6a7a5b4827d09f7b5ca6464 sha1 dc3c0bf828d0a63433775fbb948ac1d7afe41df1 )
+)
+
+game (
+	name ZZZ-UNK-zeven_(nl)
+	description "ZZZ-UNK-zeven_(nl)"
+	rom ( name ZZZ-UNK-zeven_(nl).p size 7252 crc db4f8d1c md5 f282eaf9f7e8c3d52c09a36f29b775ff sha1 688e9980ccf2a3efb61ad11fd1a8f668a829d663 )
+)
+
+game (
+	name ZZZ-UNK-zomaarwa
+	description "ZZZ-UNK-zomaarwa"
+	rom ( name ZZZ-UNK-zomaarwa.p size 3053 crc 81351baa md5 0217303512cc1c51f16580795fbd009d sha1 c6997a85d40dd46049725e12b4ffc92759f41ef0 )
+)
+
+game (
+	name ZZZ-UNK-zxas
+	description "ZZZ-UNK-zxas"
+	rom ( name ZZZ-UNK-zxas.p size 5648 crc 97b09029 md5 ebd31db3f3d4b7769833db71cb9de789 sha1 3b6c13b213e4a5f87d629ff5c4cbbb33e9265702 )
+)
+
+game (
+	name ZZZ-UNK-zxdb
+	description "ZZZ-UNK-zxdb"
+	rom ( name ZZZ-UNK-zxdb.p size 5857 crc ba8936a8 md5 420771501d91055a6044fb7ecc362edb sha1 851a394406aa043145bb139c21bb9aafbbadcb05 )
 )


### PR DESCRIPTION
checking zip archives makes no sense, so here's a dat that checks the actual roms for each games
added all 28 known/parents/available Atomiswave games (from present stable MAME source v0.235)
rebuild tested with clrmamepro, all games launch fine in latest retroarch/flycast core