### PR TITLE
Add GBA Iridion II (USA) (Code Breaker).cht

### DIFF
--- a/cht/Nintendo - Game Boy Advance/Iridion II (USA) (Code Breaker).cht
+++ b/cht/Nintendo - Game Boy Advance/Iridion II (USA) (Code Breaker).cht
@@ -1,0 +1,29 @@
+cheats = 7 
+
+cheat0_desc = "Enable Code (Must Be On)"
+cheat0_code = "00009C63+000A+100213A8+0007"
+cheat0_enable = false 
+
+cheat1_desc = "Infinite Lives"
+cheat1_code = "33000A01+0009"
+cheat1_enable = false 
+
+cheat2_desc = "Infinite Health"
+cheat2_code = "330041A0+00FF"
+cheat2_enable = false 
+
+cheat3_desc = "Infinite Smart Bombs"
+cheat3_code = "33000A0E+0003"
+cheat3_enable = false 
+
+cheat4_desc = "Transparent"
+cheat4_code = "73004186+0300+330041C9+0000"
+cheat4_enable = false 
+
+cheat5_desc = "Weapon Charged"
+cheat5_code = "33001427+0020"
+cheat5_enable = false 
+
+cheat6_desc = "Upgrades Have All"
+cheat6_code = "33000A03+0002+83000A04+0202+83000A06+0202+33000A08+0002"
+cheat6_enable = false 


### PR DESCRIPTION
Code Breaker Codes for Iridion II on Nintendo Game Boy Advance (GBA).  