### PR TITLE
Update DOOM.dat

### DIFF
--- a/dat/DOOM.dat
+++ b/dat/DOOM.dat
@@ -1,14 +1,14 @@
 clrmamepro (
 	name "Doom"
 	description "Doom"
-	version 2020.09.26
+	version 2021.11.15
 	author "Obiwantje, LodanZark, libretro"
 )
 
 game (
 	name "Action Doom 2 - Urban Brawl"
 	description "Action Doom 2 - Urban Brawl"
-	rom ( name ACTION2.WAD size 143208125 crc a65d503b md5 1914b280b0a4b517214523bc2270e758 sha1 4dbb7b0c4600ffa1c6f3fe9e052b071176498eeb )
+	rom ( name ACTION2.WAD size 209908382 crc 4310c519 md5 35f12b439cc475e8ffcba8c42a5bba6c sha1 0da97921963442f2b22959ab941744d815c4f50d )
 )
 
 game (
@@ -18,10 +18,23 @@ game (
 )
 
 game (
-	name "Blasphemer"
+	name "BlasphDM (v0.1.7)"
+	description "BlasphDM (v0.1.7)"
+	rom ( name BLASPHDM-0.1.7.WAD size 11786512 crc 395cdf71 md5 998db45146b1473b42e0edf26e88c213 sha1 441ef3e9c686a42a869def84a3199bb0ad4a8431 )
+)
+
+game (
+	name "Blasphemer (v0.1.5)"
 	description "Blasphemer (v0.1.5)"
 	rom ( name BLASPHEM.WAD size 7502640 crc b6a1d3d5 md5 c98a0eca0187edef40a06cab38949210 sha1 7fea92986e91e2f7d58e3bb7a34733ef8e0efd9d )
 )
+
+game (
+	name "Blasphemer (v0.1.7)"
+	description "Blasphemer (v0.1.7)"
+	rom ( name BLASPHEM-0.1.7.WAD size 20210180  crc a9ce8940 md5 be3b96948b523ba1f95ec7411cc9d569 sha1 cb5b47301c3ea8e0eca38a819b83770b3889fdd1 )
+)
+
 
 game (
 	name "Chex Quest"
@@ -45,6 +58,18 @@ game (
 	name "Delaweare"
 	description "Delaweare"
 	rom ( name DELAWEARE.WAD size 83219726 crc 787548eb md5 9691100ff85b0902be3851890ec5aca9 sha1 b1319702b200d95adf8da277fa237c7c0318a1b6 )
+)
+
+game (
+	name "Doom & Doom II (EXTRAS.WAD) (Unity)"
+	description "Doom & Doom II (EXTRAS.WAD) (Unity)"
+	rom ( name EXTRAS.WAD size 64779 crc 8068229f md5 0c7caf25ad1584721ff5ecc38dec97a0 sha1 55a6a95c99d7fe7b9501d34b0afecd3252a629e1 )
+)
+
+game (
+	name "Doom & Doom II (EXTRAS.WAD) (Unity) (Update - September 3)"
+	description "Doom & Doom II (EXTRAS.WAD) (Unity) (Update - September 3)"
+	rom ( name EXTRAS.WAD size 64587 crc 82bccddc 38e1bb6cdd1e4227eef13d22f6e35209 sha1 0f2a7139b640e19a08f384562f907cb0734b0512 )
 )
 
 game (
@@ -337,21 +362,21 @@ game (
 )
 
 game (
-	name "Freedoom - FreeDM (v0.11.3)"
-	description "Freedoom - FreeDM (0.11.3)"
-	rom ( name FREEDM.WAD size 21112116 crc ae55bb4d md5 87ee2494d921633420ce9bdb418127c4 sha1 7e979209685ff81f4d709e0926ba585a37d2e35a )
+	name "Freedoom - FreeDM (v0.12.1)"
+	description "Freedoom - FreeDM (0.12.1)"
+	rom ( name FREEDM.WAD size 21824448 crc bd680d11 md5 d40c932a9183ded919afa89f4a729668 sha1 61065a41a391cd2e4bff69488be36773754354ab )
 )
 
 game (
-	name "Freedoom - Phase 1 (v0.11.3)"
-	description "Freedoom - Phase 1 (0.11.3)"
-	rom ( name FREEDOOM1.WAD size 23578720 crc 81901f03 md5 ea471a3d38fcee0fb3a69bcd3221e335 sha1 36db0eb476486fa56c43f24d9b23e9d8afdbbff5 )
+	name "Freedoom - Phase 1 (v0.12.1)"
+	description "Freedoom - Phase 1 (0.12.1)"
+	rom ( name FREEDOOM1.WAD size 27284988 crc de6ddb27 md5 b36aa44a23045e503c19af4b4c438a78 sha1 e9bf428b73a04423ea7a0e9f4408f71df85ab175 )
 )
 
 game (
-	name "Freedoom - Phase 2 (v0.11.3)"
-	description "Freedoom - Phase 2 (v0.11.3)"
-	rom ( name FREEDOOM2.WAD size 29102220 crc cef01ecb md5 984f99af08f085e38070f51095ab7c31 sha1 0c03d1f754b98c53f292f66bc9505a29f47c6a9f )
+	name "Freedoom - Phase 2 (v0.12.1)"
+	description "Freedoom - Phase 2 (v0.12.1)"
+	rom ( name FREEDOOM2.WAD size 28544132 crc 212e1cf9 md5 ca9a4159a7833544a89144c7f5053412 sha1 51c997f430dc12abba7888c2d83c237a8e0758a7 )
 )
 
 game (


### PR DESCRIPTION
I'm not sure if the EXTRAS.WAD notation is correct, so please correct it appropriately.
I left Blasphemer v0.1.5 because it is an older version before adding BlasphDM.

Add wads:
EXTRAS.WAD (from Doom & Doom II Unity)
BlasphDM v0.1.7

Update wads:
Action Doom 2 - Urban Brawl
FreeDM v0.12.1
Freedoom v0.12.1
Blasphemer v0.1.7

Closes #1241