### PR TITLE
Gameboy : Rename gb_boot.bin to gb_bios.bin

### DIFF
--- a/dat/System.dat
+++ b/dat/System.dat
@@ -143,7 +143,7 @@ game (
 
 	comment "Nintendo - Gameboy"
 	rom ( name dmg_boot.bin size 256 crc 59c8598e md5 32fbbd84168d3482956eb3c5051637f5 sha1 4ed31ec6b0b175bb109c0eb5fd3d193da823339f )
-	rom ( name gb_boot.bin size 256 crc 59c8598e md5 32fbbd84168d3482956eb3c5051637f5 sha1 4ed31ec6b0b175bb109c0eb5fd3d193da823339f )
+	rom ( name gb_bios.bin size 256 crc 59c8598e md5 32fbbd84168d3482956eb3c5051637f5 sha1 4ed31ec6b0b175bb109c0eb5fd3d193da823339f )
 
 	comment "Nintendo - Game Boy Advance"
 	rom ( name gba_bios.bin size 16384 crc 81977335 md5 a860e8c0b6d573d191e4ec7db1b1e4f6 sha1 300c20df6731a33952ded8c436f7f186d25d3492 )


### PR DESCRIPTION
Since gambatte, mgba and vbam use it as gb_bios.bin, should we don't rename it to be in conformity?

Thanks