### PR TITLE
Add Sega Genesis cheat for NHL '95 season 1st place bug

### DIFF
--- a/cht/Sega - Mega Drive - Genesis/NHL 95 (USA, Europe).cht
+++ b/cht/Sega - Mega Drive - Genesis/NHL 95 (USA, Europe).cht
@@ -1,4 +1,4 @@
-cheats = 5
+cheats = 6
 
 cheat0_desc = "Infinite Time (Minutes)"
 cheat0_code = "FFC022:0009"
@@ -19,3 +19,7 @@ cheat3_enable = false
 cheat4_desc = "Master Code"
 cheat4_code = "RZ3B-Y60R"
 cheat4_enable = false
+
+cheat5_desc = "Season 1st place bug"
+cheat5_code = "ADLT-WE7L+ADLT-WL7R+AANA-WE4E+AANA-WL4J"
+cheat5_enable = false


### PR DESCRIPTION
This is a pretty infamous bug where if you win over 63 regular season games, your point score overflows (8bit signed) and you move to last place, missing the playoffs. The bug has finally been fixed using 4 different cheat codes to fix the bug. I have tested this and it works!

More details can be found here:

https://forum.nhl94.com/index.php?/topic/26073-nhl95-bug-fix-make-the-playoffs-with-128-points/

Thank you!