### PR TITLE
Add missing Pokemon Mystery Dungeon - Red Rescue Team (USA, Australia) release date and game serial

### DIFF
--- a/metadat/releasemonth/Nintendo - Game Boy Advance.dat
+++ b/metadat/releasemonth/Nintendo - Game Boy Advance.dat
@@ -8356,6 +8356,12 @@ game (
 )
 
 game (
+	comment "Pokemon Mystery Dungeon - Red Rescue Team (USA, Australia)"
+	releasemonth "9"
+	rom ( crc DD0AC86C )
+)
+
+game (
 	comment "Pokemon Mystery Dungeon - Red Rescue Team (USA) (Demo) (Kiosk)"
 	releasemonth "9"
 	rom ( crc F12F908E )

--- a/metadat/releaseyear/Nintendo - Game Boy Advance.dat
+++ b/metadat/releaseyear/Nintendo - Game Boy Advance.dat
@@ -8506,6 +8506,12 @@ game (
 )
 
 game (
+	comment "Pokemon Mystery Dungeon - Red Rescue Team (USA, Australia)"
+	releaseyear "2006"
+	rom ( crc DD0AC86C )
+)
+
+game (
 	comment "Pokemon Mystery Dungeon - Red Rescue Team (USA) (Demo) (Kiosk)"
 	releaseyear "2006"
 	rom ( crc F12F908E )

--- a/metadat/serial/Nintendo - Game Boy Advance.dat
+++ b/metadat/serial/Nintendo - Game Boy Advance.dat
@@ -13612,6 +13612,14 @@ game (
 )
 
 game (
+	comment "Pokemon Mystery Dungeon - Red Rescue Team (USA, Australia)"
+	serial "AGB-B24E-USA"
+	rom (
+		crc DD0AC86C
+	)
+)
+
+game (
 	comment "Pokemon Pinball - Ruby & Sapphire (Europe) (En,Fr,De,Es,It)"
 	serial "AGB-BPPP-EUR"
 	rom (


### PR DESCRIPTION
data for  Pokemon Mystery Dungeon - Red Rescue Team (USA, Australia)   in the releaseyear, releasemonth and serial datasets where missing

data was obtained from https://gamefaqs.gamespot.com/gba/929408-pokemon-mystery-dungeon-red-rescue-team/data