### PR TITLE
Fix checksum for 'Doraemon 4 - Nobita to Tsuki no Oukoku'

### DIFF
--- a/metadat/developer/Nintendo - Super Nintendo Entertainment System.dat
+++ b/metadat/developer/Nintendo - Super Nintendo Entertainment System.dat
@@ -3894,7 +3894,7 @@ game (
 game (
 	comment "Doraemon 4 - Nobita to Tsuki no Oukoku (Japan)"
 	developer "Epoch"
-	rom ( crc 4097BC01 )
+	rom ( crc 5B6C63C8 )
 )
 
 game (

--- a/metadat/franchise/Nintendo - Super Nintendo Entertainment System.dat
+++ b/metadat/franchise/Nintendo - Super Nintendo Entertainment System.dat
@@ -1368,7 +1368,7 @@ game (
 game (
 	comment "Doraemon 4 - Nobita to Tsuki no Oukoku (Japan)"
 	franchise "Doraemon"
-	rom ( crc 4097BC01 )
+	rom ( crc 5B6C63C8 )
 )
 
 game (

--- a/metadat/genre/Nintendo - Super Nintendo Entertainment System.dat
+++ b/metadat/genre/Nintendo - Super Nintendo Entertainment System.dat
@@ -3888,7 +3888,7 @@ game (
 game (
 	comment "Doraemon 4 - Nobita to Tsuki no Oukoku (Japan)"
 	genre "Platform"
-	rom ( crc 4097BC01 )
+	rom ( crc 5B6C63C8 )
 )
 
 game (

--- a/metadat/maxusers/Nintendo - Super Nintendo Entertainment System.dat
+++ b/metadat/maxusers/Nintendo - Super Nintendo Entertainment System.dat
@@ -3864,7 +3864,7 @@ game (
 game (
 	comment "Doraemon 4 - Nobita to Tsuki no Oukoku (Japan)"
 	users 2
-	rom ( crc 4097BC01 )
+	rom ( crc 5B6C63C8 )
 )
 
 game (

--- a/metadat/no-intro/Nintendo - Super Nintendo Entertainment System.dat
+++ b/metadat/no-intro/Nintendo - Super Nintendo Entertainment System.dat
@@ -4465,7 +4465,7 @@ game (
 	name "Doraemon 4 - Nobita to Tsuki no Oukoku (Japan)"
 	description "Doraemon 4 - Nobita to Tsuki no Oukoku (Japan)"
 	region "Japan"
-	rom ( name "Doraemon 4 - Nobita to Tsuki no Oukoku (Japan).sfc" size 1572864 crc 4097BC01 md5 930CB24C28F2851F8C3A99A588B9FE8B sha1 E9C04238C10240A2C9F8DBD7CF1E3021F01C9C6D )
+	rom ( name "Doraemon 4 - Nobita to Tsuki no Oukoku (Japan).sfc" size 2097152 crc 5B6C63C8 md5 37ED37646C9F206097450A311E1094EA sha1 613D396A49892B9F81FB5A8C395578FA443B3D84 )
 )
 
 game (

--- a/metadat/publisher/Nintendo - Super Nintendo Entertainment System.dat
+++ b/metadat/publisher/Nintendo - Super Nintendo Entertainment System.dat
@@ -3876,7 +3876,7 @@ game (
 game (
 	comment "Doraemon 4 - Nobita to Tsuki no Oukoku (Japan)"
 	publisher "Epoch"
-	rom ( crc 4097BC01 )
+	rom ( crc 5B6C63C8 )
 )
 
 game (

--- a/metadat/releasemonth/Nintendo - Super Nintendo Entertainment System.dat
+++ b/metadat/releasemonth/Nintendo - Super Nintendo Entertainment System.dat
@@ -3240,7 +3240,7 @@ game (
 game (
 	comment "Doraemon 4 - Nobita to Tsuki no Oukoku (Japan)"
 	releasemonth "12"
-	rom ( crc 4097BC01 )
+	rom ( crc 5B6C63C8 )
 )
 
 game (

--- a/metadat/releaseyear/Nintendo - Super Nintendo Entertainment System.dat
+++ b/metadat/releaseyear/Nintendo - Super Nintendo Entertainment System.dat
@@ -3444,7 +3444,7 @@ game (
 game (
 	comment "Doraemon 4 - Nobita to Tsuki no Oukoku (Japan)"
 	releaseyear "1995"
-	rom ( crc 4097BC01 )
+	rom ( crc 5B6C63C8 )
 )
 
 game (

--- a/metadat/serial/Nintendo - Super Nintendo Entertainment System.dat
+++ b/metadat/serial/Nintendo - Super Nintendo Entertainment System.dat
@@ -4047,7 +4047,7 @@ game (
 	comment "Doraemon 4 - Nobita to Tsuki no Oukoku (Japan)"
 	serial "SHVC-AD4J-JPN"
 	rom (
-		crc 4097BC01
+		crc 5B6C63C8
 	)
 )
 


### PR DESCRIPTION
Fixing the checksums of rom "Doraemon 4 - Nobita to Tsuki no Oukoku (J) [!].sfc".
This info can be checked with the GoodSNES V3.27 (last version).

The file has the hash:
- CRC32: 5b6c63c8
- MD5: 37ed37646c9f206097450a311e1094ea
- SHA1: 613d396a49892b9f81fb5a8c395578fa443b3d84
- SHA-256: bd3d3e46a8ac35a5e7291935f58a74017d0ba406cca7cbedf99efb40d1248372


PS: The hash in libretro refers to the old BadDump1 of this ROM.