### PR TITLE
Update Friday the 13th (USA).cht

### DIFF
--- a/cht/Nintendo - Nintendo Entertainment System/Friday the 13th (USA).cht
+++ b/cht/Nintendo - Nintendo Entertainment System/Friday the 13th (USA).cht
@@ -44,8 +44,8 @@ cheat10_desc = "Set Powered Character"
 cheat10_code = "051B:03"
 cheat10_enable = false
 
-cheat11_desc = "Set Jason's Health To Zero"
-cheat11_code = "051C:00"
+cheat11_desc = "Jason only has one health bar left"
+cheat11_code = "051C:01"
 cheat11_enable = false
 
 cheat12_desc = "Infinite Children"


### PR DESCRIPTION
The code "Set Jason's Health To Zero" actually makes it impossible to kill Jason even after shutting it off mid-game.