### PR TITLE
Added Game Genie codes for Super Mario World.

### DIFF
--- a/cht/Nintendo - Super Nintendo Entertainment System/Super Mario World (USA) (Game Genie).cht
+++ b/cht/Nintendo - Super Nintendo Entertainment System/Super Mario World (USA) (Game Genie).cht
@@ -1,0 +1,601 @@
+cheats = 149
+
+cheat0_desc = "Mario On Ice"
+cheat0_code = "EDA5-0F6F+61A5-040F+61A6-0D6F"
+cheat0_enable = false
+
+cheat1_desc = "Waterworld Mario"
+cheat1_code = "EDA5-0F6F+69A5-040F+69A6-0D6F"
+cheat1_enable = false
+
+cheat2_desc = "Reverse Switch Palace Blocks"
+cheat2_code = "2D80-0DE1+ED8B-0D89"
+cheat2_enable = false
+
+cheat3_desc = "Yoshi is Invincible"
+cheat3_code = "89E4-AFD9+89C6-D4DB"
+cheat3_enable = false
+
+cheat4_desc = "Infinite Items Yoshi Picks Up"
+cheat4_code = "82E9-64A0+82E2-04D0"
+cheat4_enable = false
+
+cheat5_desc = "Infinite Flying Time For Yoshi"
+cheat5_code = "C2EC-0700"
+cheat5_enable = false
+
+cheat6_desc = "Collecting A Yoshi Coin Gives You Yoshi's Wings"
+cheat6_code = "B9E5-A4AD+F8E5-A7DD"
+cheat6_enable = false
+
+cheat7_desc = "Multi-Jump and Low Gravity"
+cheat7_code = "336B-D4D0"
+cheat7_enable = false
+
+cheat8_desc = "Shoot Fireballs Straight"
+cheat8_code = "DDEA-6F07+DDB2-AFD8"
+cheat8_enable = false
+
+cheat9_desc = "Power-up Select"
+cheat9_code = "EDA5-0F6F"
+cheat9_enable = false
+
+cheat10_desc = "Warp to Star World"
+cheat10_code = "EDB7-0FBD"
+cheat10_enable = false
+
+cheat11_desc = "Rapid-Fire Fireballs (Facing Right Only)"
+cheat11_code = "D5EB-6F07"
+cheat11_enable = false
+
+cheat12_desc = "Stomp 8 Enemies And Get 1-Ups"
+cheat12_code = "C23B-AF07"
+cheat12_enable = false
+
+cheat13_desc = "Nintendo Debug #2"
+cheat13_code = "DDA6-DF07"
+cheat13_enable = false
+
+cheat14_desc = "Item Doesn't Fall From Box When You Get Hit"
+cheat14_code = "6DEE-14DF+D4EE-140F"
+cheat14_enable = false
+
+cheat15_desc = "Start with 1 life instead of 5"
+cheat15_code = "DDB4-6F07"
+cheat15_enable = false
+
+cheat16_desc = "Start with 9 lives"
+cheat16_code = "D6B4-6F07"
+cheat16_enable = false
+
+cheat17_desc = "Start with 15 lives"
+cheat17_code = "D3B4-6F07"
+cheat17_enable = false
+
+cheat18_desc = "Start with 25 lives"
+cheat18_code = "F6B4-6F07"
+cheat18_enable = false
+
+cheat19_desc = "Start with 50 lives"
+cheat19_code = "7FB4-6F07"
+cheat19_enable = false
+
+cheat20_desc = "Start with 99 lives"
+cheat20_code = "14B4-6F07"
+cheat20_enable = false
+
+cheat21_desc = "Infinite lives"
+cheat21_code = "C222-D4DD"
+cheat21_enable = false
+
+cheat22_desc = "Extra life at 5 coins instead of 100"
+cheat22_code = "D964-A7D7+D967-AFA7"
+cheat22_enable = false
+
+cheat23_desc = "Extra life at 10 coins"
+cheat23_code = "DC64-A7D7+DC67-AFA7"
+cheat23_enable = false
+
+cheat24_desc = "Extra life at 20 coins"
+cheat24_code = "F064-A7D7+F067-AFA7"
+cheat24_enable = false
+
+cheat25_desc = "Extra life at 50 coins"
+cheat25_code = "7464-A7D7+7467-AFA7"
+cheat25_enable = false
+
+cheat26_desc = "Start and stay invincible most of the time"
+cheat26_code = "DD32-6DAD"
+cheat26_enable = false
+
+cheat27_desc = "Stay as Super Mario, Fire Mario or Cape Mario when you get hit"
+cheat27_code = "CBED-6DDF"
+cheat27_enable = false
+
+cheat28_desc = "Stay as Super Mario, Fire Mario or Cape Mario when you fall and die"
+cheat28_code = "CB28-DF6D"
+cheat28_enable = false
+
+cheat29_desc = "Low jump"
+cheat29_code = "D02C-AF6F"
+cheat29_enable = false
+
+cheat30_desc = "Super jump"
+cheat30_code = "D42C-AF6F"
+cheat30_enable = false
+
+cheat31_desc = "Mega-jump"
+cheat31_code = "DF2C-AF6F"
+cheat31_enable = false
+
+cheat32_desc = "Infinite time"
+cheat32_code = "C264-64D7"
+cheat32_enable = false
+
+cheat33_desc = "Extra life with every dragon coin instead of 5"
+cheat33_code = "D2E5-A7AD"
+cheat33_enable = false
+
+cheat34_desc = "Start as Super Mario"
+cheat34_code = "31B7-6F07"
+cheat34_enable = false
+
+cheat35_desc = "Start as Cape Mario"
+cheat35_code = "CBB7-6D67+D4B7-6DA7+3CB7-6FD7+69B7-6F07"
+cheat35_enable = false
+
+cheat36_desc = "Start as Fire Mario"
+cheat36_code = "CBB7-6D67+D7B7-6DA7+3CB7-6FD7+69B7-6F07"
+cheat36_enable = false
+
+cheat37_desc = "Little Yoshi grows into big Yoshi after eating just 1 enemy instead of 5"
+cheat37_code = "DFCE-64A0"
+cheat37_enable = false
+
+cheat38_desc = "Little Yoshi grows into big Yoshi after eating just 2 enemies"
+cheat38_code = "D4CE-64A0"
+cheat38_enable = false
+
+cheat39_desc = "Little Yoshi grows into big Yoshi after eating just 3 enemies"
+cheat39_code = "D7CE-64A0"
+cheat39_enable = false
+
+cheat40_desc = "Little Yoshi grows into big Yoshi after eating just 4 enemies"
+cheat40_code = "D0CE-64A0"
+cheat40_enable = false
+
+cheat41_desc = "Mutli-Jump Spin-Jumps, Hold For Slow Descent"
+cheat41_code = "F53F-6767+DD3F-67A7"
+cheat41_enable = false
+
+cheat42_desc = "Coins Rack Up All The Time"
+cheat42_code = "4064-ADD7"
+cheat42_enable = false
+
+cheat43_desc = "Get Yoshi Coin Must Of The Time"
+cheat43_code = "40ED-A4AD"
+cheat43_enable = false
+
+cheat44_desc = "Get Coins Must Of The Time"
+cheat44_code = "6DED-A7AD"
+cheat44_enable = false
+
+cheat45_desc = "Jump In Midair"
+cheat45_code = "6D2E-0FDF"
+cheat45_enable = false
+
+cheat46_desc = "Disable Swimming"
+cheat46_code = "1031-6DD4+6D30-67A4"
+cheat46_enable = false
+
+cheat47_desc = "Always Shoot Fireballs"
+cheat47_code = "4026-DDAD"
+cheat47_enable = false
+
+cheat48_desc = "Invincible Pits/Lava/Enemies"
+cheat48_code = "CBED-646F+6DED-64AF+69ED-67DF+52ED-670F+18ED-676F+CECF-0FA1"
+cheat48_enable = false
+
+cheat49_desc = "Walk Through Walls"
+cheat49_code = "1D3F-6D04+C23D-64D4+6D3F-0D67+1D37-6D64"
+cheat49_enable = false
+
+cheat50_desc = "Enemies Die When You Get Close To Them"
+cheat50_code = "40C7-DDD1+6DC7-DF01+40C7-D761+40C0-DF01"
+cheat50_enable = false
+
+cheat51_desc = "Fireballs Hit Anywhere"
+cheat51_code = "40C2-D7A6"
+cheat51_enable = false
+
+cheat52_desc = "Cape Hits Anywhere"
+cheat52_code = "40BE-AD66"
+cheat81_enable = false
+
+cheat53_desc = "Fireballs Turn Most Enemies Into Lives"
+cheat53_code = "56C4-0466"
+cheat53_enable = false
+
+cheat54_desc = "Fireballs Turn Most Enemies Into Starman"
+cheat54_code = "51C4-0466"
+cheat54_enable = false
+
+cheat55_desc = "Fireballs Turn Most Enemies Into Flowers"
+cheat55_code = "59C4-0466"
+cheat55_enable = false
+
+cheat56_desc = "Grab Key To Finish Level From Anywhere"
+cheat56_code = "DD3D-6460"
+cheat56_enable = false
+
+cheat57_desc = "Press L / R To Cycle Items In The Item Box"
+cheat57_code = "F6AE-07A7+A4AD-67D7+D2AD-6707+A4AD-67A7+D2AF-6DD7+D1AF-6D67+17AF-6FD7+CBAF-6F07+DFAF-6F67+62AF-6FA7+A4AF-64D7+D2AF-6407+1DAF-6467"
+cheat57_enable = false
+
+cheat58_desc = "Causes Mario To Jump And Float Until You Let Go Of Jump"
+cheat58_code = "DD2C-AF6F"
+cheat58_enable = false
+
+cheat59_desc = "Funky Mario"
+cheat59_code = "CBB7-6D67+DEB7-6DA7+3CB7-6FD7+69B7-6F07"
+cheat59_enable = false
+
+cheat60_desc = "Swim In Every Level!"
+cheat60_code = "CBEA-6DAD"
+cheat60_enable = false
+
+cheat61_desc = "Fake Fire Mario"
+cheat61_code = "7732-6DAD"
+cheat61_enable = false
+
+cheat62_desc = "Nighttime!"
+cheat62_code = "0DED-AFDF"
+cheat62_enable = false
+
+cheat63_desc = "Fake Invincibility"
+cheat63_code = "D032-6DAD"
+cheat63_enable = false
+
+cheat64_desc = "Jackhammer Jump"
+cheat64_code = "232C-AF6F"
+cheat64_enable = false
+
+cheat65_desc = "Spontaneously Change From Mario To Luigi"
+cheat65_code = "FD32-6DAD"
+cheat65_enable = false
+
+cheat66_desc = "If You Hold Down The B Button, You Float Around!"
+cheat66_code = "EE2C-AF6F"
+cheat66_enable = false
+
+cheat67_desc = "Little Yoshie Only Has To Eat 13 Enemies To Get Big"
+cheat67_code = "DECE-64A0"
+cheat67_enable = false
+
+cheat68_desc = "Little Yoshie Only Has To Eat 25 Enemies To Get Big"
+cheat68_code = "F8CE-64A0"
+cheat68_enable = false
+
+cheat69_desc = "Extra Life After Each Coin, Even Yoshi Coins"
+cheat69_code = "DD64-A7D7+DD67-AFA7"
+cheat69_enable = false
+
+cheat70_desc = "&quot;Gem&quot; Mario"
+cheat70_code = "0032-6DAD"
+cheat70_enable = false
+
+cheat71_desc = "If You Die, Restart At The Halfway Point"
+cheat71_code = "6267-AF97"
+cheat71_enable = false
+
+cheat72_desc = "As Soon As You Start A Level, You'll Automatically Exit Thru The 2nd Exit"
+cheat72_code = "62C3-64DF"
+cheat72_enable = false
+
+cheat73_desc = "Activates The Green Blocks In The Level"
+cheat73_code = "B286-07E9"
+cheat73_enable = false
+
+cheat74_desc = "Collect 1 Berry For Yoshi To Hatch A Mushroom"
+cheat74_code = "DFE3-D7A0"
+cheat74_enable = false
+
+cheat75_desc = "Collect 2 Berries For Yoshi To Hatch A Cloud"
+cheat75_code = "DBE3-DF00"
+cheat75_enable = false
+
+cheat76_desc = "Continue With A Yoshi If You Die While On One"
+cheat76_code = "62C2-DF0D"
+cheat76_enable = false
+
+cheat77_desc = "Start Most Stages With A Flying Yoshi (Must Have Yoshi Collect A Turtle Shell To Fly)"
+cheat77_code = "62C1-ADAB"
+cheat77_enable = false
+
+cheat78_desc = "4000 Points Kicking An Empty Turtle Shell"
+cheat78_code = "62C0-AFA1"
+cheat78_enable = false
+
+cheat79_desc = "Nintendo's Debug"
+cheat79_code = "DDC1-64DD+DDC5-6DAD"
+cheat79_enable = false
+
+cheat80_desc = "Enable Item Window's &quot;Goal Point&quot; (Quit)"
+cheat80_code = "7E0D-C2D7"
+cheat80_enable = false
+
+cheat81_desc = "Skip Worlds"
+cheat81_code = "EECD-AF6F"
+cheat81_enable = false
+
+cheat82_desc = "Black Mario"
+cheat82_code = "9E32-6DAD"
+cheat82_enable = false
+
+cheat83_desc = "No Enemies"
+cheat83_code = "3E32-6DAD"
+cheat83_enable = false
+
+cheat84_desc = "Low Gravity Float"
+cheat84_code = "4D2C-AF0F"
+cheat84_enable = false
+
+cheat85_desc = "Any Yoshi Always Has Wings And Flies Without A Shell"
+cheat85_code = "DDE0-07A0"
+cheat85_enable = false
+
+cheat86_desc = "Lakitu Throws Out An Amazing Flying Hammer Brother"
+cheat86_code = "B837-6D61+BA37-6F61"
+cheat86_enable = false
+
+cheat86_desc = "Mario Has A Halo On Map"
+cheat86_code = "31B4-6F07"
+cheat86_enable = false
+
+cheat87_desc = "Time Doesn't Countdown"
+cheat87_code = "6664-64D7"
+cheat87_enable = false
+
+cheat88_desc = "Time Never Runs Out"
+cheat88_code = "BB64-64D7"
+cheat88_enable = false
+
+cheat89_desc = "Super-Fast Clock"
+cheat89_code = "AA64-64D7"
+cheat89_enable = false
+
+cheat90_desc = "Start As Red Spasms Mario"
+cheat90_code = "69B7-6F07"
+cheat90_enable = false
+
+cheat91_desc = "Start Button Has No Effect"
+cheat91_code = "CBC4-6DAD"
+cheat91_enable = false
+
+cheat92_desc = "Start And Select Button Combo Makes The Game Pause Forever"
+cheat92_code = "CBC5-6DAD"
+cheat92_enable = false
+
+cheat93_desc = "Whenever You Land Hard On The Ground Via The Cape, You Die"
+cheat93_code = "CBCA-6DAD"
+cheat93_enable = false
+
+cheat94_desc = "At The Beginning of A Level You Go To The Yoshi Bonus Stage And  When You Fall The Level Is Beaten!"
+cheat94_code = "0BCD-AF6F"
+cheat94_enable = false
+
+cheat95_desc = "Can Repeatedly Hit Some Blocks, Some Coins Don't Disappear When Collected (Switch Off For Some Special Blocks To Work As Normal)"
+cheat95_code = "188A-6767"
+cheat95_enable = false
+
+cheat96_desc = "Die After Losing One Life"
+cheat96_code = "DE22-D4DD"
+cheat96_enable = false
+
+cheat97_desc = "Lose Every Life Except One When You Die"
+cheat97_code = "BB22-D4DD"
+cheat97_enable = false
+
+cheat98_desc = "Says Game Over After Every Life"
+cheat98_code = "C022-D4DD"
+cheat98_enable = false
+
+cheat99_desc = "Runs Super Fast Without Holding Down Run; Turn Around With Spin Jump"
+cheat99_code = "EE28-6F6F"
+cheat99_enable = false
+
+cheat100_desc = "Run Super Fast One Direction; Hard To Control"
+cheat100_code = "EE2D-AF6F"
+cheat100_enable = false
+
+cheat101_desc = "Bogus Jump"
+cheat101_code = "DE2C-AF6F"
+cheat101_enable = false
+
+cheat102_desc = "Fiying Ability"
+cheat102_code = "CF2C-AF6F"
+cheat102_enable = false
+
+cheat103_desc = "Skitz Jumps"
+cheat103_code = "842C-AF6F"
+cheat103_enable = false
+
+cheat104_desc = "Wierd Jump (Doesn't Work With A Cape)"
+cheat104_code = "3D2C-AF6F"
+cheat104_enable = false
+
+cheat105_desc = "Bunny/Moon Jumps"
+cheat105_code = "312C-AF6F"
+cheat105_enable = false
+
+cheat106_desc = "To-The-Moon Jump, Flying Helicopter Spin"
+cheat106_code = "EE2C-AF6F"
+cheat106_enable = false
+
+cheat107_desc = "You Can Climb And Fall Just Like The Original Except Much Faster"
+cheat107_code = "E82C-AF64"
+cheat107_enable = false
+
+cheat108_desc = "Low Gravity In Levels Over Water"
+cheat108_code = "D732-6DAD"
+cheat108_enable = false
+
+cheat109_desc = "Dragon Coins Change Little Mario Into Luigi"
+cheat109_code = "D332-6DAD"
+cheat109_enable = false
+
+cheat110_desc = "Black Mario"
+cheat110_code = "9D32-6DAD"
+cheat110_enable = false
+
+cheat111_desc = "After You Get A Powerup, Mario's Head Will Always Face Left, Even While Walking/Flying/Jumping Right!!"
+cheat111_code = "4832-ADAD"
+cheat111_enable = false
+
+cheat112_desc = "You Can Swim In Every Level"
+cheat112_code = "CBEA-6DAD"
+cheat112_enable = false
+
+cheat113_desc = "Super Stomp - Run Into Any Enemy From The Side When Small And You Will Be Propelled Upwards And Stomp Them!"
+cheat113_code = "CBEF-6F6F"
+cheat113_enable = false
+
+cheat114_desc = "Shrink/Die Instantly"
+cheat114_code = "CBEF-67AF"
+cheat114_enable = false
+
+cheat115_desc = "Shrink When Hit Ultra Fast"
+cheat115_code = "CBE4-6DDF"
+cheat115_enable = false
+
+cheat116_desc = "Regular Nighttime"
+cheat116_code = "0DED-AFDF"
+cheat116_enable = false
+
+cheat117_desc = "No Background"
+cheat117_code = "07ED-AFDF"
+cheat117_enable = false
+
+cheat118_desc = "Nighttime For Pros"
+cheat118_code = "00ED-AFDF"
+cheat118_enable = false
+
+cheat119_desc = "Screen Is Upside Down When You Play"
+cheat119_code = "9EED-AF6F"
+cheat119_enable = false
+
+cheat120_desc = "Sickening"
+cheat120_code = "40EC-AFDF"
+cheat120_enable = false
+
+cheat121_desc = "Start As A Red Faced Mario In Need of A Chiropractor"
+cheat121_code = "CBB7-6D67+D0B7-6DA7+3CB7-6FD7+69B7-6F07"
+cheat121_enable = false
+
+cheat122_desc = "Start As Sub-Zero Mario - Grab A Mushroom To Become Invincible"
+cheat122_code = "CBB7-6D67+DBB7-6DA7+3CB7-6FD7+69B7-6F07"
+cheat122_enable = false
+
+cheat123_desc = "Start As Nodding Mario - Grab A Mushroom To Get 1-Up"
+cheat123_code = "CBB7-6D67+FDB7-6DA7+3CB7-6FD7+69B7-6F07"
+cheat123_enable = false
+
+cheat124_desc = "Start As Mario - Grab A Mushroom And It Turns Into A Pirahna Plant"
+cheat124_code = "CBB7-6D67+47B7-6DA7+3CB7-6FD7+69B7-6F07"
+cheat124_enable = false
+
+cheat125_desc = "Start As Hovercraft Mario, Get Any Item To Become Invincible"
+cheat125_code = "CBB7-6D67+59B7-6DA7+3CB7-6FD7+69B7-6F07"
+cheat125_enable = false
+
+cheat126_desc = "Start As Hovercraft Mario, Get Any Item To Put A Shelless Turtle In Reserve"
+cheat126_code = "CBB7-6D67+55B7-6DA7+3CB7-6FD7+69B7-6F07"
+cheat126_enable = false
+
+cheat127_desc = "Start As Hovercraft Mario, Get A Mushroom To Turn It Into A Pirahna Plant And Get A Giant Bullet Blob In Reserve"
+cheat127_code = "CBB7-6D67+5BB7-6DA7+3CB7-6FD7+69B7-6F07"
+cheat127_enable = false
+
+cheat128_desc = "Start As Hovercraft Mario, Get A Mushroom To Put A Flying Key In Reserve"
+cheat128_code = "CBB7-6D67+6DB7-6DA7+3CB7-6FD7+69B7-6F07"
+cheat128_enable = false
+
+cheat129_desc = "Start As Hovercraft Mario, Or A Mushroom To Turn Invincible And Get A Football Koopa In Reserve"
+cheat129_code = "CBB7-6D67+3CB7-6FD7+69B7-6F07"
+cheat129_enable = false
+
+cheat130_desc = "Start As Hovercraft Mario, Get A Fire Flower To Put A Magic Squished Dinosaur In Reserve Which Will Let You Clear The Round Instantly If Collected"
+cheat130_code = "CBB7-6D67+67B7-6DA7+3CB7-6FD7+69B7-6F07"
+cheat130_enable = false
+
+cheat131_desc = "Start As Sub-Zero Mario, Get A Fire Flower Or Mushroom To Put A 1-Up Mushroom In Reserve, Use That Or Any Other 1-Up Mushroom To Put A Yoshi In Reserve"
+cheat131_code = "CBB7-6D67+66B7-6DA7+3CB7-6FD7+69B7-6F07"
+cheat131_enable = false
+
+cheat132_desc = "Start As Mario With A Strange Walk, Get A Mushroom For Yoshi's Thank-You Message"
+cheat132_code = "CBB7-6D67+6BB7-6DA7+3CB7-6FD7+69B7-6F07"
+cheat132_enable = false
+
+cheat133_desc = "Mario Drives Without Benefit of A Car"
+cheat133_code = "CBB7-6D67+C9B7-6DA7+3CB7-6FD7+69B7-6F07"
+cheat133_enable = false
+
+cheat134_desc = "Start As Mario With An Extremely Strange Walk, Get A Fire Flower To Put A Glitched Ghost In Reserve"
+cheat134_code = "CBB7-6D67+2DB7-6DA7+3CB7-6FD7+69B7-6F07"
+cheat134_enable = false
+
+cheat135_desc = "Skip Story Intro"
+cheat135_code = "6DCB-D40D"
+cheat135_enable = false
+
+cheat136_desc = "Show Save Prompt After Beating Any Level"
+cheat136_code = "DD34-6D2F+B066-0D2F"
+cheat136_enable = false
+
+cheat137_desc = "Mario is Always Running"
+cheat137_code = "DD9F-A4DF"
+cheat137_enable = false
+
+cheat138_desc = "Jump in Midair"
+cheat138_code = "6D2E-0FDF"
+cheat138_enable = false
+
+cheat139_desc = "Disable Swimming"
+cheat139_code = "1031-6DD4+6D30-67A4"
+cheat139_enable = false
+
+cheat140_desc = "Always Guess Correct At 1up Minigame"
+cheat140_code = "6DE7-6FDD"
+cheat140_enable = false
+
+cheat141_desc = "Fireballs Pierce Through Enemies"
+cheat141_code = "C2C3-D466"
+cheat141_enable = false
+
+cheat142_desc = "Easy Pipes"
+cheat142_code = "DFC7-6451+7DC7-6481"
+cheat142_enable = false
+
+cheat143_desc = "Play As Luigi"
+cheat143_code = "CE3F-A4DD+CE6A-A407+8FB2-040D"
+cheat143_enable = false
+
+cheat144_desc = "One Hit Kills Chargin' Chucks"
+cheat144_code = "DDCD-0F06"
+cheat144_enable = false
+
+cheat145_desc = "Enable Special Stage Mode"
+cheat145_code = "38BF-6467+F3BF-64A7+CDC5-6DA4+CDC6-0F0C"
+cheat145_enable = false
+
+cheat146_desc = "Disable Special Stage Mode "
+cheat146_code = "38BF-6ED7+F3BF-6E07+DDBF-6367"
+cheat146_enable = false
+
+cheat147_desc = "Invincibility (mostly)"
+cheat147_code = "6DE8-040F"
+cheat147_enable = false
+
+cheat148_desc = "Disable X and Y Buttons Running"
+cheat148_code = "6D2F-AFAF"
+cheat148_enable = false


### PR DESCRIPTION
This is just the codes from Super Mario World (USA).cht with the non-Game Genie codes removed and the cheat numbers renumbered.
It's mainly for Superfaust, which will crash if you give it non-Game Genie cheat codes.