### PR TITLE
Initial "tooling" for DAT sorting

### DIFF
--- a/dat/HBMAME.dat
+++ b/dat/HBMAME.dat
@@ -2812,8 +2812,7 @@ game (
 	rom ( name decodemo.zip size 89178 crc a3a387d0 sha1 48ad6a75baa4774bea9c241f7f23403727b20ec5 )
 )
 game (
-	name "Deco Cassette System Multi)
-game (ROM based)"
+	name "Deco Cassette System Multigame (ROM based)"
 	releaseyear 2008
 	developer "bootleg (David Widel)"
 	rom ( name decomult.zip size 456801 crc fc5ccd07 sha1 35db3a89233ced5f0d490594e4e6349d259a9912 )

--- a/dat/RPG Maker.dat
+++ b/dat/RPG Maker.dat
@@ -6,6 +6,54 @@ clrmamepro (
 )
 
 game (
+	name ".flow"
+	description ".flow (ver.0.194)(English Patched)"
+	rom ( name RPG_RT.ini size 60192 crc 1204305322 md5 d89da02d37cc18fbe4224aeae13bfb76 sha1 df27d409e0b128dd6556e90677da67b016bcbbb9 )
+)
+
+game (
+	name "Dead Again"
+	description "Dead Again"
+	rom ( name RPG_RT.ini size 2019 crc 1429345850 md5 d0536abcfac9fe6588b8c81d1d7c7a93 sha1 3ec5c4aeb4a6d49aa8d7db01d7eb5f754adf683d )
+)
+
+game (
+	name "Dessert Nightmare"
+	description "Desert Nightmare (English Translation)"
+	rom ( name RPG_RT.ini size 2009 crc 4282449154 md5 130853a12cbe7fa33b8259c72b13fb36 sha1 9f04c16c591351bee98e2053565f5bdbffdd5845 )
+)
+
+game (
+	name "Embric of Wulfhammer's Castle"
+	description "Embric of Wulfhammer's Castle"
+	rom ( name RPG_RT.ini size 2889959490 crc 2889959490 md5 c7e1be4e3f5c55bf2030dae1939be88e sha1 b830be3e44eba9a4387b4df80cb8ec2ed632c136 )
+)
+
+game (
+	name "Ib"
+	description "Ib (version 1.07) (English Translated)"
+	rom ( name RPG_RT.ini size 2014 crc 2294698241 md5 194aea2082603f5c0845105f53ae2274 sha1sum 959dcca224fdb0e475dfaca3f84a131351e07b0d )
+)
+
+game (
+	name "Lavender"
+	description "Lavender v1.05"
+	rom ( name RPG_RT.ini size 2017 crc 3921066047 md5 7c53a2f67833f2f3c8e23c5d00ef0568 sha1 24759d6bee35fbd63e5a63d8104011c5d9816fc7 )
+)
+
+game (
+	name "Lisa the First"
+	description "Lisa the First"
+	rom ( name RPG_RT.ini size 111732 crc 2168173091 md5 f758a8c6fbee9e0b0f12be5d5db952d8 sha1 d532e9aaae929ea54f8ceb7a875824478ab27e6f )
+)
+
+game (
+	name "Momoka"
+	description "Momoka v1.1"
+	rom ( name RPG_RT.ini size 2020 crc 3125855566 md5 21c462e5f508bb138ffac8f11826a0b2 sha1 4f5295d472f3079e8baddd50ade9825a2b617138 )
+)
+
+game (
 	name "RPG Maker 2000 Test Suite"
 	description "RPG Maker 2000 Test Suite"
 	homepage "https://github.com/EasyRPG/TestGame"
@@ -20,45 +68,9 @@ game (
 )
 
 game (
-	name "Yume Nikki"
-	description "Yume Nikki (Steam)"
-	rom ( name RPG_RT.ini size 888 crc 57a92897 md5 c53e963adb158b2d86c35ce2083aa28a sha1 d12c4457d1d6c208e349557e510d1218c72ed5b2 )
-)
-
-game (
-	name "Yume 2kki"
-	description "Yume 2kki (v0.106)"
-	rom ( name RPG_RT.ini size 1576968 crc cffbe463 md5 d654f75e0b642401a4d6215a03d5998f sha1 4608c9fde1ac7fdff5a1bf342392bd05011c7713 )
-)
-
-game (
-	name "Lisa the First"
-	description "Lisa the First"
-	rom ( name RPG_RT.ini size 111732 crc 2168173091 md5 f758a8c6fbee9e0b0f12be5d5db952d8 sha1 d532e9aaae929ea54f8ceb7a875824478ab27e6f )
-)
-
-game (
-	name ".flow"
-	description ".flow (ver.0.194)(English Patched)"
-	rom ( name RPG_RT.ini size 60192 crc 1204305322 md5 d89da02d37cc18fbe4224aeae13bfb76 sha1 df27d409e0b128dd6556e90677da67b016bcbbb9 )
-)
-
-game (
-	name "Dessert Nightmare"
-	description "Desert Nightmare (English Translation)"
-	rom ( name RPG_RT.ini size 2009 crc 4282449154 md5 130853a12cbe7fa33b8259c72b13fb36 sha1 9f04c16c591351bee98e2053565f5bdbffdd5845 )
-)
-
-game (
 	name "Super Columbine Massacre RPG"
 	description "Super Columbine Massacre RPG"
 	rom ( name RPG_RT.ini size 2006 crc 1089491356 md5 e80bb3258bce89017f66ce78a255c4cd sha1 7e4f8e0770e6095ae8aa3f3578977c10ba2c95a9 )
-)
-
-game (
-	name "Embric of Wulfhammer's Castle"
-	description "Embric of Wulfhammer's Castle"
-	rom ( name RPG_RT.ini size 2889959490 crc 2889959490 md5 c7e1be4e3f5c55bf2030dae1939be88e sha1 b830be3e44eba9a4387b4df80cb8ec2ed632c136 )
 )
 
 game (
@@ -68,31 +80,19 @@ game (
 )
 
 game (
-	name "Ib"
-	description "Ib (version 1.07) (English Translated)"
-	rom ( name RPG_RT.ini size 2014 crc 2294698241 md5 194aea2082603f5c0845105f53ae2274 sha1sum 959dcca224fdb0e475dfaca3f84a131351e07b0d )
+	name "Yume 2kki"
+	description "Yume 2kki (v0.106)"
+	rom ( name RPG_RT.ini size 1576968 crc cffbe463 md5 d654f75e0b642401a4d6215a03d5998f sha1 4608c9fde1ac7fdff5a1bf342392bd05011c7713 )
+)
+
+game (
+	name "Yume Nikki"
+	description "Yume Nikki (Steam)"
+	rom ( name RPG_RT.ini size 888 crc 57a92897 md5 c53e963adb158b2d86c35ce2083aa28a sha1 d12c4457d1d6c208e349557e510d1218c72ed5b2 )
 )
 
 game (
 	name "Yume Nikki"
 	description "Yume Nikki (Uboachan Translation)"
 	rom ( name RPG_RT.ini size 2008 crc 3809916251 md5 d0a463fbd5fbe7d3746905dd5c45d529 sha1 22f65e5085f9031f0d7e6b5d177f6af7b1265fa4 )
-)
-
-game (
-	name "Dead Again"
-	description "Dead Again"
-	rom ( name RPG_RT.ini size 2019 crc 1429345850 md5 d0536abcfac9fe6588b8c81d1d7c7a93 sha1 3ec5c4aeb4a6d49aa8d7db01d7eb5f754adf683d )
-)
-
-game (
-	name "Momoka"
-	description "Momoka v1.1"
-	rom ( name RPG_RT.ini size 2020 crc 3125855566 md5 21c462e5f508bb138ffac8f11826a0b2 sha1 4f5295d472f3079e8baddd50ade9825a2b617138 )
-)
-
-game (
-	name "Lavender"
-	description "Lavender v1.05"
-	rom ( name RPG_RT.ini size 2017 crc 3921066047 md5 7c53a2f67833f2f3c8e23c5d00ef0568 sha1 24759d6bee35fbd63e5a63d8104011c5d9816fc7 )
 )

--- a/scripts/clrmamepro-sorter.py
+++ b/scripts/clrmamepro-sorter.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+# This implements a very stupid ClrMamePro DAT file sorter. It expects a DAT
+# file to be "well formed", so everything except the first level should be
+# indented, since that is used to lump lines together into one "entry".
+
+import re
+import sys
+
+from typing import List
+
+
+START_STANZA = re.compile(r'([a-z0-9]+)\s*\(', re.IGNORECASE)
+VALID_START = {'clrmamepro', 'game'}
+
+
+def sortdat(lines: str) -> str:
+    data: List[str] = []
+    curline: str = ''
+    for line in lines.split('\n'):
+        start = START_STANZA.match(line)
+        if start:
+            if start.group(1) not in VALID_START:
+                raise Exception("File doesn't look like a valid DAT file!")
+            if curline != '':
+                data.append(curline)
+            curline = line
+        else:
+            curline += '\n' + line
+    if curline != '':
+        data.append(curline)
+
+    return '\n'.join(sorted(data))
+
+
+if __name__ == '__main__':
+    for file in sys.argv[1:]:
+        print(f'Sorting {file}')
+        with open(file, 'r') as infile:
+            content = sortdat(infile.read())
+        with open(file, 'w') as outfile:
+            outfile.write(content)


### PR DESCRIPTION
While trying to add some more games to the RPG Maker DAT file, I wondered if it would be a good idea to sort libretro's custom DAT files (to make it easier to find duplicates & try to avoid merge conflicts if multiple pull requests to the same file are pending)

This initial PR is just to see if this is something other people find valuable and to show how the initial sorting commit would look. If this is seen as something useful, I could put some more time into creating a GitHub Action which would always enforce proper order for a subset (or all) DAT files. (If the script is considered "too crude", I could also put some more time into a proper ClrMamePro DAT style checker...)