### PR TITLE
Add Sakura Taisen Translation v2.1

### DIFF
--- a/metadat/hacks/Sega - Saturn.dat
+++ b/metadat/hacks/Sega - Saturn.dat
@@ -56,3 +56,19 @@ game (
     comment "No reputable source"
     comment "Beetle Saturn requires a cue file to read MODE1/2048 iso/bin files"
 )
+game (
+    name "Sakura Taisen (Japan) (Disc 1) [T-En by NoahSteam v2.1]"
+    description "Sakura Taisen (Disc 1) English translation by NoahSteam version (1.0)"
+    rom ( name "Sakura Taisen (Japan) (Disc 1) (Track 1) [T-En by NoahSteam v2.1].bin" size 554635264 crc 11d8c8b1 md5 3783d3cba691417c8b6a50fb7bd5aac7 sha1 d18842900b3ba4ce4bed3b0e67c881811aac7645 )
+    patch "https://www.romhacking.net/translations/5318/"
+    comment "No reputable source"
+    comment "Beetle Saturn requires a cue file to read MODE1/2048 iso/bin files"
+)
+game (
+    name "Sakura Taisen (Japan) (Disc 2) [T-En by NoahSteam v2.1]"
+    description "Sakura Taisen (Disc 2) English translation by NoahSteam version (1.0)"
+    rom ( name "Sakura Taisen (Japan) (Disc 2) (Track 1) [T-En by NoahSteam v2.1].bin" size 538929152 crc 73a4542d md5 7a116d8350ea257c2217fafc12b0bb37 sha1 557e4564a2d48d7323e97e614c9b3cfbbb21b65d )
+    patch "https://www.romhacking.net/translations/5318/"
+    comment "No reputable source"
+    comment "Beetle Saturn requires a cue file to read MODE1/2048 iso/bin files"
+)


### PR DESCRIPTION
It would be awesome if the most recent translation of Sakura Taisen is recognized by retroarch.

Patched from redump.org Sakura Taisen (6M):
69b12554031b7e3b22ae37aaf03d3c3d *Sakura Taisen (Japan) (Disc 1) (6M) (Track 1).bin 13a0fdbce9f763e42bf981ceb4cebbf9 *Sakura Taisen (Japan) (Disc 1) (6M) (Track 2).bin b215bcec8d128f6cf68034d92aef7933 *Sakura Taisen (Japan) (Disc 1) (6M).cue

2c68b0b4444dbcc53a29ccea484b63f1 *Sakura Taisen (Japan) (Disc 2) (6M) (Track 1).bin d3379df2aba7ea8e0757032667222e8c *Sakura Taisen (Japan) (Disc 2) (6M) (Track 2).bin 5e5ea2f21a8a2254a6b6dc763ab7df31 *Sakura Taisen (Japan) (Disc 2) (6M).cue

Patch source:
https://www.romhacking.net/translations/5318/