### PR TITLE
Add quotes around file name and missing size key

### DIFF
--- a/dat/Sony - PlayStation Minis.dat
+++ b/dat/Sony - PlayStation Minis.dat
@@ -10,5 +10,5 @@ game (
 	description "Zenonia"
 	region "USA"
 	genre "Action RPG"
-	rom ( name Zenonia (USA).cso crc 66124887 22049497 md5 c25c40111275be7e822de504e3077d4f )
+	rom ( name "Zenonia (USA).cso" crc 66124887 size 22049497 md5 c25c40111275be7e822de504e3077d4f )
 )


### PR DESCRIPTION
The file name seemed to be lacking quotes and the key for file size was missing.