### PR TITLE
Update Amstrad - CPC database

### DIFF
--- a/dat/Amstrad - CPC.dat
+++ b/dat/Amstrad - CPC.dat
@@ -1,7 +1,7 @@
 clrmamepro (
 	name "Amstrad CPC"
 	description "Amstrad CPC - clean-cpc-db"
-	version "v1.0a - 2022.6.7"
+	version "v1.1 - 2022.6.22"
 	homepage "https://github.com/clean-cpc-db/dat"
 )
 game (
@@ -30,11 +30,6 @@ game (
 	rom ( name "2 Player Soccer Squad (1986)(Cult Games)[cr].dsk" size 194816 crc 16B25D5F md5 CB75947096FAFC711C03D97A74A5C08C sha1 47BDFD26AAD9F7B4707F8684941CFC5EFCD712F8 )
 )
 game (
-	name "3D Starfighter (Codemasters)"
-	description "3D Starfighter (Codemasters)"
-	rom ( name "3D Starfighter (1988)(Codemasters)[cr].dsk" size 204544 crc 53E36BF4 md5 605B939BBE2695446481F36BE7EEBCF6 sha1 787470DFE2A2C875970C49B2B3DB38D66B26807C )
-)
-game (
 	name "4 Soccer Simulators (Codemasters Gold)"
 	description "4 Soccer Simulators (Codemasters Gold)"
 	rom ( name "4 Soccer Simulators (1989)(Codemasters Gold).dsk" size 205491 crc F4BB9C85 md5 0F570C99586D0F16151ED6631564B200 sha1 318DB15EDC97968FB51459D526BCFD7B90925EAB )
@@ -43,6 +38,11 @@ game (
 	name "180 (Mastertronic)"
 	description "180 (Mastertronic)"
 	rom ( name "180 (1986)(Mastertronic)[cr].dsk" size 194816 crc 90B13E33 md5 D9DFAAA8E296EEE891ABB20A49F9CAA3 sha1 375BB823B87AF66FA4ECCA4DB19F4E621847678E )
+)
+game (
+	name "750cc Grand Prix (Codemasters Software)"
+	description "750cc Grand Prix (Codemasters Software)"
+	rom ( name "750cc Grand Prix (1989)(Codemasters Software)[cr].dsk" size 204544 crc 84EFCC59 md5 0786678208AD7A88E6A7E8065AAEEBBA sha1 57E25911A11A6B815DB3FD4DBC938360F9E937D0 )
 )
 game (
 	name "7 Card Stud (Martech Games)"
@@ -182,9 +182,9 @@ game (
 	rom ( name "3D Boxing (1985)(Amsoft).dsk" size 195635 crc F23F30D4 md5 70F4D0FA4D2F52F5253CE401D3395DA2 sha1 7E24EC2BBF6683885F1E583D8601FB8D84DB4C72 )
 )
 game (
-	name "750cc Grand Prix (Codemasters)"
-	description "750cc Grand Prix (Codemasters)"
-	rom ( name "750cc Grand Prix (1989)(Codemasters)[cr].dsk" size 204544 crc 84EFCC59 md5 0786678208AD7A88E6A7E8065AAEEBBA sha1 57E25911A11A6B815DB3FD4DBC938360F9E937D0 )
+	name "3D Starfighter (Codemasters Software)"
+	description "3D Starfighter (Codemasters Software)"
+	rom ( name "3D Starfighter (1988)(Codemasters Software)[cr].dsk" size 204544 crc 53E36BF4 md5 605B939BBE2695446481F36BE7EEBCF6 sha1 787470DFE2A2C875970C49B2B3DB38D66B26807C )
 )
 game (
 	name "3D Voicechess (CP Software)"
@@ -621,6 +621,11 @@ game (
 	rom ( name "Atlantis (1988)(Cobra Soft)(fr).dsk" size 200003 crc D82C9F67 md5 C929CBE5B1A9CEB6C5D80A6B36217F4A sha1 65C28C2B7B4B2F71A872DDD8684A5E8798F53B03 )
 )
 game (
+	name "ATV Simulator (Codemasters Software)"
+	description "ATV Simulator (Codemasters Software)"
+	rom ( name "ATV Simulator (1988)(Codemasters Software)[cr].dsk" size 204544 crc F56C5741 md5 76CC7B3AB1704086C9AE927A27FEB8F3 sha1 493B87954D74932062D970A105575D4202D3F96E )
+)
+game (
 	name "APB - All Point Bulletin (Domark)"
 	description "APB - All Point Bulletin (Domark)"
 	rom ( name "APB - All Point Bulletin (1989)(Domark).dsk" size 193345 crc FA44813B md5 D62B51CB245B292B01E39239434F823A sha1 361883A26F49A9593476435D3A45481D0D232FFD )
@@ -687,11 +692,6 @@ game (
 	name "Aladdin's Cave (Artic Computing)"
 	description "Aladdin's Cave (Artic Computing)"
 	rom ( name "Aladdin's Cave (1985)(Artic Computing)[cr].dsk" size 194816 crc C989A491 md5 7DEA6CDE980E4E1B8BA70E19540BE106 sha1 39B4D7076B7666C36F51FD5CB585E07C26D98017 )
-)
-game (
-	name "ATV Simulator (Codemasters)"
-	description "ATV Simulator (Codemasters)"
-	rom ( name "ATV Simulator (1988)(Codemasters)[cr].dsk" size 204544 crc F56C5741 md5 76CC7B3AB1704086C9AE927A27FEB8F3 sha1 493B87954D74932062D970A105575D4202D3F96E )
 )
 game (
 	name "Astro Attack (Amsoft)"
@@ -1260,11 +1260,6 @@ game (
 	rom ( name "Billy The Kid (1990)(Mastertronic)[cr].dsk" size 204544 crc F0AB7AEC md5 5AFB82183810450EC5B36AAF8AD1BB23 sha1 33F7BCE9BCCE1DF99E9FDF504F63876E50406430 )
 )
 game (
-	name "Bigfoot (Codemasters)"
-	description "Bigfoot (Codemasters)"
-	rom ( name "Bigfoot (1988)(Codemasters).dsk" size 74240 crc 371E44F9 md5 6A042F397A54414003990DE5EC5F7A6D sha1 12D7CD84D8211C141D14B0C65A694A60A639401E )
-)
-game (
 	name "Buster Block (Kuma Computers)"
 	description "Buster Block (Kuma Computers)"
 	rom ( name "Buster Block (1986)(Kuma Computers)[cr].dsk" size 194816 crc 96D31131 md5 1EADB546176C8EC744DAF290CA932121 sha1 2DA01E9760465D73E66A2F54D611F0F796E05312 )
@@ -1424,6 +1419,11 @@ game (
 	rom ( name "Base, The (1985)(The Adventure Workshop).dsk" size 194816 crc 845FE56D md5 31A914179EEE1B03927BB7F3E830C75D sha1 34B95C2E2647180C924DB47B7D0F23DC86BFB930 )
 )
 game (
+	name "BMX Freestyle (Codemasters Software)"
+	description "BMX Freestyle (Codemasters Software)"
+	rom ( name "BMX Freestyle (1989)(Codemasters Software)[cr].dsk" size 204544 crc FFC7E373 md5 1C04E24BD46CDCEF546F6C0B88208F8E sha1 9BFFAE1623CBF513DDDCE3BA1DB9F9CDAAEA05A9 )
+)
+game (
 	name "Bobsleigh (Digital Integration)"
 	description "Bobsleigh (Digital Integration)"
 	rom ( name "Bobsleigh (1987)(Digital Integration)[cr].dsk" size 194816 crc AC0510D0 md5 7C206A1D9B4DFD6AE08EF21E64EEE3FB sha1 BF3C1588859B432FAA4876444B2AF7662788FFF0 )
@@ -1490,7 +1490,7 @@ game (
 game (
 	name "Ballyhoo (Infocom)"
 	description "Ballyhoo (Infocom)"
-	rom ( name "Ballyhoo (1986)(Infocom)(Side A).dsk" size 195635 crc 925BF86B md5 D77F29E1C8804891692BFD7FD3E159D4 sha1 9FB2DB3B889D6589F9131D3413C0BEA613246EBE )
+	rom ( name "Ballyhoo (1986)(Infocom)(Side A)[CPM].dsk" size 195635 crc 925BF86B md5 D77F29E1C8804891692BFD7FD3E159D4 sha1 9FB2DB3B889D6589F9131D3413C0BEA613246EBE )
 	rom ( name "Ballyhoo (1986)(Infocom)(Side B).dsk" size 195635 crc A6DC3157 md5 CF4387E59937469039852F3B57C9EBCC sha1 FCD7291A7FA6E7704C149A490AEA2E57BE7C7458 )
 )
 game (
@@ -1512,6 +1512,11 @@ game (
 	name "Barbarian Part III (Des Soft) (France) (Hack)"
 	description "Barbarian Part III (Des Soft) (France) (Hack)"
 	rom ( name "Barbarian Part III (1988)(Des Soft)(fr)(Hack)[cr].dsk" size 204544 crc B0A4F51F md5 EF259AA4B91731D6D1A0C3ADDC4F3FAF sha1 65F9CDDBA20A02029222743347433CB282BB239D )
+)
+game (
+	name "Bigfoot (Codemasters Software)"
+	description "Bigfoot (Codemasters Software)"
+	rom ( name "Bigfoot (1988)(Codemasters Software).dsk" size 74240 crc 371E44F9 md5 6A042F397A54414003990DE5EC5F7A6D sha1 12D7CD84D8211C141D14B0C65A694A60A639401E )
 )
 game (
 	name "Bobo (Inforgrames) (France)"
@@ -1596,11 +1601,6 @@ game (
 	rom ( name "Barbarian Part II (1988)(Georgessoft)(Hack)(v2)[cr].dsk" size 194816 crc 1E366BB6 md5 5070E05C269DE95C1052D804342913B1 sha1 1E0A37332FD16CE3F521FD804D26CD7D262D2EC7 )
 )
 game (
-	name "BMX Simulator (Codemasters)"
-	description "BMX Simulator (Codemasters)"
-	rom ( name "BMX Simulator (1987)(Codemasters)[cr].dsk" size 204544 crc 6CF1612C md5 40636E4F1EC37255EB0F2CADE6DB865F sha1 DBAE45DE0BDE2919A5E7BC507DA44C6BE820F798 )
-)
-game (
 	name "Blazing Thunder (Hi-Tec Software)"
 	description "Blazing Thunder (Hi-Tec Software)"
 	rom ( name "Blazing Thunder (1990)(Hi-Tec Software)[cr][f].dsk" size 204544 crc 204B87BA md5 40387DE37A61D8620D0E0D251F316AFB sha1 7979F5E0AB9669ABDA42FF7BBF77349352B61A2F )
@@ -1663,7 +1663,7 @@ game (
 game (
 	name "Blueberry (Coktel Vision) (Spain)"
 	description "Blueberry (Coktel Vision) (Spain)"
-	rom ( name "Blueberry (1987)(Coktel Vision)(es)(Side A).dsk" size 205659 crc D81CD9FB md5 E909C30183DB7EB74B2ACD777F74E986 sha1 FA567BE97907E06073D922769EF06DF0B1B56DB2 )
+	rom ( name "Blueberry (1987)(Coktel Vision)(es)(Side A)[CPM].dsk" size 205659 crc D81CD9FB md5 E909C30183DB7EB74B2ACD777F74E986 sha1 FA567BE97907E06073D922769EF06DF0B1B56DB2 )
 	rom ( name "Blueberry (1987)(Coktel Vision)(es)(Side B).dsk" size 205659 crc F5DD8263 md5 2F181194D00470FCFA545C398E1261F6 sha1 FFC18436B66061953EA3B8C1F53ECB774212D8BD )
 )
 game (
@@ -1781,6 +1781,11 @@ game (
 	rom ( name "Ball Bearing (1993)(Radical Software)[cr].dsk" size 194816 crc 2E58903C md5 0408709C81781F17EAFFE99D67ABB82A sha1 BEA2C5F079AC8D32B665DA2A76C1C1063F130546 )
 )
 game (
+	name "Boloncio (G.T.S. Editorial) (Spain)"
+	description "Boloncio (G.T.S. Editorial) (Spain)"
+	rom ( name "Boloncio (1986)(G.T.S. Editorial)(es)[cr].dsk" size 194816 crc 5FC8032D md5 5044BE6EEA3F0B1868E56805C983CD23 sha1 5B2D78C2BAEB7C097117370641461DAAE1745C14 )
+)
+game (
 	name "Big League Soccer (Viper) (Spain) (Hack)"
 	description "Big League Soccer (Viper) (Spain) (Hack)"
 	rom ( name "Big League Soccer (1985)(Viper)(es)(Hack)[cr].dsk" size 204544 crc 7234D56E md5 79DD2D4AB83F9A5E14D8AEB2C90EBFF9 sha1 70666957B0CD35158FF78F46BB00AF70AFBBE691 )
@@ -1892,11 +1897,6 @@ game (
 	rom ( name "Black Fountain, The (1987)(Incentive Software)[cr][f].dsk" size 194816 crc 100BCC3 md5 F62A2DE076A48A3EF68B78D50143AF5D sha1 2DEB960FABD2F386D6FCBBF94921F101583242E7 )
 )
 game (
-	name "BMX Freestyle (Codemasters)"
-	description "BMX Freestyle (Codemasters)"
-	rom ( name "BMX Freestyle (1989)(Codemasters)[cr].dsk" size 204544 crc FFC7E373 md5 1C04E24BD46CDCEF546F6C0B88208F8E sha1 9BFFAE1623CBF513DDDCE3BA1DB9F9CDAAEA05A9 )
-)
-game (
 	name "Biff (Beyond Belief)"
 	description "Biff (Beyond Belief)"
 	rom ( name "Biff (1992)(Beyond Belief)[cr].dsk" size 204544 crc 76C0F723 md5 2756D084271C058EB461FC82F91DA836 sha1 6E231699F1A8E12B952285EFD4388B69DC47240E )
@@ -1976,8 +1976,8 @@ game (
 game (
 	name "Budokan (Electronic Arts)"
 	description "Budokan (Electronic Arts)"
-	rom ( name "Budokan (1990)(Electronic Arts)(Side B).dsk" size 156581 crc 662A9BDE md5 89E8DC4130714052FDFA5A1739931D1C sha1 02450353B90062EEFB0CA2A6CCE13197D9AFF038 )
 	rom ( name "Budokan (1990)(Electronic Arts)(Side A).dsk" size 195637 crc 480C9E65 md5 DAE80E2682969048C50DDE550467F5D5 sha1 F073E4F01B0F5979710216356833CEF15966EA3F )
+	rom ( name "Budokan (1990)(Electronic Arts)(Side B).dsk" size 156581 crc 662A9BDE md5 89E8DC4130714052FDFA5A1739931D1C sha1 02450353B90062EEFB0CA2A6CCE13197D9AFF038 )
 )
 game (
 	name "Batman (Ocean Software)"
@@ -2026,6 +2026,11 @@ game (
 	name "BMX Kidz (Firebird)"
 	description "BMX Kidz (Firebird)"
 	rom ( name "BMX Kidz (1988)(Firebird)[cr].dsk" size 194816 crc 4E5FA31A md5 CEF9E03BBCB1131E0A6E4A30385BD8E8 sha1 A8127970C698786ED4E6B08CBF5B969C3860CE9F )
+)
+game (
+	name "Brainache (Codemasters Software)"
+	description "Brainache (Codemasters Software)"
+	rom ( name "Brainache (1987)(Codemasters Software)[cr].dsk" size 204544 crc 44179CDE md5 ED33F5D5BA415A5FB0E72EC205441C0C sha1 53C2FD963BDEA831D533D026783FD545F9BDC356 )
 )
 game (
 	name "Bridge It (Amsoft)"
@@ -2091,11 +2096,6 @@ game (
 	name "Blokker (Computer Magazine)"
 	description "Blokker (Computer Magazine)"
 	rom ( name "Blokker (1985)(Computer Magazine)[cr].dsk" size 204544 crc 207FB361 md5 9B4E8B7B8B66F84B11A4BC2A1C7E4A50 sha1 65F143DE7D00C75C5B8F1A2212DA037690C2FC40 )
-)
-game (
-	name "Brainache (Codemasters)"
-	description "Brainache (Codemasters)"
-	rom ( name "Brainache (1987)(Codemasters)[cr].dsk" size 204544 crc 44179CDE md5 ED33F5D5BA415A5FB0E72EC205441C0C sha1 53C2FD963BDEA831D533D026783FD545F9BDC356 )
 )
 game (
 	name "B.A.T. (Ubi Soft)"
@@ -2271,6 +2271,11 @@ game (
 	rom ( name "Bo! (1994)(Bollaware)(de)[cr].dsk" size 194816 crc EB9C2347 md5 BA50BFC60E76EDA58E6C5805D4D92DF4 sha1 B53B2EBA6912003E4CC1B81499BB1AA111822FF7 )
 )
 game (
+	name "BMX Simulator (Codemasters Software)"
+	description "BMX Simulator (Codemasters Software)"
+	rom ( name "BMX Simulator (1987)(Codemasters Software)[cr].dsk" size 204544 crc 6CF1612C md5 40636E4F1EC37255EB0F2CADE6DB865F sha1 DBAE45DE0BDE2919A5E7BC507DA44C6BE820F798 )
+)
+game (
 	name "Big League Soccer II (Viper) (Spain) (Hack)"
 	description "Big League Soccer II (Viper) (Spain) (Hack)"
 	rom ( name "Big League Soccer II (2018)(Viper)(es)(Hack)[cr].dsk" size 194816 crc FAC68415 md5 3F9382F1F9D6E924A0E78636187E268E sha1 853B5B3E96E273D18B0072D2D9565D7F8692A3EA )
@@ -2355,7 +2360,7 @@ game (
 game (
 	name "Blueberry (Coktel Vision) (de)"
 	description "Blueberry (Coktel Vision) (de)"
-	rom ( name "Blueberry (1987)(Coktel Vision)(de)(Side A).dsk" size 210283 crc 2DC8C009 md5 F943F349CC3F5276DA85D136B2DF1B2D sha1 1C1E95A5ECDED201ED0D857A60B806A41887B534 )
+	rom ( name "Blueberry (1987)(Coktel Vision)(de)(Side A)[CPM].dsk" size 210283 crc 2DC8C009 md5 F943F349CC3F5276DA85D136B2DF1B2D sha1 1C1E95A5ECDED201ED0D857A60B806A41887B534 )
 	rom ( name "Blueberry (1987)(Coktel Vision)(de)(Side B).dsk" size 210283 crc 49A750A5 md5 51539588C643B9521F6ACAEE1060270D sha1 CAFE38AFB29AB5B6108EF5C6CB28E52EDCF5A2E5 )
 )
 game (
@@ -2610,6 +2615,11 @@ game (
 	name "Camelot Warriors (Dinamic Software) (Spain)"
 	description "Camelot Warriors (Dinamic Software) (Spain)"
 	rom ( name "Camelot Warriors (1986)(Dinamic Software)(es)[cr].dsk" size 204544 crc 2669032B md5 C74B904ABF42E1359815633F090E5237 sha1 D2B5135E922375C504616D0A4D7DD03AC9E5F9C7 )
+)
+game (
+	name "Castle Master II - The Crypt (Incentive)"
+	description "Castle Master II - The Crypt (Incentive)"
+	rom ( name "Castle Master II - The Crypt (1990)(Incentive)[tape].dsk" size 204544 crc D415B403 md5 227EFE47A5D1950D93838F80E4F139BD sha1 EE2DB9957DB35E19B4ACE2EEEBA675C65B5B54B7 )
 )
 game (
 	name "Crazy Brick (Ingo Bordach) (de)"
@@ -3391,11 +3401,6 @@ game (
 	rom ( name "Crucial Test (1988)(Coktel Vision)(fr)(Side B)(Q2).dsk" size 195635 crc 1DBEE4 md5 037B6CA695906C9EBC5E6A10981CD66F sha1 8C507EDE59D5ECFD2593B180352F52521E457645 )
 )
 game (
-	name "Castle Master II - The Crypt (1990)"
-	description "Castle Master II - The Crypt (1990)"
-	rom ( name "Castle Master II - The Crypt (UK) (1990)[cr][f].dsk" size 204544 crc CCC69659 md5 E8206160A22F274DE12EC90AC76ADD12 sha1 866F24144B0A1A13C9D24B09B067291C5839B0A2 )
-)
-game (
 	name "Can I Cheat the Death (Amstrad Adventure PD Library)"
 	description "Can I Cheat the Death (Amstrad Adventure PD Library)"
 	rom ( name "Can I Cheat the Death (1990)(Amstrad Adventure PD Library)(PD)[cr].dsk" size 194816 crc 11864F72 md5 0B5DD3EA42819B6013B115789B643EA4 sha1 634985FE9F232D312DAF80BB089F01991F2B5CB4 )
@@ -3630,11 +3635,6 @@ game (
 	description "Devilry 2 (Eric Cubizolle - Emmanuel Rigot) (France)"
 	rom ( name "Devilry 2 (1989)(Eric Cubizolle - Emmanuel Rigot)(fr)(Side A).dsk" size 194816 crc 76F1D396 md5 099457E443564CE635B9C6F3600BD5EA sha1 DB073ECC79C0AE04EAD1139384848F57EB638E43 )
 	rom ( name "Devilry 2 (1989)(Eric Cubizolle - Emmanuel Rigot)(fr)(Side B).dsk" size 194816 crc 18464AC0 md5 CBDB4359785F4A42C630488AAE6B1723 sha1 6E1E7F6225FBAF5B84B0CA0F16F10FFAA843C139 )
-)
-game (
-	name "Dizzy VI - Prince of the Yolkfolk (Codemasters)"
-	description "Dizzy VI - Prince of the Yolkfolk (Codemasters)"
-	rom ( name "Dizzy VI - Prince of the Yolkfolk (1991)(Codemasters)[cr].dsk" size 194816 crc 4065E278 md5 852BCF814CB2A968A69F9E6D39DAAAB6 sha1 04DBE458BCF779AA8E0786FC7CF1617A066645F5 )
 )
 game (
 	name "Digger Barnes (Cable Software)"
@@ -3931,6 +3931,11 @@ game (
 	rom ( name "Dominoes (1987)(Blue Ribbon Software)[tape].dsk" size 194816 crc 8D4A1AB8 md5 AA5EA8315A557E4D3CE80FBA42DCB888 sha1 FB71654F3DBEC695AD53E51778DF2735E5127608 )
 )
 game (
+	name "Dizzy VII - Crystal Kingdom Dizzy (Codemasters Software)"
+	description "Dizzy VII - Crystal Kingdom Dizzy (Codemasters Software)"
+	rom ( name "Dizzy VII - Crystal Kingdom Dizzy (1992)(Codemasters Software)[cr].dsk" size 204544 crc DC891BE2 md5 5B4EFA78DBEEB2B669E17B4297759F30 sha1 3BE1659E6C4ED046D44E6DB3DE78EDB16056B1D7 )
+)
+game (
 	name "Dragon Spirit (Domark)"
 	description "Dragon Spirit (Domark)"
 	rom ( name "Dragon Spirit (1989)(Domark)(Side A).dsk" size 195635 crc C53E8BE1 md5 19E2B1A0DDCD865F6931529EF68371FE sha1 0723D4A217C5E2A6036C0B47A1161C2A47603965 )
@@ -4099,6 +4104,11 @@ game (
 	rom ( name "Dom Camillo (1987)(Free Game Blot)(fr)[cr].dsk" size 194816 crc A3BC8BFE md5 C269CBEA1E3E29512D10BD78DF5EB227 sha1 CA77B0290CA1CF0A4BB84AA974D61A9646F0DBDA )
 )
 game (
+	name "Dizzy VI - Prince of the Yolkfolk (Codemasters Software)"
+	description "Dizzy VI - Prince of the Yolkfolk (Codemasters Software)"
+	rom ( name "Dizzy VI - Prince of the Yolkfolk (1991)(Codemasters Software)[cr].dsk" size 194816 crc 4065E278 md5 852BCF814CB2A968A69F9E6D39DAAAB6 sha1 04DBE458BCF779AA8E0786FC7CF1617A066645F5 )
+)
+game (
 	name "Dark Century (Titus)"
 	description "Dark Century (Titus)"
 	rom ( name "Dark Century (1990)(Titus).dsk" size 110583 crc BE2EB246 md5 A0D78E87AC3396C197E1E41E296B7C24 sha1 2752DE60926780BDB11A035F0177035838C15F06 )
@@ -4107,11 +4117,6 @@ game (
 	name "Devil Highway (Infomedia)"
 	description "Devil Highway (Infomedia)"
 	rom ( name "Devil Highway (1987)(Infomedia)[cr].dsk" size 204544 crc 3105977F md5 06EDB77581273BAD0A216DA90FF55478 sha1 BBDA2BECB3EDFDBF26E565B68556B909BF8BBA8E )
-)
-game (
-	name "Dizzy VII - Crystal Kingdom Dizzy (Codemasters)"
-	description "Dizzy VII - Crystal Kingdom Dizzy (Codemasters)"
-	rom ( name "Dizzy VII - Crystal Kingdom Dizzy (1992)(Codemasters)[cr].dsk" size 204544 crc DC891BE2 md5 5B4EFA78DBEEB2B669E17B4297759F30 sha1 3BE1659E6C4ED046D44E6DB3DE78EDB16056B1D7 )
 )
 game (
 	name "Dragon's Lair II - Escape from Singe's Castle (Software Projects)"
@@ -4723,11 +4728,6 @@ game (
 	rom ( name "Fairlight - A Trail Of Darkness (1986)(The Edge)[cr][f].dsk" size 194816 crc B7609628 md5 13665B825760C256B494C554DE64A60D sha1 A5B463B576544F247A7DE75545754472DFE27360 )
 )
 game (
-	name "Fast Food Dizzy (Codemasters)"
-	description "Fast Food Dizzy (Codemasters)"
-	rom ( name "Fast Food Dizzy (1989)(Codemasters).dsk" size 59015 crc CA3CB7DF md5 2A58CC155DDB21D678AFA8D41C38FFC7 sha1 43830A1092E396719409AD5E94856C7F6DE5A1E2 )
-)
-game (
 	name "ForceField (David Hall)"
 	description "ForceField (David Hall)"
 	rom ( name "ForceField (19xx)(David Hall)(PD)[cr].dsk" size 194816 crc 2A6A6691 md5 60AEAAAB1164664B87AFED18CB1313EC sha1 CC4E84C5D5B4EA7C87A38ECE8B2BE0AD6A17CA5A )
@@ -4923,11 +4923,6 @@ game (
 	rom ( name "Fu-Kung in Las Vegas (1985)(Amsoft).dsk" size 78467 crc DF940198 md5 06E74B20DCE83AFF9D10D3E6EA11275F sha1 A19495F6A2B72460967F649C5970B3E7FCD974EF )
 )
 game (
-	name "Fruit Machine 2 Simulator (Codemasters)"
-	description "Fruit Machine 2 Simulator (Codemasters)"
-	rom ( name "Fruit Machine 2 Simulator (1990)(Codemasters)[cr].dsk" size 194816 crc AED93596 md5 F6DE5187B05236CF3534165E20C3E594 sha1 316FD3CCF34A77B7A9DC833A23C7543B5A282682 )
-)
-game (
 	name "Fer & Flamme (Ubi Soft) (France)"
 	description "Fer & Flamme (Ubi Soft) (France)"
 	rom ( name "Fer & Flamme (1986)(Ubi Soft)(fr)(Disk 1 Side A).dsk" size 203597 crc BC7B47C3 md5 AF3DD8C14E7382DE414BF85FA8B99050 sha1 12CC081FE95CC829D1C4BA28D313DBCAA6638A74 )
@@ -4981,6 +4976,11 @@ game (
 	rom ( name "Footballer of the Year (1986)(Gremlin Graphics Software).dsk" size 175589 crc 9C474AFB md5 A73D81BC31CDA87ACCC85DFF23B40BAC sha1 42FCBEF430E5A4F04118D684F7A7DA19F0910F87 )
 )
 game (
+	name "Fruit Machine 2 Simulator (Codemasters Software)"
+	description "Fruit Machine 2 Simulator (Codemasters Software)"
+	rom ( name "Fruit Machine 2 Simulator (1990)(Codemasters Software)[cr].dsk" size 194816 crc AED93596 md5 F6DE5187B05236CF3534165E20C3E594 sha1 316FD3CCF34A77B7A9DC833A23C7543B5A282682 )
+)
+game (
 	name "Faial (Excalibur) (France)"
 	description "Faial (Excalibur) (France)"
 	rom ( name "Faial (1986)(Excalibur)(fr)(Side A).dsk" size 198211 crc BCA5ACB2 md5 56FE7E75E3D287E949C20E98B3EC0088 sha1 7AFF0592E7BEB9F9B87147D6FAE1A29CA4940F75 )
@@ -5015,12 +5015,6 @@ game (
 	name "Freddy Hardest (Dinamic Software)"
 	description "Freddy Hardest (Dinamic Software)"
 	rom ( name "Freddy Hardest (1987)(Dinamic Software).dsk" size 195379 crc 7A8FE41D md5 CC61BF9C6E0E8AC2F93C78D0CCCDA524 sha1 F2DD92265B2462A838728F7BAA07E106CD7FF802 )
-)
-game (
-	name "Fiendish Freddy's Big Top O' Fun (Mindscape) (Codes)"
-	description "Fiendish Freddy's Big Top O' Fun (Mindscape) (Codes)"
-	rom ( name "Fiendish Freddy's Big Top O' Fun (1990)(Mindscape)(Side A)[codes].dsk" size 211179 crc DF73E59F md5 A40DE8331FECBB27A66E711709B5FAA5 sha1 0BFE13A72226155BCBC0A1A217E39087B4E6BBEE )
-	rom ( name "Fiendish Freddy's Big Top O' Fun (1990)(Mindscape)(Side B).dsk" size 211179 crc 9F51A10D md5 D60CE2D8DC4A787576DEC4B28126840B sha1 FBE82223E4642BFB6BDFD48EF601F1D381FE5931 )
 )
 game (
 	name "Friss Man (Amsoft)"
@@ -5113,6 +5107,11 @@ game (
 	rom ( name "Frankie Crashed on Jupiter (1985)(Kingsoft)(Side B).dsk" size 195637 crc 6F473E32 md5 D35D228F75032AB844DB10F570AF4F40 sha1 8FEE0BEBF4B7A803C2BB22B122E98223B21BED1F )
 )
 game (
+	name "Fast Food Dizzy (Codemasters Software)"
+	description "Fast Food Dizzy (Codemasters Software)"
+	rom ( name "Fast Food Dizzy (1989)(Codemasters Software).dsk" size 59015 crc CA3CB7DF md5 2A58CC155DDB21D678AFA8D41C38FFC7 sha1 43830A1092E396719409AD5E94856C7F6DE5A1E2 )
+)
+game (
 	name "Fruity Frank (Kuma Computers) (de)"
 	description "Fruity Frank (Kuma Computers) (de)"
 	rom ( name "Fruity Frank (1984)(Kuma Computers)(de)[cr].dsk" size 204544 crc 669D006 md5 B83256F1A48AA8D4CC275F1636347989 sha1 A353062E7ED814D865166519127836D84BC0146F )
@@ -5141,6 +5140,12 @@ game (
 	name "Forgotten Worlds (US Gold)"
 	description "Forgotten Worlds (US Gold)"
 	rom ( name "Forgotten Worlds (1989)(US Gold).dsk" size 220581 crc B74E5F17 md5 04DA205C56D176C6781C576C3C3AAA20 sha1 B00E82DC769FD813DB0EC07F5F28855803D76B17 )
+)
+game (
+	name "Fiendish Freddy's Big Top O' Fun (Mindscape) (Codes)"
+	description "Fiendish Freddy's Big Top O' Fun (Mindscape) (Codes)"
+	rom ( name "Fiendish Freddy's Big Top O' Fun (1990)(Mindscape)(Side A)[codes].dsk" size 211179 crc DF73E59F md5 A40DE8331FECBB27A66E711709B5FAA5 sha1 0BFE13A72226155BCBC0A1A217E39087B4E6BBEE )
+	rom ( name "Fiendish Freddy's Big Top O' Fun (1990)(Mindscape)(Side B)[codes].dsk" size 211179 crc 9F51A10D md5 D60CE2D8DC4A787576DEC4B28126840B sha1 FBE82223E4642BFB6BDFD48EF601F1D381FE5931 )
 )
 game (
 	name "Football Manager World Cup Edition (Addictive Games) (de)"
@@ -5272,19 +5277,9 @@ game (
 	rom ( name "Gob (1987)(TJC)[cr].dsk" size 194816 crc 1F01E07C md5 A5780DED29618E75A8693104E80D4EB3 sha1 19AB3F7DC2B8A38ED5893129E2318DA6ADCB553F )
 )
 game (
-	name "Grand Prix 500cc (Microids)"
-	description "Grand Prix 500cc (Microids)"
-	rom ( name "Grand Prix 500cc (1986)(Microids)[cr].dsk" size 204544 crc 6E0E3657 md5 0DC297B6EB86B28CEFE44A998BC0CA8E sha1 2306548F35EBAAD21739E15CEEB723D7ABD329BC )
-)
-game (
 	name "Grand Prix 500cc (Microids) (France)"
 	description "Grand Prix 500cc (Microids) (France)"
 	rom ( name "Grand Prix 500cc (1986)(Microids)(fr).dsk" size 267315 crc EDAE7DD md5 E1339CA3E098A042A7948A4106DB74E6 sha1 AC42AD76B653C4F0133F899EDAAF4002F4B50CCB )
-)
-game (
-	name "Grand Prix 500cc (Microids) (Spain)"
-	description "Grand Prix 500cc (Microids) (Spain)"
-	rom ( name "Grand Prix 500cc (1986)(Microids)(es)[cr].dsk" size 194816 crc DAD8D078 md5 B79A7277E9599ED26919733F3ED5395D sha1 BCEB5F4AB9A95C5672B25FC61E230BC9973E1348 )
 )
 game (
 	name "Gun Dogs (Andromeda Software)"
@@ -5444,11 +5439,6 @@ game (
 	rom ( name "Gutter (1985)(ERE Informatique)[tape].dsk" size 194816 crc DE622D6E md5 9993A972F49047D9761CD1DD9B5D4A8E sha1 4D1147B54F41830E4BA66423CE1AEFA62A12319B )
 )
 game (
-	name "Grand Prix Simulator 2 (Codemasters)"
-	description "Grand Prix Simulator 2 (Codemasters)"
-	rom ( name "Grand Prix Simulator 2 (1989)(Codemasters)[cr].dsk" size 204544 crc F020EE31 md5 1CAFE91DF6D1527B39C29E7512A54E0B sha1 7491A03697BBB49470737915F7170F669FFCE725 )
-)
-game (
 	name "Great Escape, The (Ocean)"
 	description "Great Escape, The (Ocean)"
 	rom ( name "Great Escape, The (1986)(Ocean).dsk" size 195379 crc 8D478D60 md5 4A39F193BF4C72709CD7A8069432327C sha1 6A87A4A78DFB30BDD54F7FD8BDA38D08BAEE94FE )
@@ -5508,6 +5498,11 @@ game (
 	name "Ghosts (Cascade Games)"
 	description "Ghosts (Cascade Games)"
 	rom ( name "Ghosts (1985)(Cascade Games)[cr].dsk" size 194816 crc D050C94E md5 A57AE0F02CC6C9D177FF890C82E1E1A6 sha1 F0394C645AF77B97D9AB7208BB94EED2AD4AE91A )
+)
+game (
+	name "Grand Prix 500cc (Microids) (Spain)"
+	description "Grand Prix 500cc (Microids) (Spain)"
+	rom ( name "Grand Prix 500cc (1986)(Microids)(es)[cr].dsk" size 194816 crc DAD8D078 md5 B79A7277E9599ED26919733F3ED5395D sha1 BCEB5F4AB9A95C5672B25FC61E230BC9973E1348 )
 )
 game (
 	name "Ghouls 'n' Ghosts (US Gold)"
@@ -5614,6 +5609,11 @@ game (
 	name "Great Barrier Reef, The (The Power House)"
 	description "Great Barrier Reef, The (The Power House)"
 	rom ( name "Great Barrier Reef, The (1987)(The Power House)[cr].dsk" size 194816 crc 2A17ECD1 md5 B0718997D2BAFF9D1D60030EA93A2FFE sha1 7AB4E612BB13860570A1DA9F888572E75F83AD3C )
+)
+game (
+	name "Grand Prix 500cc (Microids)"
+	description "Grand Prix 500cc (Microids)"
+	rom ( name "Grand Prix 500cc (1986)(Microids)[cr].dsk" size 204544 crc 6E0E3657 md5 0DC297B6EB86B28CEFE44A998BC0CA8E sha1 2306548F35EBAAD21739E15CEEB723D7ABD329BC )
 )
 game (
 	name "Gogly (Ace Software) (Spain)"
@@ -5725,6 +5725,11 @@ game (
 	name "Guillermo Tell (Opera Soft) (Spain) (LightGun)"
 	description "Guillermo Tell (Opera Soft) (Spain) (LightGun)"
 	rom ( name "Guillermo Tell (1989)(Opera Soft)(es)(LightGun).dsk" size 219405 crc 38A6771E md5 7447D26E45386DB3BC256AF6F7C04F9C sha1 0BC50B5A9E4ADA000884C2A8AFF2288D9690B52C )
+)
+game (
+	name "Grand Prix Simulator 2 (Codemasters Software)"
+	description "Grand Prix Simulator 2 (Codemasters Software)"
+	rom ( name "Grand Prix Simulator 2 (1989)(Codemasters Software)[cr].dsk" size 204544 crc F020EE31 md5 1CAFE91DF6D1527B39C29E7512A54E0B sha1 7491A03697BBB49470737915F7170F669FFCE725 )
 )
 game (
 	name "GBA Championship Basketball (Activision)"
@@ -6594,6 +6599,11 @@ game (
 	rom ( name "Inquisitor - Shade of Swords (1988)(Chip)(fr).dsk" size 273965 crc 298E8919 md5 CA42BE1AC486509DA6E6CBF1D01528FA sha1 58FAA42B2F059C920EFA0FD9F51DD99DAA9C8BF4 )
 )
 game (
+	name "Italian Supercar (Codemasters Software)"
+	description "Italian Supercar (Codemasters Software)"
+	rom ( name "Italian Supercar (1990)(Codemasters Software)[tape].dsk" size 204544 crc F08C5B1C md5 7C082C51551863524A952243AA5D03B2 sha1 88F331E1DB2A0A87B47056CB823C09FA9584717D )
+)
+game (
 	name "Il Etait Une Fois (Carraz Editions) (France)"
 	description "Il Etait Une Fois (Carraz Editions) (France)"
 	rom ( name "Il Etait Une Fois (1989)(Carraz Editions)(fr).dsk" size 195635 crc 730747D5 md5 9CE57A11B85D8B48426C18A6D068D79C sha1 90AF99455D0EC827478773276A20FC9745D5FE5A )
@@ -7311,7 +7321,7 @@ game (
 game (
 	name "Labyrinthe aux Cent Calculs, Le - Ecole (Retz) (France)"
 	description "Labyrinthe aux Cent Calculs, Le - Ecole (Retz) (France)"
-	rom ( name "Labyrinthe aux Cent Calculs, Le - Ecole (1989)(Retz)(fr)(Disk 1 Side A)[CPM] .dsk" size 195635 crc 92B6A819 md5 0A0B32D712A5DA982A7BA29752046C5D sha1 02C638A3FC3486DB7283889D2CBE0173DB38ADFE )
+	rom ( name "Labyrinthe aux Cent Calculs, Le - Ecole (1989)(Retz)(fr)(Disk 1 Side A)[CPM].dsk" size 195635 crc 92B6A819 md5 0A0B32D712A5DA982A7BA29752046C5D sha1 02C638A3FC3486DB7283889D2CBE0173DB38ADFE )
 	rom ( name "Labyrinthe aux Cent Calculs, Le - Ecole (1989)(Retz)(fr)(Disk 1 Side B).dsk" size 195635 crc E3955D4D md5 26CAF345DF45A550EDA69DE6E204204E sha1 EB06FDA3631BA75F6FC6B1BA6B8324686B3FA01A )
 	rom ( name "Labyrinthe aux Cent Calculs, Le - Ecole (1989)(Retz)(fr)(Disk 2 Side A).dsk" size 195635 crc DA04BC18 md5 4D3E7698A3CBC74ED3CE8654559FC25C sha1 FF16C8C024BEF9F816EB36B2062D615166520D60 )
 	rom ( name "Labyrinthe aux Cent Calculs, Le - Ecole (1989)(Retz)(fr)(Disk 2 Side B).dsk" size 195635 crc D7AD58E3 md5 135BCBC9C75D9E3394ABE20DD49C18BF sha1 D026AA9D8E9E4F6C4E951DB155C44C7DB269C950 )
@@ -7324,7 +7334,7 @@ game (
 game (
 	name "Lancelot (Level 9 Computing)"
 	description "Lancelot (Level 9 Computing)"
-	rom ( name "Lancelot (1988)(Level 9 Computing)(Side A)[CPM].dsk" size 194816 crc C5AD3E3E md5 83090F57D36C262FB457F31E377FF8E0 sha1 137C65F45B5130EBE04B24C0ED67B7107E14A176 )
+	rom ( name "Lancelot (1988)(Level 9 Computing)(Side A).dsk" size 194816 crc C5AD3E3E md5 83090F57D36C262FB457F31E377FF8E0 sha1 137C65F45B5130EBE04B24C0ED67B7107E14A176 )
 	rom ( name "Lancelot (1988)(Level 9 Computing)(Side B).dsk" size 194816 crc 2943604C md5 4B94EBB9DA77E5A5C59114EC76E83F9D sha1 571AD9CE99545A072E8C31CCDCFF1E52AA313CEF )
 )
 game (
@@ -7644,14 +7654,14 @@ game (
 	rom ( name "Lord of the Rings - Game Two - Shadows of Mordor (1987)(Melbourne House)[cr].dsk" size 194816 crc E31090F5 md5 8412BB701A837C7F578ED81F5F03F01A sha1 65C9AF1703DB4A7EC68D2D88F9D851741BC94F66 )
 )
 game (
-	name "Little Puff in Dragonland (Codemasters)"
-	description "Little Puff in Dragonland (Codemasters)"
-	rom ( name "Little Puff in Dragonland (1990)(Codemasters).dsk" size 52357 crc 504E2A3F md5 BB6E074F6F0C419587D99E2AA29E7E73 sha1 1CCC6323D04D38A72362F3DDBFE9AD1097846277 )
-)
-game (
 	name "La Mansion Encantada (Anirog Software) (Spain)"
 	description "La Mansion Encantada (Anirog Software) (Spain)"
 	rom ( name "La Mansion Encantada (1984)(Anirog Software)(es)[cr].dsk" size 204544 crc 92F208CA md5 F0A893E85F0A3811E384ABA42EC4301C sha1 51BBEE106014698A312E3221282D147DCA0A8D45 )
+)
+game (
+	name "Little Puff in Dragonland (Codemasters Software)"
+	description "Little Puff in Dragonland (Codemasters Software)"
+	rom ( name "Little Puff in Dragonland (1990)(Codemasters Software).dsk" size 52357 crc 504E2A3F md5 BB6E074F6F0C419587D99E2AA29E7E73 sha1 1CCC6323D04D38A72362F3DDBFE9AD1097846277 )
 )
 game (
 	name "Last Mission, The (Opera Soft) (Spain)"
@@ -8322,8 +8332,8 @@ game (
 game (
 	name "Meurtres en Serie (Cobra Soft) (France)"
 	description "Meurtres en Serie (Cobra Soft) (France)"
-	rom ( name "Meurtres en Serie (1987)(Cobra Soft)(fr)(Side B).dsk" size 195635 crc ECA69E3E md5 5E5A4D54AD23D056A67EE9D9EA88C5A3 sha1 40EBAF3DBA0A05B0B2FACFB2C34C8A4DFFF3BCCD )
 	rom ( name "Meurtres en Serie (1987)(Cobra Soft)(fr)(Side A).dsk" size 195635 crc 5E917C38 md5 313BD4F573491B8A9A5339C89CDB5DF0 sha1 4F160158E47F3ED2B0D875C5749F372F581902E2 )
+	rom ( name "Meurtres en Serie (1987)(Cobra Soft)(fr)(Side B).dsk" size 195635 crc ECA69E3E md5 5E5A4D54AD23D056A67EE9D9EA88C5A3 sha1 40EBAF3DBA0A05B0B2FACFB2C34C8A4DFFF3BCCD )
 )
 game (
 	name "Mach 3 (Loriciels)"
@@ -8873,6 +8883,11 @@ game (
 	rom ( name "Night Gunner (1989)(Digital Integration)(M3)[codes].dsk" size 71168 crc 5867C8E4 md5 418F6982368E478966A4350B05CD0F24 sha1 E7FA8347C1FEEF369CFE0918B3FF908C032BCD30 )
 )
 game (
+	name "Necris Dome (Codemasters Software)"
+	description "Necris Dome (Codemasters Software)"
+	rom ( name "Necris Dome (1987)(Codemasters Software)[cr].dsk" size 194816 crc 93743DC7 md5 A9E5A85BBC4A94CA0D96008CF4C5EE6A sha1 3E631F7447FEF7979E6934BDD732E4DD0AFE3108 )
+)
+game (
 	name "Nemesis the Warlock (Martech Games)"
 	description "Nemesis the Warlock (Martech Games)"
 	rom ( name "Nemesis the Warlock (1987)(Martech Games).dsk" size 185425 crc F5B719CC md5 C12DEB875BED79D2D9D8C76464FE20AE sha1 46C5EC1F84AC044D331A0790DE2E8E212DA3B37E )
@@ -8961,11 +8976,6 @@ game (
 	name "Nibbler (Mosaik Software)"
 	description "Nibbler (Mosaik Software)"
 	rom ( name "Nibbler (1984)(Mosaik Software)[cr].dsk" size 204544 crc 380C424F md5 633BC7421A98E1901FEE8CC6E6540133 sha1 79142C4061943B35D7866E68682F4613025143D8 )
-)
-game (
-	name "Necris Dome (Codemasters)"
-	description "Necris Dome (Codemasters)"
-	rom ( name "Necris Dome (1987)(Codemasters)[cr].dsk" size 194816 crc 93743DC7 md5 A9E5A85BBC4A94CA0D96008CF4C5EE6A sha1 3E631F7447FEF7979E6934BDD732E4DD0AFE3108 )
 )
 game (
 	name "Nick Faldo Plays the Open (Mind Games)"
@@ -11379,7 +11389,7 @@ game (
 game (
 	name "Storm Warrior (Elite Systems)"
 	description "Storm Warrior (Elite Systems)"
-	rom ( name "Storm Warrior (1989)(Elite Systems)[cr][f].dsk" size 194816 crc B15ABD80 md5 2FA0C674EE6B0BE01C129CFEC2242001 sha1 84C076E26FD1EC6AA10EB898AEB6FADE3371792A )
+	rom ( name "Storm Warrior (1989)(Elite Systems)[cr].dsk" size 204544 crc C83F6F3B md5 1EA208BC3F02F13F9660DAF440574E20 sha1 9CAF131E79F9D2A209874745CD383F470485FE8A )
 )
 game (
 	name "Saboteur 2 (Durell Software)"
@@ -11682,7 +11692,7 @@ game (
 game (
 	name "Strip Poker Animado (Knight Soft) (Spain) (Hack)"
 	description "Strip Poker Animado (Knight Soft) (Spain) (Hack)"
-	rom ( name "Strip Poker Animado (1987)(Knight Soft)(es)(Hack)[cr][f].dsk" size 194816 crc AD77EA49 md5 E71D28F77F0B32B61715BB3B61710A3E sha1 81D92C90EFBA3DCF1786CC7D33995BC19D122A38 )
+	rom ( name "Strip Poker Animado (1987)(Knight Soft)(es)(Hack)[cr].dsk" size 204544 crc 80B4D1DE md5 43E8F372B7087EC15C4DE52A0312C04E sha1 F0B45A39AA9684430324C281644F101BC3CBE7C7 )
 )
 game (
 	name "Scoop Junior (Generation 5) (France)"
@@ -11935,7 +11945,7 @@ game (
 game (
 	name "Suspect (Infocom)"
 	description "Suspect (Infocom)"
-	rom ( name "Suspect (1986)(Infocom)[CPM].dsk" size 195635 crc ED5A1C75 md5 E1F7C29BAFCB436396FBFA257F0A0B8F sha1 3494236B48DA64B55F02762A5273E5F7FCFE2EAB )
+	rom ( name "Suspect (1986)(Infocom).dsk" size 195635 crc ED5A1C75 md5 E1F7C29BAFCB436396FBFA257F0A0B8F sha1 3494236B48DA64B55F02762A5273E5F7FCFE2EAB )
 )
 game (
 	name "Strip Poker (Logipresse) (France)"
@@ -12142,7 +12152,7 @@ game (
 game (
 	name "Sultans Maze (Amsoft)"
 	description "Sultans Maze (Amsoft)"
-	rom ( name "Sultans Maze (1984)(Amsoft)[cr][f].dsk" size 204544 crc 43157458 md5 C25195336146A27082FF6CAEFE9DBC8D sha1 5D5D01E61FBEA18ADBCCAA95DD95EE8F191C146E )
+	rom ( name "Sultans Maze (1984)(Amsoft)[cr][f][BASIC 1.1].dsk" size 204544 crc 43157458 md5 C25195336146A27082FF6CAEFE9DBC8D sha1 5D5D01E61FBEA18ADBCCAA95DD95EE8F191C146E )
 )
 game (
 	name "Scrounch (Hebdogiciel) (France)"
@@ -12596,7 +12606,7 @@ game (
 game (
 	name "Skyfox (Electronics Arts) (Spain)"
 	description "Skyfox (Electronics Arts) (Spain)"
-	rom ( name "Skyfox (1985)(Electronics Arts)(es)[cr][f].dsk" size 204544 crc 7EB01165 md5 DA3F7E6C8D5A8BE69BD628BA4B2E0C99 sha1 811BF4644F32E0FED093834E4371A97FCA6A8ED4 )
+	rom ( name "Skyfox (1985)(Electronics Arts)(es)[cr].dsk" size 204544 crc 1BAB7A1C md5 960CD554ED11AF9BFA70C34635B564AE sha1 675D06409D29AD2A72ECCE991B32A216068CE613 )
 )
 game (
 	name "Super Hang-On (Activision)"
@@ -12835,9 +12845,9 @@ game (
 	rom ( name "Snakes and Hazards (1987)(Gremlin Graphics Software)[cr].dsk" size 194816 crc 630C1A6 md5 19DBE319D1E003E0EE50ACF3D7489325 sha1 0EFE8449CB4186F76893D65390E44436DC0FCF42 )
 )
 game (
-	name "Satelite Warrior (Amsoft)"
-	description "Satelite Warrior (Amsoft)"
-	rom ( name "Satelite Warrior (1985)(Amsoft).dsk" size 158464 crc D5E3633D md5 85FB719C1F6838B52954DB1FF1A0D881 sha1 BA061B01CFD81F5C719D1282F4D920BF54A2A008 )
+	name "Satellite Warrior (Amsoft)"
+	description "Satellite Warrior (Amsoft)"
+	rom ( name "Satellite Warrior (1985)(Amsoft).dsk" size 158464 crc D5E3633D md5 85FB719C1F6838B52954DB1FF1A0D881 sha1 BA061B01CFD81F5C719D1282F4D920BF54A2A008 )
 )
 game (
 	name "Sorcery+ (Amsoft) (France)"
@@ -13470,8 +13480,8 @@ game (
 game (
 	name "Trivial Pursuit - Edition Revolution (Domark) (France)"
 	description "Trivial Pursuit - Edition Revolution (Domark) (France)"
-	rom ( name "Trivial Pursuit - Edition Revolution (1986)(Domark)(fr)(Side B).dsk" size 195635 crc 2E134ED8 md5 8BC4FAD1DE19FF26D05B86320DDD93D6 sha1 E7E43F55D08B325F47666876FDC42AF4F2CB0793 )
 	rom ( name "Trivial Pursuit - Edition Revolution (1986)(Domark)(fr)(Side A).dsk" size 195635 crc 668247D3 md5 536FBD058D2BA8F158A5D9B552E9A1A6 sha1 68E458686E7661EDF33A72533A2BD4CACDE0F330 )
+	rom ( name "Trivial Pursuit - Edition Revolution (1986)(Domark)(fr)(Side B).dsk" size 195635 crc 2E134ED8 md5 8BC4FAD1DE19FF26D05B86320DDD93D6 sha1 E7E43F55D08B325F47666876FDC42AF4F2CB0793 )
 )
 game (
 	name "Tiny Skweeks, The (Loriciels) (France)"
@@ -13600,11 +13610,6 @@ game (
 	name "Through the Trap Door (Piranha)"
 	description "Through the Trap Door (Piranha)"
 	rom ( name "Through the Trap Door (1987)(Piranha).dsk" size 195635 crc 5EEB0371 md5 27536B3B20DDD1F6F830EF853CA53FA0 sha1 E9D56C99048686CF589D9DED7609F1E55E662F7C )
-)
-game (
-	name "Transx (G.T.S Editorial) (Spain)"
-	description "Transx (G.T.S Editorial) (Spain)"
-	rom ( name "Transx (1987)(G.T.S Editorial)(es)[cr].dsk" size 194816 crc 3BEF5D59 md5 81972B13AA22504BC64387B69A67E831 sha1 A3C6B7AEB8A8F4BF44787980E5024C16F4EA59F1 )
 )
 game (
 	name "Trik Trak (Wave Software)"
@@ -13949,6 +13954,11 @@ game (
 	rom ( name "Tensions (1986)(ERE Informatique)(M3).dsk" size 133469 crc 8B4B44C1 md5 60AEEDAF4B6CFB7741D2C81F66097805 sha1 5B4D6EAD47C7D9A06229615609175D44565077EC )
 )
 game (
+	name "Transx (G.T.S. Editorial) (Spain)"
+	description "Transx (G.T.S. Editorial) (Spain)"
+	rom ( name "Transx (1987)(G.T.S. Editorial)(es)[cr].dsk" size 194816 crc 3BEF5D59 md5 81972B13AA22504BC64387B69A67E831 sha1 A3C6B7AEB8A8F4BF44787980E5024C16F4EA59F1 )
+)
+game (
 	name "Turbo Girl (Dinamic Software) (Spain)"
 	description "Turbo Girl (Dinamic Software) (Spain)"
 	rom ( name "Turbo Girl (1988)(Dinamic Software)(es).dsk" size 80641 crc 77C7C536 md5 4539F45C55B31672B2DC22269FC0C636 sha1 0D59E7EB49328408F61F2E33A3138A74019B73BE )
@@ -14068,7 +14078,7 @@ game (
 game (
 	name "Vera Cruz Affair, The (Infogrames)"
 	description "Vera Cruz Affair, The (Infogrames)"
-	rom ( name "Vera Cruz Affair, The (1986)(Infogrames)[CPM].dsk" size 194048 crc 4F6B8AE6 md5 99A15BE332474895BDBC68E9F6C0E626 sha1 BD1C49D9FEDD59998ADEFE55898042C16ED04513 )
+	rom ( name "Vera Cruz Affair, The (1986)(Infogrames).dsk" size 194048 crc 4F6B8AE6 md5 99A15BE332474895BDBC68E9F6C0E626 sha1 BD1C49D9FEDD59998ADEFE55898042C16ED04513 )
 )
 game (
 	name "Village of Lost Souls (Robico Software)"
@@ -14387,6 +14397,11 @@ game (
 	rom ( name "Wacky Orchard (1985)(Argus Press Software)[cr].dsk" size 194816 crc 5BA4FA75 md5 E628CC5B117E3C1AB0437001AECB7406 sha1 B23B00F54F3529239F849F5CBCC60FD181A031D6 )
 )
 game (
+	name "Witness, The (Infocom)"
+	description "Witness, The (Infocom)"
+	rom ( name "Witness, The (1984)(Infocom)[CPM].dsk" size 195635 crc B16409A2 md5 EF5BD5F009F18D94585214A52DD0156D sha1 177E802B15903F6C781FB8DC0BF8C727273AD041 )
+)
+game (
 	name "WWF Wrestlemania (Ocean Software)"
 	description "WWF Wrestlemania (Ocean Software)"
 	rom ( name "WWF Wrestlemania (1991)(Ocean Software).dsk" size 217457 crc 6533FB5 md5 09071A18FA86B7FAF89F9EF588188203 sha1 AAFA5953B58C777E50736EFBCB51FBB58F0977B4 )
@@ -14465,7 +14480,7 @@ game (
 game (
 	name "Wishbringer (Infocom)"
 	description "Wishbringer (Infocom)"
-	rom ( name "Wishbringer (1985)(Infocom)[CPM].dsk" size 195635 crc B16409A2 md5 EF5BD5F009F18D94585214A52DD0156D sha1 177E802B15903F6C781FB8DC0BF8C727273AD041 )
+	rom ( name "Wishbringer (1985)(Infocom)[CPM].dsk" size 195635 crc 5332C3AD md5 A2AD7C5C578C4368270397B4AD4C7390 sha1 305E6DE9EFBCEC4E59EBB7FE487845848E33BCBB )
 )
 game (
 	name "Wanderer 3D (Elite Systems)"
@@ -14753,9 +14768,9 @@ game (
 	name "Zap 't' Balls (NoName EDV-Service)"
 	description "Zap 't' Balls (NoName EDV-Service)"
 	rom ( name "Zap 't' Balls (1992)(NoName EDV-Service)(Side A)[QWERTY].dsk" size 207360 crc E434E0DB md5 610D62A3FC2D067967321A09AC673FFA sha1 38190DDE633AFD09FBA3810772E13A7A9D0CF75C )
-	rom ( name "Zap 't' Balls (1992)(NoName EDV-Service)(Side B)[QWERTY].dsk" size 196608 crc 1976725 md5 460D1EA708F44BF1A53E8B9F0944C487 sha1 C526143634415757935E8EC794EBC0EAB9B6416D )
 	rom ( name "Zap 't' Balls (1992)(NoName EDV-Service)(Side A)[AZERTY].dsk" size 203264 crc 8559909A md5 101809789150E04DD9F84295ED20B6C6 sha1 A12F8565650AD85B5AD1085EA5C77104EEA537F8 )
 	rom ( name "Zap 't' Balls (1992)(NoName EDV-Service)(Side B)[AZERTY].dsk" size 196608 crc 318284F3 md5 A515EE1B728367A75634F0A33B46EA9A sha1 D81B143E40347F20BC53419CDBAD5965B80867E1 )
+	rom ( name "Zap 't' Balls (1992)(NoName EDV-Service)(Side B)[QWERTY].dsk" size 196608 crc 1976725 md5 460D1EA708F44BF1A53E8B9F0944C487 sha1 C526143634415757935E8EC794EBC0EAB9B6416D )
 )
 game (
 	name "Zox 2099 (Loriciels) (France)"
@@ -14822,11 +14837,6 @@ game (
 	name "Zeichner, Der (Bollaware) (de)"
 	description "Zeichner, Der (Bollaware) (de)"
 	rom ( name "Zeichner, Der (1988)(Bollaware)(de)[cr].dsk" size 194816 crc A831626E md5 EB289BC65151755454A7E8FA25509606 sha1 67746BE94E68E2A8820F2DD0F4AF36F23781C13A )
-)
-game (
-	name "Zombi (Face B)"
-	description "Zombi (Face B)"
-	rom ( name "Zombi (F) (Face B) (1986) (v1) [Original].dsk" size 195635 crc 38108FE5 md5 A953B7FFA615AE52571D7B00BF678167 sha1 C0D9583574E5E35559A5C6551D2079CC33F01E93 )
 )
 game (
 	name "Zub (Mastertronic)"

--- a/dat/Amstrad - CPC.dat
+++ b/dat/Amstrad - CPC.dat
@@ -77,8 +77,8 @@ game (
 game (
 	name "20000 Lieus sous les Mers (Coktel Vision) (France)"
 	description "20000 Lieus sous les Mers (Coktel Vision) (France)"
-	rom ( name "20000 Lieus sous les Mers (1988)(Coktel Vision)(fr)(Side A)[CPM].dsk" size 200537 crc B8B6A065 md5 F4263CDC072C7A3F8699F74BD5B5F49E sha1 934C08B96AC2C1FD6E7131C096536E51E4FD0A7F )
 	rom ( name "20000 Lieus sous les Mers (1988)(Coktel Vision)(fr)(Side B).dsk" size 195635 crc 1037BC27 md5 A438C72B844CDF391787F105D14A8B73 sha1 55007DCD59B35A72892084B8702723F0184E9838 )
+	rom ( name "20000 Lieus sous les Mers (1988)(Coktel Vision)(fr)(Side A)[CPM].dsk" size 200537 crc B8B6A065 md5 F4263CDC072C7A3F8699F74BD5B5F49E sha1 934C08B96AC2C1FD6E7131C096536E51E4FD0A7F )
 )
 game (
 	name "720 Degrees (US Gold)"
@@ -153,8 +153,8 @@ game (
 game (
 	name "007 - The Spy Who Loved Me (Domark)"
 	description "007 - The Spy Who Loved Me (Domark)"
-	rom ( name "007 - The Spy Who Loved Me (1990)(Domark)(Side A).dsk" size 194816 crc 81DF2EE2 md5 53DD42BA3A70E7676C4EA3AD09CF4589 sha1 88B7F4081E9E78D2587DA92BF6352B19B6A331F2 )
 	rom ( name "007 - The Spy Who Loved Me (1990)(Domark)(Side B)[64K].dsk" size 194816 crc 777ACC7F md5 4E76D225124E7196686327CE8743C1BC sha1 F412292ADFA794488D885B2F993EB5443757478D )
+	rom ( name "007 - The Spy Who Loved Me (1990)(Domark)(Side A).dsk" size 194816 crc 81DF2EE2 md5 53DD42BA3A70E7676C4EA3AD09CF4589 sha1 88B7F4081E9E78D2587DA92BF6352B19B6A331F2 )
 )
 game (
 	name "007 - The Living Daylights (Domark)"
@@ -209,8 +209,8 @@ game (
 game (
 	name "3 Guerra Mundial (Pactum) (Spain)"
 	description "3 Guerra Mundial (Pactum) (Spain)"
-	rom ( name "3 Guerra Mundial (1989)(Pactum)(es)(Side A)[cr].dsk" size 194816 crc 9F378 md5 715FE711FF52F7020ADE18B33B67109B sha1 D71111873D00A89D0CF36B7EB4E28BC26CE59C54 )
 	rom ( name "3 Guerra Mundial (1989)(Pactum)(es)(Side B)[cr].dsk" size 194816 crc A4663877 md5 2166A5977192960575FBDF80BA90F3BA sha1 99FE02FEC391366F02F203B613CEB0F86B47E9F0 )
+	rom ( name "3 Guerra Mundial (1989)(Pactum)(es)(Side A)[cr].dsk" size 194816 crc 9F378 md5 715FE711FF52F7020ADE18B33B67109B sha1 D71111873D00A89D0CF36B7EB4E28BC26CE59C54 )
 )
 game (
 	name "007 - A View To A Kill (Domark)"
@@ -245,8 +245,8 @@ game (
 game (
 	name "Arachnophobia (Titus) (M5)"
 	description "Arachnophobia (Titus) (M5)"
-	rom ( name "Arachnophobia (1991)(Titus)(M5)(Side A).dsk" size 195635 crc 1F368D7B md5 DED65FD05888D8FE2E88DA897E41BDCD sha1 57A136F70B7D0066EE125E7676CFB191011F55D7 )
 	rom ( name "Arachnophobia (1991)(Titus)(M5)(Side B).dsk" size 195637 crc D207F993 md5 F75DF025F4F131F7627FB6077C207FDD sha1 11EFE435A028E4A42BE72FC28A9F109D05CB4858 )
+	rom ( name "Arachnophobia (1991)(Titus)(M5)(Side A).dsk" size 195635 crc 1F368D7B md5 DED65FD05888D8FE2E88DA897E41BDCD sha1 57A136F70B7D0066EE125E7676CFB191011F55D7 )
 )
 game (
 	name "Aton (Sygram) (Spain)"
@@ -376,14 +376,14 @@ game (
 game (
 	name "Alien Storm (US Gold)"
 	description "Alien Storm (US Gold)"
-	rom ( name "Alien Storm (1991)(US Gold)(v2)(Side A).dsk" size 255232 crc 92E55932 md5 874149B56A2F3140785D998B6ED6C21E sha1 AAFA6C4024BFB7CB9CB74EFD994049861D4C9ED9 )
 	rom ( name "Alien Storm (1991)(US Gold)(v2)(Side B).dsk" size 256256 crc 5DBBEE95 md5 4EEA948F0F6F73F1528A614CE12F9C59 sha1 1D72DE01D36764370A691CC039AF8B3EE06AF548 )
+	rom ( name "Alien Storm (1991)(US Gold)(v2)(Side A).dsk" size 255232 crc 92E55932 md5 874149B56A2F3140785D998B6ED6C21E sha1 AAFA6C4024BFB7CB9CB74EFD994049861D4C9ED9 )
 )
 game (
 	name "Asterix Chez Rahazade (Coktel Vision) (France)"
 	description "Asterix Chez Rahazade (Coktel Vision) (France)"
-	rom ( name "Asterix Chez Rahazade (1988)(Coktel Vision)(fr)(Side A).dsk" size 198211 crc 33E38C87 md5 A4A62013C39FF479E69C6F0539334EE7 sha1 BCCF1395FFF59A4894FFA034D4DE15676C4A67A8 )
 	rom ( name "Asterix Chez Rahazade (1988)(Coktel Vision)(fr)(Side B).dsk" size 195635 crc DCF9AE3E md5 0D1F9862D0DE7A64C8633DB11C0829CA sha1 0127E0DCB00D9B3C1023791720D0441549A57BDA )
+	rom ( name "Asterix Chez Rahazade (1988)(Coktel Vision)(fr)(Side A).dsk" size 198211 crc 33E38C87 md5 A4A62013C39FF479E69C6F0539334EE7 sha1 BCCF1395FFF59A4894FFA034D4DE15676C4A67A8 )
 )
 game (
 	name "Archon (Electronic Arts)"
@@ -483,8 +483,8 @@ game (
 game (
 	name "Aussie Safari (U.S.Gold)"
 	description "Aussie Safari (U.S.Gold)"
-	rom ( name "Aussie Safari (1990)(U.S.Gold)(Side A).dsk" size 194816 crc 23768ED0 md5 4E1683F76818BBE6CB2AEB2A4D4E5FE1 sha1 EB11B503AB6365370FF50E026B7702E16BE90569 )
 	rom ( name "Aussie Safari (1990)(U.S.Gold)(Side B).dsk" size 194816 crc 1E31AA5 md5 59E1C144D5E4E7DEB8EE559C4B157AFA sha1 92D5B9CD588EE2F08E1FC785952B63273BEF435E )
+	rom ( name "Aussie Safari (1990)(U.S.Gold)(Side A).dsk" size 194816 crc 23768ED0 md5 4E1683F76818BBE6CB2AEB2A4D4E5FE1 sha1 EB11B503AB6365370FF50E026B7702E16BE90569 )
 )
 game (
 	name "Alien Break-In (Romik Software - Amsoft) (Spain)"
@@ -544,8 +544,8 @@ game (
 game (
 	name "Anneau de Zengara (Ubi Soft) (France)"
 	description "Anneau de Zengara (Ubi Soft) (France)"
-	rom ( name "Anneau de Zengara (1987)(Ubi Soft)(fr)(Side A).dsk" size 228352 crc 934357AE md5 F5F6A1092CEFE3C29FF9E33E36F97DDF sha1 77BB91B09DDE1C9D66730C30E0A8EB47EA94FE21 )
 	rom ( name "Anneau de Zengara (1987)(Ubi Soft)(fr)(Side B).dsk" size 229291 crc 29F788A1 md5 A682216C1DD8DA79CDF3FC635339AB98 sha1 1C17ADFBB015AF67D7670D77DC77CB53F67DD468 )
+	rom ( name "Anneau de Zengara (1987)(Ubi Soft)(fr)(Side A).dsk" size 228352 crc 934357AE md5 F5F6A1092CEFE3C29FF9E33E36F97DDF sha1 77BB91B09DDE1C9D66730C30E0A8EB47EA94FE21 )
 )
 game (
 	name "Aventures de Moktar, Les (Titus) (France)"
@@ -580,8 +580,8 @@ game (
 game (
 	name "Alphakhor (Loriciels) (France)"
 	description "Alphakhor (Loriciels) (France)"
-	rom ( name "Alphakhor (1989)(Loriciels)(fr)(Side A).dsk" size 196915 crc 483D8366 md5 3B2F2EC4ABB0E13AE988C7037CC775C1 sha1 4C0B1BDD46C9D8F35F8E1910D0B0E44BFE442D47 )
 	rom ( name "Alphakhor (1989)(Loriciels)(fr)(Side B).dsk" size 195635 crc 2A7AD414 md5 BB4FD05BC48BBF6908BC7224FA069C37 sha1 10F6E50532A1AFC9F75E77327F529B51B4AFE287 )
+	rom ( name "Alphakhor (1989)(Loriciels)(fr)(Side A).dsk" size 196915 crc 483D8366 md5 3B2F2EC4ABB0E13AE988C7037CC775C1 sha1 4C0B1BDD46C9D8F35F8E1910D0B0E44BFE442D47 )
 )
 game (
 	name "Adult One (Simon Avery)"
@@ -596,8 +596,8 @@ game (
 game (
 	name "Affaire Santa Fe, L' (Infogrames) (France)"
 	description "Affaire Santa Fe, L' (Infogrames) (France)"
-	rom ( name "Affaire Santa Fe, L' (1988)(Infogrames)(fr)(Side A).dsk" size 197171 crc 2203C641 md5 14CA226DEAE0A4655CEBDCCA72508866 sha1 3EED85A33ACCA54306100DB9F4BF4A6A8246970B )
 	rom ( name "Affaire Santa Fe, L' (1988)(Infogrames)(fr)(Side B).dsk" size 195635 crc 2EB9DE77 md5 3D71C4D7BEF5B3D0B794DE4FBE782F3B sha1 6C8F5B60046FDD82F368740B0F6299539F63BE0D )
+	rom ( name "Affaire Santa Fe, L' (1988)(Infogrames)(fr)(Side A).dsk" size 197171 crc 2203C641 md5 14CA226DEAE0A4655CEBDCCA72508866 sha1 3EED85A33ACCA54306100DB9F4BF4A6A8246970B )
 )
 game (
 	name "Axys - The Last Battle (CPC Infos, Amstar)"
@@ -612,8 +612,8 @@ game (
 game (
 	name "A320 (Loriciels) (France)"
 	description "A320 (Loriciels) (France)"
-	rom ( name "A320 (1989)(Loriciels)(fr)(Side A).dsk" size 276037 crc AA9F21C3 md5 B85E8BCC673FE714B1212D50D5509B31 sha1 ED9CF9E86CF6A5E15FD49D8567B8CE80C631935A )
 	rom ( name "A320 (1989)(Loriciels)(fr)(Side B).dsk" size 274501 crc 5909D93B md5 CFDD928F20724CD5B3632E914E0D3E90 sha1 CE172A7CDA40AE097FBCD0918319FFEA7D6E4C0A )
+	rom ( name "A320 (1989)(Loriciels)(fr)(Side A).dsk" size 276037 crc AA9F21C3 md5 B85E8BCC673FE714B1212D50D5509B31 sha1 ED9CF9E86CF6A5E15FD49D8567B8CE80C631935A )
 )
 game (
 	name "Atlantis (Cobra Soft) (France)"
@@ -643,8 +643,8 @@ game (
 game (
 	name "Asterix En La India (Coktel Vision) (Spain)"
 	description "Asterix En La India (Coktel Vision) (Spain)"
-	rom ( name "Asterix En La India (1988)(Coktel Vision)(es)(Side A).dsk" size 194816 crc 392FBB50 md5 E97265CA9D6EE823DC482422BCEE5025 sha1 1C6A914AE4231A6025C50A4915E3F279F708CFA6 )
 	rom ( name "Asterix En La India (1988)(Coktel Vision)(es)(Side B).dsk" size 194816 crc 9C7A44E8 md5 34110717B9916A677E2882D77E1A72CC sha1 29F3D953513B50280D91C3A642D3B41C76CE092E )
+	rom ( name "Asterix En La India (1988)(Coktel Vision)(es)(Side A).dsk" size 194816 crc 392FBB50 md5 E97265CA9D6EE823DC482422BCEE5025 sha1 1C6A914AE4231A6025C50A4915E3F279F708CFA6 )
 )
 game (
 	name "Asterix et la Potion Magique (Coktel Vision) (France)"
@@ -659,8 +659,8 @@ game (
 game (
 	name "Affaire Ravenhood, L' (Bruno Fonters) (France)"
 	description "Affaire Ravenhood, L' (Bruno Fonters) (France)"
-	rom ( name "Affaire Ravenhood, L' (1993)(Bruno Fonters)(fr)(Side A)[cr].dsk" size 194816 crc 33F566E2 md5 ADEA7189E780AF99DFF9CC4F2FF1C69F sha1 5DD67FE3B292AAB19F22C171DA5BE3E6ACBE5863 )
 	rom ( name "Affaire Ravenhood, L' (1993)(Bruno Fonters)(fr)(Side B)[cr].dsk" size 194816 crc 5497709A md5 BD2891EA648EF31588B6BD4C37C943B0 sha1 D530E75F826FF17E08132482E11F41C68249339D )
+	rom ( name "Affaire Ravenhood, L' (1993)(Bruno Fonters)(fr)(Side A)[cr].dsk" size 194816 crc 33F566E2 md5 ADEA7189E780AF99DFF9CC4F2FF1C69F sha1 5DD67FE3B292AAB19F22C171DA5BE3E6ACBE5863 )
 )
 game (
 	name "Aliens US (Electric Dreams Software)"
@@ -675,8 +675,8 @@ game (
 game (
 	name "Attentat (Rainbow Productions) (France)"
 	description "Attentat (Rainbow Productions) (France)"
-	rom ( name "Attentat (1986)(Rainbow Productions)(fr)(Side A).dsk" size 198211 crc 14DB334C md5 D08D66D488146271FD1EFC4978E0E847 sha1 088F0F6B1350CA3D2256B152304E0EC18231D31D )
 	rom ( name "Attentat (1986)(Rainbow Productions)(fr)(Side B).dsk" size 198211 crc 1DCB721A md5 4BE79E1DDBF1DA3FCB0E73764675B863 sha1 092CBA5678C269F9A3488A724527D2F9582DDDB3 )
+	rom ( name "Attentat (1986)(Rainbow Productions)(fr)(Side A).dsk" size 198211 crc 14DB334C md5 D08D66D488146271FD1EFC4978E0E847 sha1 088F0F6B1350CA3D2256B152304E0EC18231D31D )
 )
 game (
 	name "Attack of the Killer Tomatoes (Global Software)"
@@ -721,8 +721,8 @@ game (
 game (
 	name "Aventures de Pepito au Mexique, Les (Microids) (France)"
 	description "Aventures de Pepito au Mexique, Les (Microids) (France)"
-	rom ( name "Aventures de Pepito au Mexique, Les (1991)(Microids)(fr)(Side A).dsk" size 54057 crc E6769F19 md5 C769EA93DCE1F3B3CD587394128238E4 sha1 DC16B89624F4BEE6F855506EF1A1EA6BFB5D32B1 )
 	rom ( name "Aventures de Pepito au Mexique, Les (1991)(Microids)(fr)(Side B).dsk" size 205399 crc 9D6EE380 md5 1699DC1BA7D39B3CB318BF5725745CFA sha1 D7D4AC52FAFE802AA4E50674E68AC8FDC28E06BD )
+	rom ( name "Aventures de Pepito au Mexique, Les (1991)(Microids)(fr)(Side A).dsk" size 54057 crc E6769F19 md5 C769EA93DCE1F3B3CD587394128238E4 sha1 DC16B89624F4BEE6F855506EF1A1EA6BFB5D32B1 )
 )
 game (
 	name "Arctic Fox (Electronic Arts)"
@@ -762,14 +762,14 @@ game (
 game (
 	name "Antre de Gork, L' (Excalibur) (France)"
 	description "Antre de Gork, L' (Excalibur) (France)"
-	rom ( name "Antre de Gork, L' (1987)(Excalibur)(fr)(Side A)[f].dsk" size 198211 crc EA140F7F md5 0A05744BCF187B888D7CECEC6538B978 sha1 BA24C898B6FF6DE43CC32F6CAA2302DD4FFEBBBC )
 	rom ( name "Antre de Gork, L' (1987)(Excalibur)(fr)(Side B)[f].dsk" size 198211 crc 6A1948EB md5 869052D941DED0A8F8C3E5EF1D851678 sha1 32811C4683C23B5D709D7F3637A32FE315714D82 )
+	rom ( name "Antre de Gork, L' (1987)(Excalibur)(fr)(Side A)[f].dsk" size 198211 crc EA140F7F md5 0A05744BCF187B888D7CECEC6538B978 sha1 BA24C898B6FF6DE43CC32F6CAA2302DD4FFEBBBC )
 )
 game (
 	name "A Question Of Scruples (Leisure Genius)"
 	description "A Question Of Scruples (Leisure Genius)"
-	rom ( name "A Question Of Scruples (1987)(Leisure Genius)(Side A).dsk" size 201683 crc 4AF53293 md5 5BA1BC6BA65476D90D9AC60BC8826AE2 sha1 ACB4F923406361DAD11DE1942D8E9CA673CCEF40 )
 	rom ( name "A Question Of Scruples (1987)(Leisure Genius)(Side B).dsk" size 97995 crc 9C2ABA13 md5 01A43C32CF723A61EB7DBB1D82520752 sha1 C709EB980565A7BD33CD8B1B9C8C3B0D886B0B14 )
+	rom ( name "A Question Of Scruples (1987)(Leisure Genius)(Side A).dsk" size 201683 crc 4AF53293 md5 5BA1BC6BA65476D90D9AC60BC8826AE2 sha1 ACB4F923406361DAD11DE1942D8E9CA673CCEF40 )
 )
 game (
 	name "Atlantis (Anirog Software)"
@@ -794,8 +794,8 @@ game (
 game (
 	name "Airborne Ranger (Microprose Software)"
 	description "Airborne Ranger (Microprose Software)"
-	rom ( name "Airborne Ranger (1988)(Microprose Software)(Side A).dsk" size 195635 crc 5FC272B4 md5 F1FAF49C7C43A37C811A2FFF70CB5FEE sha1 1E4B870F27780381F807B1F9350DEEC3D87AEC57 )
 	rom ( name "Airborne Ranger (1988)(Microprose Software)(Side B).dsk" size 195635 crc 635C9042 md5 48CAF17238C356514B1522C9F9713BD1 sha1 9ADD1999DE2345E72DC1DA08A2AA1AF934CF37B9 )
+	rom ( name "Airborne Ranger (1988)(Microprose Software)(Side A).dsk" size 195635 crc 5FC272B4 md5 F1FAF49C7C43A37C811A2FFF70CB5FEE sha1 1E4B870F27780381F807B1F9350DEEC3D87AEC57 )
 )
 game (
 	name "Archon II - Adept (Electronic Arts)"
@@ -805,8 +805,8 @@ game (
 game (
 	name "Asterix Im Morgenland (Coktel Vision) (de)"
 	description "Asterix Im Morgenland (Coktel Vision) (de)"
-	rom ( name "Asterix Im Morgenland (1988)(Coktel Vision)(de)(Side A).dsk" size 198211 crc 31D37BA2 md5 76D6E4325EE129197B1E058EC2842C21 sha1 8DD69499A8BC654EF04D0B620629581234204539 )
 	rom ( name "Asterix Im Morgenland (1988)(Coktel Vision)(de)(Side B).dsk" size 195635 crc C1508616 md5 2819F0472BDADE793DB636ACF8AB7647 sha1 6317C29F8B7F7B9AC853A7B677DDB61610747C6A )
+	rom ( name "Asterix Im Morgenland (1988)(Coktel Vision)(de)(Side A).dsk" size 198211 crc 31D37BA2 md5 76D6E4325EE129197B1E058EC2842C21 sha1 8DD69499A8BC654EF04D0B620629581234204539 )
 )
 game (
 	name "Alex Higgins World Snooker (Amsoft)"
@@ -826,8 +826,8 @@ game (
 game (
 	name "A-Team, The (Zafiro Software Division) (Spain) (LightGun)"
 	description "A-Team, The (Zafiro Software Division) (Spain) (LightGun)"
-	rom ( name "A-Team, The (1989)(Zafiro Software Division)(es)(LightGun)(Side A).dsk" size 74752 crc 2BE8B9DD md5 A66CF48F4A8EE33FD04C1A15F1E293D1 sha1 3C050347BEE3B95DDD23C75AF85854CCC310C3D7 )
 	rom ( name "A-Team, The (1989)(Zafiro Software Division)(es)(LightGun)(Side B).dsk" size 93184 crc 47FC2EDC md5 670D9CE83273830FD623C04F92FD8965 sha1 F826D1FC3B9EEEB3D9055924548B747473F61DD8 )
+	rom ( name "A-Team, The (1989)(Zafiro Software Division)(es)(LightGun)(Side A).dsk" size 74752 crc 2BE8B9DD md5 A66CF48F4A8EE33FD04C1A15F1E293D1 sha1 3C050347BEE3B95DDD23C75AF85854CCC310C3D7 )
 )
 game (
 	name "Abbey Of Crime, The (Opera Soft) (Hack)"
@@ -867,8 +867,8 @@ game (
 game (
 	name "Altered Beast (Activision)"
 	description "Altered Beast (Activision)"
-	rom ( name "Altered Beast (1989)(Activision)(Side A).dsk" size 215171 crc E9E99D67 md5 33C024753701A88FBD6759BF25AED82A sha1 9AB6AE8370428719BBAE35CEAB4FC1B844A2D0DD )
 	rom ( name "Altered Beast (1989)(Activision)(Side B).dsk" size 195635 crc 1DD7E040 md5 81F51A8188D5B20106A36C41FE378FD8 sha1 99138E884030A89B5AACB7F3F727E4F682F3CC27 )
+	rom ( name "Altered Beast (1989)(Activision)(Side A).dsk" size 215171 crc E9E99D67 md5 33C024753701A88FBD6759BF25AED82A sha1 9AB6AE8370428719BBAE35CEAB4FC1B844A2D0DD )
 )
 game (
 	name "African Trail Simulator (Positive) (M2)"
@@ -953,8 +953,8 @@ game (
 game (
 	name "A-Team, The (Zafiro Software Division) (Spain)"
 	description "A-Team, The (Zafiro Software Division) (Spain)"
-	rom ( name "A-Team, The (1989)(Zafiro Software Division)(es)(Side A).dsk" size 74752 crc 49389379 md5 E320D2D6C327556A5069A5ADE6B2A2F0 sha1 276757A4CB1B80632A6CBB96AB50F4482EBD763A )
 	rom ( name "A-Team, The (1989)(Zafiro Software Division)(es)(Side B).dsk" size 93184 crc 7BE35474 md5 83431BD2B7533FDF4B00881E27C68912 sha1 A3E41DA3CFC68E0C57B54099347ED95DB73637CD )
+	rom ( name "A-Team, The (1989)(Zafiro Software Division)(es)(Side A).dsk" size 74752 crc 49389379 md5 E320D2D6C327556A5069A5ADE6B2A2F0 sha1 276757A4CB1B80632A6CBB96AB50F4482EBD763A )
 )
 game (
 	name "Alien 8 (Ultimate Play The Game)"
@@ -979,8 +979,8 @@ game (
 game (
 	name "A la Pursuite de Carmen Sandiego dans le Monde (Broderbund Software) (France)"
 	description "A la Pursuite de Carmen Sandiego dans le Monde (Broderbund Software) (France)"
-	rom ( name "A la Pursuite de Carmen Sandiego dans le Monde (1990)(Broderbund Software)(fr)(Side A).dsk" size 205399 crc C0405F10 md5 244CB3C112B1EACF3A48B501ED56C63E sha1 017AF2ADB0ABDA29356AF84DCBFC08809E54E7A2 )
 	rom ( name "A la Pursuite de Carmen Sandiego dans le Monde (1990)(Broderbund Software)(fr)(Side B).dsk" size 205399 crc 3E909EFF md5 066E95E1A0C66B9B6B20563AA9AB37B2 sha1 6AFB89E5DC71C26FD1F10A2FD828D947D881CBAF )
+	rom ( name "A la Pursuite de Carmen Sandiego dans le Monde (1990)(Broderbund Software)(fr)(Side A).dsk" size 205399 crc C0405F10 md5 244CB3C112B1EACF3A48B501ED56C63E sha1 017AF2ADB0ABDA29356AF84DCBFC08809E54E7A2 )
 )
 game (
 	name "Army Moves (Dinamic Software) (Spain)"
@@ -990,8 +990,8 @@ game (
 game (
 	name "Alive (Lankhor) (France)"
 	description "Alive (Lankhor) (France)"
-	rom ( name "Alive (1991)(Lankhor)(fr)(Side A).dsk" size 274009 crc E0A5E28A md5 C928C4A1DE961698F0DEC848D8FB0153 sha1 939E11070F7BED099F4B062D6AE0AB59CD867A7F )
 	rom ( name "Alive (1991)(Lankhor)(fr)(Side B).dsk" size 195635 crc EE0DB8B md5 EFFBF5B3052EB25BF49ED365A93F8F29 sha1 B232CB64FE1E2DDA4A2BE58A3396442EBD3E8BBC )
+	rom ( name "Alive (1991)(Lankhor)(fr)(Side A).dsk" size 274009 crc E0A5E28A md5 C928C4A1DE961698F0DEC848D8FB0153 sha1 939E11070F7BED099F4B062D6AE0AB59CD867A7F )
 )
 game (
 	name "Alkahera (Rino Marketing)"
@@ -1176,8 +1176,8 @@ game (
 game (
 	name "Abracadabra (Proein Soft Line) (Spain)"
 	description "Abracadabra (Proein Soft Line) (Spain)"
-	rom ( name "Abracadabra (1988)(Proein Soft Line)(es)(Side A).dsk" size 194816 crc 1789290E md5 94D74F7835E5B92F4FDE9CA90F474227 sha1 32CA07E06A95FC035AD4BFC5412AE5641A917318 )
 	rom ( name "Abracadabra (1988)(Proein Soft Line)(es)(Side B).dsk" size 194816 crc DCB960F9 md5 D2121B019569203F1F09F24C077CC596 sha1 28C1BF11B0EC44C9F12DBE9131DF545376530AC0 )
+	rom ( name "Abracadabra (1988)(Proein Soft Line)(es)(Side A).dsk" size 194816 crc 1789290E md5 94D74F7835E5B92F4FDE9CA90F474227 sha1 32CA07E06A95FC035AD4BFC5412AE5641A917318 )
 )
 game (
 	name "Alex Higgins World Pool (Amsoft)"
@@ -1277,8 +1277,8 @@ game (
 game (
 	name "Bored of the Rings (Silversoft)"
 	description "Bored of the Rings (Silversoft)"
-	rom ( name "Bored of the Rings (1985)(Silversoft)(Side A).dsk" size 195633 crc B4E66EDC md5 82CA14F26B969305A50002C715DE9B27 sha1 E888833C26700CE07A9FB1B37D00216381FBC3CF )
 	rom ( name "Bored of the Rings (1985)(Silversoft)(Side B).dsk" size 195633 crc FF288ABD md5 DA28FEBF6659BE80BEDA5ED5142984AB sha1 74594162258E0BCC7B0AF008D0C181CBF2219612 )
+	rom ( name "Bored of the Rings (1985)(Silversoft)(Side A).dsk" size 195633 crc B4E66EDC md5 82CA14F26B969305A50002C715DE9B27 sha1 E888833C26700CE07A9FB1B37D00216381FBC3CF )
 )
 game (
 	name "Blue Star (Free Game Blot) (France)"
@@ -1303,8 +1303,8 @@ game (
 game (
 	name "Back to the Future II (Image Works)"
 	description "Back to the Future II (Image Works)"
-	rom ( name "Back to the Future II (1990)(Image Works)(Side A).dsk" size 210944 crc 3CB7F8E6 md5 7A4101E06239BABE394ECC44F56A5881 sha1 4551632D526E37BD3ADC6CADEA70BB4E9BB21825 )
 	rom ( name "Back to the Future II (1990)(Image Works)(Side B).dsk" size 194816 crc 11BFE1E9 md5 174763F353CC62916CB493F77204C0C5 sha1 2AAEFDE072375655BFD4C37D34D22720C00BD0E8 )
+	rom ( name "Back to the Future II (1990)(Image Works)(Side A).dsk" size 210944 crc 3CB7F8E6 md5 7A4101E06239BABE394ECC44F56A5881 sha1 4551632D526E37BD3ADC6CADEA70BB4E9BB21825 )
 )
 game (
 	name "Baba's Palace (cpcretrodev.byterealms)"
@@ -1344,8 +1344,8 @@ game (
 game (
 	name "Back To The Future III (Image Works)"
 	description "Back To The Future III (Image Works)"
-	rom ( name "Back To The Future III (1990)(Image Works)(Side A).dsk" size 202557 crc 9F759EB0 md5 034BFC898307834101EC5DC07728040C sha1 EDBB158D2E8B6EE7CC1BE671A1C9A513CA9E9A98 )
 	rom ( name "Back To The Future III (1990)(Image Works)(Side B).dsk" size 195635 crc 2FC30262 md5 0B5548A791659A1FC25BD0E7F5B13187 sha1 4FFD1D07EACD00FF955162D8006C90486D7F1623 )
+	rom ( name "Back To The Future III (1990)(Image Works)(Side A).dsk" size 202557 crc 9F759EB0 md5 034BFC898307834101EC5DC07728040C sha1 EDBB158D2E8B6EE7CC1BE671A1C9A513CA9E9A98 )
 )
 game (
 	name "Bronx (MCM Software) (Spain)"
@@ -1385,8 +1385,8 @@ game (
 game (
 	name "Back to the Golden Age (Ubi Soft) (France)"
 	description "Back to the Golden Age (Ubi Soft) (France)"
-	rom ( name "Back to the Golden Age (1991)(Ubi Soft)(fr)(Side A).dsk" size 195635 crc E5C3E538 md5 34D07717EE7F505FF07A9C5C4592D1F4 sha1 DE51EE28E81002E800BFAD1A58D39CB40F00DEDF )
 	rom ( name "Back to the Golden Age (1991)(Ubi Soft)(fr)(Side B).dsk" size 195635 crc 97EAB65C md5 ACB49373B09E6713E9C4F8429EEF8291 sha1 64AC158461513791F876CF8E2E3431B08F75D12F )
+	rom ( name "Back to the Golden Age (1991)(Ubi Soft)(fr)(Side A).dsk" size 195635 crc E5C3E538 md5 34D07717EE7F505FF07A9C5C4592D1F4 sha1 DE51EE28E81002E800BFAD1A58D39CB40F00DEDF )
 )
 game (
 	name "Bob Morane - Chevalerie (Infogrames) (France)"
@@ -1446,11 +1446,11 @@ game (
 game (
 	name "Black Land (Bollaware)"
 	description "Black Land (Bollaware)"
-	rom ( name "Black Land (1995)(Bollaware)(Disk 1 Side A)[cr].dsk" size 225024 crc 3C0251BF md5 F62C9979EB109122C36EF875A142888A sha1 63EC00CF2ED8491808FD3565A4F557891937D47D )
 	rom ( name "Black Land (1995)(Bollaware)(Disk 1 Side B)[cr].dsk" size 226048 crc 9D7D2CF0 md5 6F9962F03AB192105899B739BAB3205B sha1 1902A39CBE7DE14724263B19A74229150B8B8389 )
 	rom ( name "Black Land (1995)(Bollaware)(Disk 2 Side A)[cr].dsk" size 226048 crc FE1CACCB md5 9799B329B70768F049075D7E63EEA1D7 sha1 932D9314880928242E66CDE9E5C6253C777E164D )
 	rom ( name "Black Land (1995)(Bollaware)(Disk 2 Side B)[cr].dsk" size 226048 crc 7542FB4F md5 8196155BDEDF50005AA86DD4566024FD sha1 AD460050E60CDCD20DBF604593B17883D27826FB )
 	rom ( name "Black Land (1995)(Bollaware)(Disk 3 Side A)[cr].dsk" size 194816 crc 2516908E md5 A2CBAEF1FA0154403F4E463253674585 sha1 761B5571E8C4D9039814ED0966F60C80EB974E19 )
+	rom ( name "Black Land (1995)(Bollaware)(Disk 1 Side A)[cr].dsk" size 225024 crc 3C0251BF md5 F62C9979EB109122C36EF875A142888A sha1 63EC00CF2ED8491808FD3565A4F557891937D47D )
 )
 game (
 	name "Bachou (Central Solutions LTD)"
@@ -1460,16 +1460,16 @@ game (
 game (
 	name "Black Land (Bollaware) (de)"
 	description "Black Land (Bollaware) (de)"
-	rom ( name "Black Land (1995)(Bollaware)(de)(Disk 1 Side A)[cr].dsk" size 225024 crc AA5757B5 md5 6F2846FDF51655324CE42A722F8A18A2 sha1 7266AED3014651990C1FE45AB867D3266BEA604C )
 	rom ( name "Black Land (1995)(Bollaware)(de)(Disk 1 Side B)[cr].dsk" size 226048 crc D31B44EE md5 45811172C8A4E8F144C6084C4112860F sha1 CC4273740612752E9510E101BE578DF50162AB80 )
 	rom ( name "Black Land (1995)(Bollaware)(de)(Disk 2 Side A)[cr].dsk" size 226048 crc B5315D62 md5 6048263A9FC4B3A3386F0B594365A5FC sha1 44FF2152A1CFF9C8B39F28119C933360C0261072 )
 	rom ( name "Black Land (1995)(Bollaware)(de)(Disk 2 Side B)[cr].dsk" size 226048 crc 7F685488 md5 C9BFA956E771B1EBBAF6DC7454239484 sha1 3021B4351DFAE1B7F0D1CBB767DC90B6BB4B76A2 )
+	rom ( name "Black Land (1995)(Bollaware)(de)(Disk 1 Side A)[cr].dsk" size 225024 crc AA5757B5 md5 6F2846FDF51655324CE42A722F8A18A2 sha1 7266AED3014651990C1FE45AB867D3266BEA604C )
 )
 game (
 	name "Bard's Tale, The (Electronic Arts)"
 	description "Bard's Tale, The (Electronic Arts)"
-	rom ( name "Bard's Tale, The (1988)(Electronic Arts)(Side A).dsk" size 196147 crc 24FE433A md5 0506F4BBC799A6525BC82ED015CE0499 sha1 DEA4EBB136BAFD6E8235841738D4D02E04A52651 )
 	rom ( name "Bard's Tale, The (1988)(Electronic Arts)(Side B).dsk" size 196147 crc A2451C8E md5 54D7DD993C404AF2410DB945510D79B9 sha1 19EDF11D180A0486ADFC6AA3B25F404D6CE06E42 )
+	rom ( name "Bard's Tale, The (1988)(Electronic Arts)(Side A).dsk" size 196147 crc 24FE433A md5 0506F4BBC799A6525BC82ED015CE0499 sha1 DEA4EBB136BAFD6E8235841738D4D02E04A52651 )
 )
 game (
 	name "Blip! (Silverbird)"
@@ -1479,8 +1479,8 @@ game (
 game (
 	name "Blaue Kristall, Der (Rainbow Arts) (de)"
 	description "Blaue Kristall, Der (Rainbow Arts) (de)"
-	rom ( name "Blaue Kristall, Der (1985)(Rainbow Arts)(de)(Side A).dsk" size 200517 crc E63C83E md5 DA97274BCC9C1E4197BAB5241EE29484 sha1 EAA56458F90A7BB990E9BD8B16B59B6E8DABED54 )
 	rom ( name "Blaue Kristall, Der (1985)(Rainbow Arts)(de)(Side B).dsk" size 195635 crc 2DB6DA2A md5 55698F8093A3557667F8C753CF1FA5F2 sha1 BF97A124790F7A478D3284BA4A68B7D5C413F564 )
+	rom ( name "Blaue Kristall, Der (1985)(Rainbow Arts)(de)(Side A).dsk" size 200517 crc E63C83E md5 DA97274BCC9C1E4197BAB5241EE29484 sha1 EAA56458F90A7BB990E9BD8B16B59B6E8DABED54 )
 )
 game (
 	name "Beyond the Ice Palace (Elite Systems)"
@@ -1490,8 +1490,8 @@ game (
 game (
 	name "Ballyhoo (Infocom)"
 	description "Ballyhoo (Infocom)"
-	rom ( name "Ballyhoo (1986)(Infocom)(Side A)[CPM].dsk" size 195635 crc 925BF86B md5 D77F29E1C8804891692BFD7FD3E159D4 sha1 9FB2DB3B889D6589F9131D3413C0BEA613246EBE )
 	rom ( name "Ballyhoo (1986)(Infocom)(Side B).dsk" size 195635 crc A6DC3157 md5 CF4387E59937469039852F3B57C9EBCC sha1 FCD7291A7FA6E7704C149A490AEA2E57BE7C7458 )
+	rom ( name "Ballyhoo (1986)(Infocom)(Side A)[CPM].dsk" size 195635 crc 925BF86B md5 D77F29E1C8804891692BFD7FD3E159D4 sha1 9FB2DB3B889D6589F9131D3413C0BEA613246EBE )
 )
 game (
 	name "Bump Set Spike (Mastertronic)"
@@ -1521,8 +1521,8 @@ game (
 game (
 	name "Bobo (Inforgrames) (France)"
 	description "Bobo (Inforgrames) (France)"
-	rom ( name "Bobo (1988)(Inforgrames(fr)(Side A).dsk" size 195584 crc C36F1142 md5 8F4458F1218A4E04C7DD132541CDC705 sha1 C6AE822F1C2F428DFD5C73B541896444AE48DFE8 )
 	rom ( name "Bobo (1988)(Inforgrames(fr)(Side B).dsk" size 197632 crc B7045BC1 md5 07DBFFA42E029B7D33B22A5024A2D6A3 sha1 43857787EC264A39A1D8C9F99E1B33143671899B )
+	rom ( name "Bobo (1988)(Inforgrames(fr)(Side A).dsk" size 195584 crc C36F1142 md5 8F4458F1218A4E04C7DD132541CDC705 sha1 C6AE822F1C2F428DFD5C73B541896444AE48DFE8 )
 )
 game (
 	name "Bivouac - Chamonix Challenge (Infogrames) (France)"
@@ -1547,8 +1547,8 @@ game (
 game (
 	name "Battle Command (Ocean Software) (Bugs)"
 	description "Battle Command (Ocean Software) (Bugs)"
-	rom ( name "Battle Command (1991)(Ocean Software)(Side A)[b].dsk" size 125975 crc 8D933A44 md5 6BD53D333D5B6576AD4C6386393599EF sha1 C494540CC61EF923FD04E9A9274B698CD78DD9D6 )
 	rom ( name "Battle Command (1991)(Ocean Software)(Side B)[b].dsk" size 146817 crc 55EBBD9E md5 3FD3DFD1E13285403B4F3F1DA4D99B73 sha1 B9A38D5772D64CD4F3039FBC5ABF105E162A7F17 )
+	rom ( name "Battle Command (1991)(Ocean Software)(Side A)[b].dsk" size 125975 crc 8D933A44 md5 6BD53D333D5B6576AD4C6386393599EF sha1 C494540CC61EF923FD04E9A9274B698CD78DD9D6 )
 )
 game (
 	name "Boulder Dash 2 (Peter Liepa) (Hack)"
@@ -1663,8 +1663,8 @@ game (
 game (
 	name "Blueberry (Coktel Vision) (Spain)"
 	description "Blueberry (Coktel Vision) (Spain)"
-	rom ( name "Blueberry (1987)(Coktel Vision)(es)(Side A)[CPM].dsk" size 205659 crc D81CD9FB md5 E909C30183DB7EB74B2ACD777F74E986 sha1 FA567BE97907E06073D922769EF06DF0B1B56DB2 )
 	rom ( name "Blueberry (1987)(Coktel Vision)(es)(Side B).dsk" size 205659 crc F5DD8263 md5 2F181194D00470FCFA545C398E1261F6 sha1 FFC18436B66061953EA3B8C1F53ECB774212D8BD )
+	rom ( name "Blueberry (1987)(Coktel Vision)(es)(Side A)[CPM].dsk" size 205659 crc D81CD9FB md5 E909C30183DB7EB74B2ACD777F74E986 sha1 FA567BE97907E06073D922769EF06DF0B1B56DB2 )
 )
 game (
 	name "Barry McGuigan World Championship Boxing (Activision)"
@@ -1694,8 +1694,8 @@ game (
 game (
 	name "BIAT (Microfutur) (France) (Bugs)"
 	description "BIAT (Microfutur) (France) (Bugs)"
-	rom ( name "BIAT (1988)(Microfutur)(fr)(Side A)[b].dsk" size 189952 crc CFCCF0CF md5 119D5395667E1B891738D29C61E9D517 sha1 D70720E5D4AC27B357336D5B3FC2F85EE86FE84E )
 	rom ( name "BIAT (1988)(Microfutur)(fr)(Side B)[b].dsk" size 194816 crc 424AFA2F md5 54C2C0D61B095A510E9684268A35877E sha1 445EA0702C14FC97A490268281E2A21832AFB05A )
+	rom ( name "BIAT (1988)(Microfutur)(fr)(Side A)[b].dsk" size 189952 crc CFCCF0CF md5 119D5395667E1B891738D29C61E9D517 sha1 D70720E5D4AC27B357336D5B3FC2F85EE86FE84E )
 )
 game (
 	name "Bosconian '87 (Mastertronic)"
@@ -1710,8 +1710,8 @@ game (
 game (
 	name "Bad Cat (Rainbow Arts)"
 	description "Bad Cat (Rainbow Arts)"
-	rom ( name "Bad Cat (1987)(Rainbow Arts)(Side A).dsk" size 201541 crc 82E295B3 md5 9B23FB99D4AEE9F9D016EF92A3CC6989 sha1 3FA64D91DECFCDA96C4DC608268A9D1524B36536 )
 	rom ( name "Bad Cat (1987)(Rainbow Arts)(Side B).dsk" size 196149 crc 5213BEA6 md5 612DFF5BA200B334A34682ADCE826350 sha1 8783AA610B7CA7F49856E6535748DA8C819F2E59 )
+	rom ( name "Bad Cat (1987)(Rainbow Arts)(Side A).dsk" size 201541 crc 82E295B3 md5 9B23FB99D4AEE9F9D016EF92A3CC6989 sha1 3FA64D91DECFCDA96C4DC608268A9D1524B36536 )
 )
 game (
 	name "Beach Volley (Ocean Software)"
@@ -1756,8 +1756,8 @@ game (
 game (
 	name "Booly (Loriciels) (M2) (Codes)"
 	description "Booly (Loriciels) (M2) (Codes)"
-	rom ( name "Booly (1991)(Loriciels)(M2)(Side A)[codes].dsk" size 199783 crc 5C140A84 md5 AC8C4ABB9F9539D9A1A23869EDA228B6 sha1 F03B8260AC55BB1E9D3847ECBB11F177D28CB481 )
 	rom ( name "Booly (1991)(Loriciels)(M2)(Side B)[codes].dsk" size 103647 crc EFD1A301 md5 76AAFAAF0C3B731186B87A0399AFF228 sha1 7952D05E896C73E52748BC429A91DD3995CB5EF3 )
+	rom ( name "Booly (1991)(Loriciels)(M2)(Side A)[codes].dsk" size 199783 crc 5C140A84 md5 AC8C4ABB9F9539D9A1A23869EDA228B6 sha1 F03B8260AC55BB1E9D3847ECBB11F177D28CB481 )
 )
 game (
 	name "BMX Ninja (Alternative Software) (M2)"
@@ -1772,8 +1772,8 @@ game (
 game (
 	name "Back To The Future III (Image Works) (Spain)"
 	description "Back To The Future III (Image Works) (Spain)"
-	rom ( name "Back To The Future III (1990)(Image Works)(es)(Side A).dsk" size 194816 crc 304B0E30 md5 BD3B4F7963BE16BAB0E5BB92812A9040 sha1 B25B457999B49AD44A489A1AFFDA5126A693352E )
 	rom ( name "Back To The Future III (1990)(Image Works)(es)(Side B).dsk" size 194816 crc 891011D8 md5 5DE388819C116A0D786794030FE38494 sha1 192A6F74BC60170A8FFD7D7FDD5756875EBDE98B )
+	rom ( name "Back To The Future III (1990)(Image Works)(es)(Side A).dsk" size 194816 crc 304B0E30 md5 BD3B4F7963BE16BAB0E5BB92812A9040 sha1 B25B457999B49AD44A489A1AFFDA5126A693352E )
 )
 game (
 	name "Ball Bearing (Radical Software)"
@@ -1858,8 +1858,8 @@ game (
 game (
 	name "Bunny Bricks (Silmarils)"
 	description "Bunny Bricks (Silmarils)"
-	rom ( name "Bunny Bricks (1992)(Silmarils)(Side A).dsk" size 274501 crc 1DE8CEAA md5 4314B2A7239F1A414C5D922AC8A68C02 sha1 77DDD3B6DD8B1F13126AA3A91604A354EA665A5A )
 	rom ( name "Bunny Bricks (1992)(Silmarils)(Side B).dsk" size 273989 crc 52A7610 md5 25D34911F7A2B4D333FE03D21C2C623D sha1 3D8CB24E9CF5DEB9873D4D39536564EF7A42C073 )
+	rom ( name "Bunny Bricks (1992)(Silmarils)(Side A).dsk" size 274501 crc 1DE8CEAA md5 4314B2A7239F1A414C5D922AC8A68C02 sha1 77DDD3B6DD8B1F13126AA3A91604A354EA665A5A )
 )
 game (
 	name "Beat the Clock (Amstrad Computer User)"
@@ -1964,20 +1964,20 @@ game (
 game (
 	name "Bard's Tale, The (Electronic Arts) (France)"
 	description "Bard's Tale, The (Electronic Arts) (France)"
-	rom ( name "Bard's Tale, The (1988)(Electronic Arts)(fr)(Side A).dsk" size 194816 crc 507323BA md5 F25D15747DBCA3A21571CF0C849BE42E sha1 FA655050F7A7E608565D539B20186A5F917D0EBB )
 	rom ( name "Bard's Tale, The (1988)(Electronic Arts)(fr)(Side B).dsk" size 194816 crc 30A2896F md5 475D9E00200389E2263446432EBB3E4E sha1 C2B119FC82F563719FF421BE6E5679715EC2C0BB )
+	rom ( name "Bard's Tale, The (1988)(Electronic Arts)(fr)(Side A).dsk" size 194816 crc 507323BA md5 F25D15747DBCA3A21571CF0C849BE42E sha1 FA655050F7A7E608565D539B20186A5F917D0EBB )
 )
 game (
 	name "Barbarian (Palace Software)"
 	description "Barbarian (Palace Software)"
-	rom ( name "Barbarian (1987)(Palace Software)(Side A).dsk" size 195635 crc C761E738 md5 9A28C6FAFEBB2A6A68411AF5257C84FA sha1 AF9F7D078DB788ACF180B2226C6FCD8AB86B5479 )
 	rom ( name "Barbarian (1987)(Palace Software)(Side B).dsk" size 195635 crc 60E1F5F0 md5 B0834E82CDD18C09AA20CDD8493A2DDC sha1 D2303E56B9F7608FD9C5227A4BCD0FCFC0FC5FD0 )
+	rom ( name "Barbarian (1987)(Palace Software)(Side A).dsk" size 195635 crc C761E738 md5 9A28C6FAFEBB2A6A68411AF5257C84FA sha1 AF9F7D078DB788ACF180B2226C6FCD8AB86B5479 )
 )
 game (
 	name "Budokan (Electronic Arts)"
 	description "Budokan (Electronic Arts)"
-	rom ( name "Budokan (1990)(Electronic Arts)(Side A).dsk" size 195637 crc 480C9E65 md5 DAE80E2682969048C50DDE550467F5D5 sha1 F073E4F01B0F5979710216356833CEF15966EA3F )
 	rom ( name "Budokan (1990)(Electronic Arts)(Side B).dsk" size 156581 crc 662A9BDE md5 89E8DC4130714052FDFA5A1739931D1C sha1 02450353B90062EEFB0CA2A6CCE13197D9AFF038 )
+	rom ( name "Budokan (1990)(Electronic Arts)(Side A).dsk" size 195637 crc 480C9E65 md5 DAE80E2682969048C50DDE550467F5D5 sha1 F073E4F01B0F5979710216356833CEF15966EA3F )
 )
 game (
 	name "Batman (Ocean Software)"
@@ -1992,14 +1992,14 @@ game (
 game (
 	name "Bumpy's Arcade Fantasy (Loriciels)"
 	description "Bumpy's Arcade Fantasy (Loriciels)"
-	rom ( name "Bumpy's Arcade Fantasy (1992)(Loriciels)(v2)(Side A).dsk" size 201797 crc DDFA0583 md5 A6B80CE9E6399761A5CCA2A4616E05CB sha1 D4C439303ADC1D6CEFA5B661CB706D910161CF21 )
 	rom ( name "Bumpy's Arcade Fantasy (1992)(Loriciels)(v2)(Side B).dsk" size 195635 crc C04FBD25 md5 86B667AEF76C76611E75A8CD1E979C8C sha1 A6384A2A164B061918B415C93FB20DE3D96F6E25 )
+	rom ( name "Bumpy's Arcade Fantasy (1992)(Loriciels)(v2)(Side A).dsk" size 201797 crc DDFA0583 md5 A6B80CE9E6399761A5CCA2A4616E05CB sha1 D4C439303ADC1D6CEFA5B661CB706D910161CF21 )
 )
 game (
 	name "Bob Winner (Loriciels)"
 	description "Bob Winner (Loriciels)"
-	rom ( name "Bob Winner (1986)(Loriciels)(Side A).dsk" size 180773 crc B94D8EF1 md5 62C850F17D9E843C18774D5AC1B91B5B sha1 2C9616B1A9F29850D139F24D83DE1BC34E599729 )
 	rom ( name "Bob Winner (1986)(Loriciels)(Side B).dsk" size 178688 crc D479A21A md5 1475A06FB963491AE14F067652B1E513 sha1 6875F3C0BC37A1825188F66AF9DA8DAD5EECB927 )
+	rom ( name "Bob Winner (1986)(Loriciels)(Side A).dsk" size 180773 crc B94D8EF1 md5 62C850F17D9E843C18774D5AC1B91B5B sha1 2C9616B1A9F29850D139F24D83DE1BC34E599729 )
 )
 game (
 	name "Bagne de Nepharia, Le (Loriciels) (France)"
@@ -2009,8 +2009,8 @@ game (
 game (
 	name "Blue Crystal, The (Rainbow Arts) (France)"
 	description "Blue Crystal, The (Rainbow Arts) (France)"
-	rom ( name "Blue Crystal, The (1985)(Rainbow Arts)(fr)(Side A).dsk" size 200517 crc E0E1A064 md5 C36A989FAEA85B0AE21D736102F09F54 sha1 7E124CC3E106B185A10A746CEE2F28017BD09577 )
 	rom ( name "Blue Crystal, The (1985)(Rainbow Arts)(fr)(Side B).dsk" size 196915 crc 47659579 md5 4474595F2A702289D081FB85894794DE sha1 20C4C2655B7851768D288C8C75710CAB7257BB11 )
+	rom ( name "Blue Crystal, The (1985)(Rainbow Arts)(fr)(Side A).dsk" size 200517 crc E0E1A064 md5 C36A989FAEA85B0AE21D736102F09F54 sha1 7E124CC3E106B185A10A746CEE2F28017BD09577 )
 )
 game (
 	name "Buggy II (Chip) (France)"
@@ -2100,10 +2100,10 @@ game (
 game (
 	name "B.A.T. (Ubi Soft)"
 	description "B.A.T. (Ubi Soft)"
-	rom ( name "B.A.T. (1991)(Ubi Soft)(Disk 1 Side A).dsk" size 195635 crc C6349FE7 md5 C35054265435453859955836AA6049B3 sha1 F1D9E5B88E20F4EF86A22483791A474367881EC4 )
 	rom ( name "B.A.T. (1991)(Ubi Soft)(Disk 1 Side B).dsk" size 195635 crc DDE0F4C md5 9CD7F53A33A83CEFA70742129F3BFFF3 sha1 C7A40B16173F0431F68ABDFA70022F5DD15304E5 )
 	rom ( name "B.A.T. (1991)(Ubi Soft)(Disk 2 Side A).dsk" size 195635 crc B5AEE4F6 md5 1A6A75FF2F634BA370FDA120FE65444C sha1 CF0336257C49C6270E8B1EB523E7ECA43347F13C )
 	rom ( name "B.A.T. (1991)(Ubi Soft)(Disk 2 Side B).dsk" size 195635 crc 5503A29A md5 2D4056CCED30DF3D330812D9E531649E sha1 C12DF214A1D23324E5D284408AA8A4B50CC3086F )
+	rom ( name "B.A.T. (1991)(Ubi Soft)(Disk 1 Side A).dsk" size 195635 crc C6349FE7 md5 C35054265435453859955836AA6049B3 sha1 F1D9E5B88E20F4EF86A22483791A474367881EC4 )
 )
 game (
 	name "Bionic Commando (US Gold) (Green)"
@@ -2178,10 +2178,10 @@ game (
 game (
 	name "B.A.T. (Ubi Soft) (France)"
 	description "B.A.T. (Ubi Soft) (France)"
-	rom ( name "B.A.T. (1991)(Ubi Soft)(fr)(Disk 1 Side A).dsk" size 195635 crc 69BD3223 md5 B7BA65B0966C533D81EE66710567E02B sha1 5E18CE06FCEB258A739BB4A7977C8B8EE900898D )
 	rom ( name "B.A.T. (1991)(Ubi Soft)(fr)(Disk 1 Side B).dsk" size 195635 crc D3CFC505 md5 412EBA443076B0DD1E066F60092066DE sha1 BE971F06BAABBA613FAE99CEF542D00FDBDCC2F4 )
 	rom ( name "B.A.T. (1991)(Ubi Soft)(fr)(Disk 2 Side A).dsk" size 195635 crc E8BBF1C7 md5 094555BC415403F81AB23B6EB9E0A493 sha1 ED4B4C8B2BEDD93611342FD9250842B48B9F2C7E )
 	rom ( name "B.A.T. (1991)(Ubi Soft)(fr)(Disk 2 Side B).dsk" size 195635 crc FD51471E md5 7B667585E957145BAEC76C7A31B01418 sha1 5ADEE252DA55524C63F26171723270025D808D55 )
+	rom ( name "B.A.T. (1991)(Ubi Soft)(fr)(Disk 1 Side A).dsk" size 195635 crc 69BD3223 md5 B7BA65B0966C533D81EE66710567E02B sha1 5E18CE06FCEB258A739BB4A7977C8B8EE900898D )
 )
 game (
 	name "Bestiary (Amstrad Adventure PD Library)"
@@ -2216,8 +2216,8 @@ game (
 game (
 	name "Bob Winner (Loriciels) (France)"
 	description "Bob Winner (Loriciels) (France)"
-	rom ( name "Bob Winner (1986)(Loriciels)(fr)(Side A).dsk" size 181283 crc 305153D3 md5 30C50AD7D1FBDF93B08F4BE518AE7AE1 sha1 4B22356784E11362EEC4D6D34A7F950D20527266 )
 	rom ( name "Bob Winner (1986)(Loriciels)(fr)(Side B).dsk" size 178951 crc D11608F md5 DC94B40DC506662FCE16770373580EF3 sha1 FAE491368C885BC85BC0C9D1C4E0809C1ADEB2BB )
+	rom ( name "Bob Winner (1986)(Loriciels)(fr)(Side A).dsk" size 181283 crc 305153D3 md5 30C50AD7D1FBDF93B08F4BE518AE7AE1 sha1 4B22356784E11362EEC4D6D34A7F950D20527266 )
 )
 game (
 	name "Battle Beyond the Stars (Solar Software)"
@@ -2262,8 +2262,8 @@ game (
 game (
 	name "Burglar (Lankhor) (France)"
 	description "Burglar (Lankhor) (France)"
-	rom ( name "Burglar (1991)(Lankhor)(fr)(side A)[cr].dsk" size 194816 crc D74B46F4 md5 E5E9CFFB7B73FF9AB79281156D80B571 sha1 3EB35E7783CB781D024BD10CDD3DC23DA3FA2A34 )
 	rom ( name "Burglar (1991)(Lankhor)(fr)(side B)[cr].dsk" size 195072 crc FA4FBF3B md5 2CAD4F03311C76294208CB3A35A4F4E6 sha1 ECDE84BB7A09B404D0CA4C419E873A93253F9F20 )
+	rom ( name "Burglar (1991)(Lankhor)(fr)(side A)[cr].dsk" size 194816 crc D74B46F4 md5 E5E9CFFB7B73FF9AB79281156D80B571 sha1 3EB35E7783CB781D024BD10CDD3DC23DA3FA2A34 )
 )
 game (
 	name "Bo! (Bollaware) (de)"
@@ -2323,8 +2323,8 @@ game (
 game (
 	name "Bard's Tale, The (Electronic Arts) (de)"
 	description "Bard's Tale, The (Electronic Arts) (de)"
-	rom ( name "Bard's Tale, The (1988)(Electronic Arts)(de)(Side A).dsk" size 194816 crc 602AAB4D md5 5C242FE5640161A6D2B576106D493122 sha1 8FF3226211124681223E53EA59368E551D8A2162 )
 	rom ( name "Bard's Tale, The (1988)(Electronic Arts)(de)(Side B).dsk" size 194304 crc C0AFB5CB md5 D6C54F2BD0B985F1AC3782E0BEFF18AD sha1 4F9849B9D9BAFCABF6576736ECE95F8A187B6D4B )
+	rom ( name "Bard's Tale, The (1988)(Electronic Arts)(de)(Side A).dsk" size 194816 crc 602AAB4D md5 5C242FE5640161A6D2B576106D493122 sha1 8FF3226211124681223E53EA59368E551D8A2162 )
 )
 game (
 	name "Big Sleaze, The (Piranha)"
@@ -2339,8 +2339,8 @@ game (
 game (
 	name "Baby Jo - Going Home (Imagine Software)"
 	description "Baby Jo - Going Home (Imagine Software)"
-	rom ( name "Baby Jo - Going Home (1991)(Imagine Software)(v2)(Side A).dsk" size 201797 crc D015805A md5 EB53809A84F5E6D2A331384867F41B68 sha1 20444068DCA4621D3384826DABE8C6A4D3F30168 )
 	rom ( name "Baby Jo - Going Home (1991)(Imagine Software)(v2)(Side B).dsk" size 195635 crc 8CBB85D9 md5 302C19921E6D824B06F406436D6A6F2F sha1 112CE119D0A7D207716A0969BC9CD27A92CE63D9 )
+	rom ( name "Baby Jo - Going Home (1991)(Imagine Software)(v2)(Side A).dsk" size 201797 crc D015805A md5 EB53809A84F5E6D2A331384867F41B68 sha1 20444068DCA4621D3384826DABE8C6A4D3F30168 )
 )
 game (
 	name "Backgammon (CP Software) (Spain)"
@@ -2360,8 +2360,8 @@ game (
 game (
 	name "Blueberry (Coktel Vision) (de)"
 	description "Blueberry (Coktel Vision) (de)"
-	rom ( name "Blueberry (1987)(Coktel Vision)(de)(Side A)[CPM].dsk" size 210283 crc 2DC8C009 md5 F943F349CC3F5276DA85D136B2DF1B2D sha1 1C1E95A5ECDED201ED0D857A60B806A41887B534 )
 	rom ( name "Blueberry (1987)(Coktel Vision)(de)(Side B).dsk" size 210283 crc 49A750A5 md5 51539588C643B9521F6ACAEE1060270D sha1 CAFE38AFB29AB5B6108EF5C6CB28E52EDCF5A2E5 )
+	rom ( name "Blueberry (1987)(Coktel Vision)(de)(Side A)[CPM].dsk" size 210283 crc 2DC8C009 md5 F943F349CC3F5276DA85D136B2DF1B2D sha1 1C1E95A5ECDED201ED0D857A60B806A41887B534 )
 )
 game (
 	name "Classiques Titus Volume 2 (Titus) (France)"
@@ -2371,8 +2371,8 @@ game (
 game (
 	name "Chuck Yeager's Advanced Flight Trainer (Electronic Arts)"
 	description "Chuck Yeager's Advanced Flight Trainer (Electronic Arts)"
-	rom ( name "Chuck Yeager's Advanced Flight Trainer (1989)(Electronic Arts)(v2)(Side A).dsk" size 134589 crc 514D61AD md5 48C48DCEB07ACC0FEADAA446E34A922C sha1 2412A788F2E05554095C303665A6CA09F147AA10 )
 	rom ( name "Chuck Yeager's Advanced Flight Trainer (1989)(Electronic Arts)(v2)(Side B).dsk" size 195635 crc 732F1945 md5 CF4273353C2BA9D8DEFD2A51BF27E30F sha1 2D194AC55C91966E97C6DC288C891EC596F51DE4 )
+	rom ( name "Chuck Yeager's Advanced Flight Trainer (1989)(Electronic Arts)(v2)(Side A).dsk" size 134589 crc 514D61AD md5 48C48DCEB07ACC0FEADAA446E34A922C sha1 2412A788F2E05554095C303665A6CA09F147AA10 )
 )
 game (
 	name "Cross Horde (Caruso, Fabrizio)"
@@ -2412,8 +2412,8 @@ game (
 game (
 	name "Crypte des Maudits, La (Lankhor) (France)"
 	description "Crypte des Maudits, La (Lankhor) (France)"
-	rom ( name "Crypte des Maudits, La (1991)(Lankhor)(fr)(Side A).dsk" size 273753 crc A5E1B296 md5 CBE9570CADB7A19200875242B2AAB949 sha1 4F8B794B256245FA37DDDDF3A01819934B6F9378 )
 	rom ( name "Crypte des Maudits, La (1991)(Lankhor)(fr)(Side B).dsk" size 195635 crc 74EE94AC md5 8BF8FC26D2EA6FBBE8A113008294B607 sha1 80B4A7E64A416D3548A4921BD2FEFF6736D66D10 )
+	rom ( name "Crypte des Maudits, La (1991)(Lankhor)(fr)(Side A).dsk" size 273753 crc A5E1B296 md5 CBE9570CADB7A19200875242B2AAB949 sha1 4F8B794B256245FA37DDDDF3A01819934B6F9378 )
 )
 game (
 	name "Cyber Power (CPC Infos) (France)"
@@ -2423,10 +2423,10 @@ game (
 game (
 	name "Cite Perdu, La (Excalibur) (France)"
 	description "Cite Perdu, La (Excalibur) (France)"
-	rom ( name "Cite Perdu, La (1987)(Excalibur)(fr)(Disk 1 Side A).dsk" size 197376 crc F490084A md5 BA341EB728A2C107F8E555AB3392A957 sha1 EB1F5051088A11834C2378CF3895B386DA4E22CD )
 	rom ( name "Cite Perdu, La (1987)(Excalibur)(fr)(Disk 1 Side B).dsk" size 197376 crc FF52F67E md5 2FBE6BC131ACD31D501D97973322727C sha1 161D8E81F7D4477CDBBE6C267967DA0C081A9ECE )
 	rom ( name "Cite Perdu, La (1987)(Excalibur)(fr)(Disk 2 Side A).dsk" size 197376 crc 585CBC31 md5 165B947D4260142D9E260F16BB6BC4A5 sha1 9926530962111E7D541EEE771958E48229448C66 )
 	rom ( name "Cite Perdu, La (1987)(Excalibur)(fr)(Disk 2 Side B).dsk" size 197376 crc EEB62090 md5 78A6DA586CC8D140244A15CC2098A89B sha1 CADC165C0055AE79877E65D59A66B90013D635CF )
+	rom ( name "Cite Perdu, La (1987)(Excalibur)(fr)(Disk 1 Side A).dsk" size 197376 crc F490084A md5 BA341EB728A2C107F8E555AB3392A957 sha1 EB1F5051088A11834C2378CF3895B386DA4E22CD )
 )
 game (
 	name "Canadair (Fil) (France)"
@@ -2476,8 +2476,8 @@ game (
 game (
 	name "Chose de Grotemburg, La (Ubi Soft) (France)"
 	description "Chose de Grotemburg, La (Ubi Soft) (France)"
-	rom ( name "Chose de Grotemburg, La (1987)(Ubi Soft)(fr)(Side A).dsk" size 205399 crc 25AEAE06 md5 B216FDFD61119268501CE82D9A54FAE9 sha1 3D2389809A2FF1823D1E682FC893E0CFC1625059 )
 	rom ( name "Chose de Grotemburg, La (1987)(Ubi Soft)(fr)(Side B).dsk" size 205399 crc 1DC4B790 md5 81489FF8E4C2AEE68BD595656C2A7324 sha1 9447B61603053DFCA4FEC5B2CE580C0E95800DC8 )
+	rom ( name "Chose de Grotemburg, La (1987)(Ubi Soft)(fr)(Side A).dsk" size 205399 crc 25AEAE06 md5 B216FDFD61119268501CE82D9A54FAE9 sha1 3D2389809A2FF1823D1E682FC893E0CFC1625059 )
 )
 game (
 	name "Croco Magneto (Public Domain) (France)"
@@ -2557,14 +2557,14 @@ game (
 game (
 	name "Chibi Akuma's Episode 1 Invasion (Keith Sear)"
 	description "Chibi Akuma's Episode 1 Invasion (Keith Sear)"
-	rom ( name "Chibi Akuma's Episode 1 Invasion (2018)(Keith Sear)(v1.666)(Side A).dsk" size 194816 crc D851FDE0 md5 363C12BCA4B13C55824E5E3C88505237 sha1 F5A8737198A7CF60422F12ABF52CD37C16B60BAE )
 	rom ( name "Chibi Akuma's Episode 1 Invasion (2018)(Keith Sear)(v1.666)(Side B).dsk" size 194816 crc 3D75A099 md5 86143C5822123310B13E41BFEF9EC045 sha1 B7ECC916AFE1E3CB28058EDEB6FC8E855CF85DB3 )
+	rom ( name "Chibi Akuma's Episode 1 Invasion (2018)(Keith Sear)(v1.666)(Side A).dsk" size 194816 crc D851FDE0 md5 363C12BCA4B13C55824E5E3C88505237 sha1 F5A8737198A7CF60422F12ABF52CD37C16B60BAE )
 )
 game (
 	name "Crazy Shoot (Loriciels) (France) (Phaser)"
 	description "Crazy Shoot (Loriciels) (France) (Phaser)"
-	rom ( name "Crazy Shoot (1989)(Loriciels)(fr)(West Phaser)(Side A).dsk" size 201797 crc CE81CFFA md5 31E4A7E9A1155BCED79DCC2AB75AD82C sha1 E45D79717CB2742C2AA591FCB3B0B3105FC8B637 )
 	rom ( name "Crazy Shoot (1989)(Loriciels)(fr)(West Phaser)(Side B).dsk" size 201797 crc 35FB2D md5 BFE41CB1928956738E3FCC4324F3C6B1 sha1 CDE64F368F6DACCF18E8876934BF988125BBDC88 )
+	rom ( name "Crazy Shoot (1989)(Loriciels)(fr)(West Phaser)(Side A).dsk" size 201797 crc CE81CFFA md5 31E4A7E9A1155BCED79DCC2AB75AD82C sha1 E45D79717CB2742C2AA591FCB3B0B3105FC8B637 )
 )
 game (
 	name "CORE (A&F Software)"
@@ -2659,8 +2659,8 @@ game (
 game (
 	name "Cine Clap (Ubi Soft) (France)"
 	description "Cine Clap (Ubi Soft) (France)"
-	rom ( name "Cine Clap (1986)(Ubi Soft)(fr)(Side A).dsk" size 200192 crc 212F7414 md5 14FD6DA6A34EFFF2AA63442C0389F74C sha1 D4EDD16375AF6641DC4FB2E49D024A12D492D97C )
 	rom ( name "Cine Clap (1986)(Ubi Soft)(fr)(Side B).dsk" size 194816 crc F6158B1F md5 4297C1D200C9B24F167D74E8253AD5FC sha1 BA790677CEF28781808B78B6FA366F21031FD9FC )
+	rom ( name "Cine Clap (1986)(Ubi Soft)(fr)(Side A).dsk" size 200192 crc 212F7414 md5 14FD6DA6A34EFFF2AA63442C0389F74C sha1 D4EDD16375AF6641DC4FB2E49D024A12D492D97C )
 )
 game (
 	name "Cobra Force (Players Premier)"
@@ -2765,8 +2765,8 @@ game (
 game (
 	name "Coloriage - Les Petits Malins I (Carraz Editions) (France)"
 	description "Coloriage - Les Petits Malins I (Carraz Editions) (France)"
-	rom ( name "Coloriage - Les Petits Malins I (1988)(Carraz Editions)(fr)(Side A).dsk" size 195635 crc DC3C3CEE md5 1FC99A2601850BCE3CEB6E25F7385F92 sha1 86D82C78450DED098BF2F54C3FB012D5B44DEFB5 )
 	rom ( name "Coloriage - Les Petits Malins I (1988)(Carraz Editions)(fr)(Side B).dsk" size 195635 crc 5F421AE2 md5 7715BB2C53475FA5429EF8BDAD15BB9F sha1 EC70AA3DD4437E4E83EFA302D40E4624160657D9 )
+	rom ( name "Coloriage - Les Petits Malins I (1988)(Carraz Editions)(fr)(Side A).dsk" size 195635 crc DC3C3CEE md5 1FC99A2601850BCE3CEB6E25F7385F92 sha1 86D82C78450DED098BF2F54C3FB012D5B44DEFB5 )
 )
 game (
 	name "Ci-U-Than Trilogy I - La Diosa de Cozumel (Aventuras AD) (Spain)"
@@ -2811,8 +2811,8 @@ game (
 game (
 	name "Colossus 4 Bridge (CDS Software LTD)"
 	description "Colossus 4 Bridge (CDS Software LTD)"
-	rom ( name "Colossus 4 Bridge (1986)(CDS Software LTD)(Side A).dsk" size 195631 crc FCA8C1BC md5 B815B090C70F4C5AFF978879D3CC7DC1 sha1 2AEE0F9E2C548989B787F420357E1A01B97A469A )
 	rom ( name "Colossus 4 Bridge (1986)(CDS Software LTD)(Side B).dsk" size 195631 crc 9281BB35 md5 B0473D4C5E6C1DD3C3DD5C0A16E76891 sha1 DBA31F21EA70D226D1000D2AA69FD7BD0A87837A )
+	rom ( name "Colossus 4 Bridge (1986)(CDS Software LTD)(Side A).dsk" size 195631 crc FCA8C1BC md5 B815B090C70F4C5AFF978879D3CC7DC1 sha1 2AEE0F9E2C548989B787F420357E1A01B97A469A )
 )
 game (
 	name "Castle of the Skull Lord (Samurai)"
@@ -2827,16 +2827,16 @@ game (
 game (
 	name "Chibi Akumas Episode 2 - Confrontation (Keith Sear)"
 	description "Chibi Akumas Episode 2 - Confrontation (Keith Sear)"
-	rom ( name "Chibi Akumas Episode 2 - Confrontation (2017)(Keith Sear)(Disk 1 Side A).dsk" size 194816 crc F50B5634 md5 22C1F462D933DDFFBDAB83DE0D25E788 sha1 7F33224852B85FE76548AC85D299AB9F0F0A9956 )
 	rom ( name "Chibi Akumas Episode 2 - Confrontation (2017)(Keith Sear)(Disk 1 Side B).dsk" size 194816 crc 167EDC38 md5 AAA4AB22832550351C977033A51F975A sha1 E412BF8DD1D3769033BC43D551A831DAFE7B1DD4 )
 	rom ( name "Chibi Akumas Episode 2 - Confrontation (2017)(Keith Sear)(Disk 2 Side A).dsk" size 194816 crc 57005904 md5 A0844BAAFD80CDEEFE1299D2EB94D1EB sha1 EB00BF6D93D07067757DB29DCFC6186EFDFF1071 )
 	rom ( name "Chibi Akumas Episode 2 - Confrontation (2017)(Keith Sear)(Disk 2 Side B).dsk" size 194816 crc 180C764C md5 1525BB7278532D2A36750A501C6F6DBA sha1 764D065CAD06CF44CEA718EF183393260BFA7C34 )
+	rom ( name "Chibi Akumas Episode 2 - Confrontation (2017)(Keith Sear)(Disk 1 Side A).dsk" size 194816 crc F50B5634 md5 22C1F462D933DDFFBDAB83DE0D25E788 sha1 7F33224852B85FE76548AC85D299AB9F0F0A9956 )
 )
 game (
 	name "Chain Reaction (Elite Systems)"
 	description "Chain Reaction (Elite Systems)"
-	rom ( name "Chain Reaction (1988)(Elite Systems)(Side A).dsk" size 195635 crc F82670FA md5 E15DEAABCEDC63011551C4362C5C6BEF sha1 5F15CFD32DC2135DEA962C0354AC09936F5D596F )
 	rom ( name "Chain Reaction (1988)(Elite Systems)(Side B).dsk" size 195635 crc A2D0AD15 md5 D83CE22E79B303629856959B345DD7C6 sha1 E0259DA79C9A2FE566576CD0AEF59AE52340E1EF )
+	rom ( name "Chain Reaction (1988)(Elite Systems)(Side A).dsk" size 195635 crc F82670FA md5 E15DEAABCEDC63011551C4362C5C6BEF sha1 5F15CFD32DC2135DEA962C0354AC09936F5D596F )
 )
 game (
 	name "Cabal (Ocean Software) (Bugs)"
@@ -2901,8 +2901,8 @@ game (
 game (
 	name "Circus Games (Tynesort)"
 	description "Circus Games (Tynesort)"
-	rom ( name "Circus Games (1989)(Tynesort)(Side A).dsk" size 199680 crc A44432B6 md5 A7A46381D22F28D3011F1966D832B41F sha1 B305C0A88C01238ECFC19488D8E2741172821FCE )
 	rom ( name "Circus Games (1989)(Tynesort)(Side B).dsk" size 199680 crc BC3D0036 md5 CC67F3CB6C72E85F4986B2E26DCFED3C sha1 9A38C5DAA0B1C8BD8B2C811E9D240EBBE7CF65F4 )
+	rom ( name "Circus Games (1989)(Tynesort)(Side A).dsk" size 199680 crc A44432B6 md5 A7A46381D22F28D3011F1966D832B41F sha1 B305C0A88C01238ECFC19488D8E2741172821FCE )
 )
 game (
 	name "Cylu (Firebird)"
@@ -3007,8 +3007,8 @@ game (
 game (
 	name "Coloriage - Les Petits Malins II (Carraz Editions) (France)"
 	description "Coloriage - Les Petits Malins II (Carraz Editions) (France)"
-	rom ( name "Coloriage - Les Petits Malins II (1988)(Carraz Editions)(fr)(Side A).dsk" size 195635 crc 125D031B md5 6DBBCD710D8A18200CABC94166CEFE4D sha1 2F0FBC5E36233DE0834742B3206F5A6240E70120 )
 	rom ( name "Coloriage - Les Petits Malins II (1988)(Carraz Editions)(fr)(Side B).dsk" size 195635 crc B89D8CD md5 F7E7D8B126FD321950E5E0307356A932 sha1 32BC4F79C4E26657C54787A69ADE8DFBD8EF072E )
+	rom ( name "Coloriage - Les Petits Malins II (1988)(Carraz Editions)(fr)(Side A).dsk" size 195635 crc 125D031B md5 6DBBCD710D8A18200CABC94166CEFE4D sha1 2F0FBC5E36233DE0834742B3206F5A6240E70120 )
 )
 game (
 	name "Car Massacre (Tilt) (France)"
@@ -3048,8 +3048,8 @@ game (
 game (
 	name "California Games (US Gold)"
 	description "California Games (US Gold)"
-	rom ( name "California Games (1987)(US Gold)(Side A).dsk" size 195653 crc 998FB414 md5 ED83A96870DCDF96F858CB9CE6808474 sha1 3E024983BE5FB4532A2B3313CD1F131C0BD92E63 )
 	rom ( name "California Games (1987)(US Gold)(Side B).dsk" size 195635 crc F16F672 md5 2C1BF6E35A5F50CDB7C58580CCB32AD2 sha1 DF4E19C040A9E451C622EA9D4913FB86D6D60614 )
+	rom ( name "California Games (1987)(US Gold)(Side A).dsk" size 195653 crc 998FB414 md5 ED83A96870DCDF96F858CB9CE6808474 sha1 3E024983BE5FB4532A2B3313CD1F131C0BD92E63 )
 )
 game (
 	name "Chevalier Blanc, Le (Cobra Soft) (France)"
@@ -3164,8 +3164,8 @@ game (
 game (
 	name "Conspiration De L'An III (Ubi Soft) (France)"
 	description "Conspiration De L'An III (Ubi Soft) (France)"
-	rom ( name "Conspiration De L'An III (1988)(Ubi Soft)(fr)(Side A).dsk" size 224931 crc 75E574CD md5 87788A78E9C9EF57C25531E8B5ED090A sha1 27BC954182FE96C691085A16F1E12BDA73DD4416 )
 	rom ( name "Conspiration De L'An III (1988)(Ubi Soft)(fr)(Side B).dsk" size 226473 crc FC3F6C0C md5 43EC468CCEE56C030B0CB70E8325E80D sha1 7A2ED3EED1C522D67F6E987B996B5522AFBE700A )
+	rom ( name "Conspiration De L'An III (1988)(Ubi Soft)(fr)(Side A).dsk" size 224931 crc 75E574CD md5 87788A78E9C9EF57C25531E8B5ED090A sha1 27BC954182FE96C691085A16F1E12BDA73DD4416 )
 )
 game (
 	name "Clever & Smart (Magic Bytes) (M3)"
@@ -3300,8 +3300,8 @@ game (
 game (
 	name "Clash (ERE Informatique) (France)"
 	description "Clash (ERE Informatique) (France)"
-	rom ( name "Clash (1987)(ERE Informatique)(fr)(Side A).dsk" size 197941 crc BB2D6AFF md5 D03D19F6EAD56C323157C62D0DAA756F sha1 09623E617EBDE4A42FC23E02375178BA781C3C9D )
 	rom ( name "Clash (1987)(ERE Informatique)(fr)(Side B).dsk" size 195635 crc BEF7FF31 md5 5FAB3A1B6250CE977CD17EC9292DCC40 sha1 E38F79C0E4216F3E8A37D15A13B1C5908E8FFFFA )
+	rom ( name "Clash (1987)(ERE Informatique)(fr)(Side A).dsk" size 197941 crc BB2D6AFF md5 D03D19F6EAD56C323157C62D0DAA756F sha1 09623E617EBDE4A42FC23E02375178BA781C3C9D )
 )
 game (
 	name "Colossus Chess 4 (CDS Software LTD)"
@@ -3361,8 +3361,8 @@ game (
 game (
 	name "Chiffres et des Lettres, Des (Loriciels) (France)"
 	description "Chiffres et des Lettres, Des (Loriciels) (France)"
-	rom ( name "Chiffres et des Lettres, Des (1987)(Loriciels)(fr)(Side A)[Juin].dsk" size 257075 crc 95272BA6 md5 978FD550BB0BAEFFCBCEA8EBF58A0183 sha1 042F3DF5329AF4B8CE6D605C34E9B5EBB576D73B )
 	rom ( name "Chiffres et des Lettres, Des (1987)(Loriciels)(fr)(Side B)[Juin].dsk" size 257075 crc F9643529 md5 C00451D9E7344038FBD3A14CD851F41C sha1 10DE4607DE15A25659E0688A1F779437E9998917 )
+	rom ( name "Chiffres et des Lettres, Des (1987)(Loriciels)(fr)(Side A)[Juin].dsk" size 257075 crc 95272BA6 md5 978FD550BB0BAEFFCBCEA8EBF58A0183 sha1 042F3DF5329AF4B8CE6D605C34E9B5EBB576D73B )
 )
 game (
 	name "Cauldron II (Palace Software)"
@@ -3397,8 +3397,8 @@ game (
 game (
 	name "Crucial Test (Coktel Vision) (France)"
 	description "Crucial Test (Coktel Vision) (France)"
-	rom ( name "Crucial Test (1988)(Coktel Vision)(fr)(Side A)(Q1).dsk" size 195635 crc A64DC6A3 md5 C5348576FC1E2925E739BA23159E3391 sha1 3644DEEF8D91DEE0539374B3EACD1E99247B8FAE )
 	rom ( name "Crucial Test (1988)(Coktel Vision)(fr)(Side B)(Q2).dsk" size 195635 crc 1DBEE4 md5 037B6CA695906C9EBC5E6A10981CD66F sha1 8C507EDE59D5ECFD2593B180352F52521E457645 )
+	rom ( name "Crucial Test (1988)(Coktel Vision)(fr)(Side A)(Q1).dsk" size 195635 crc A64DC6A3 md5 C5348576FC1E2925E739BA23159E3391 sha1 3644DEEF8D91DEE0539374B3EACD1E99247B8FAE )
 )
 game (
 	name "Can I Cheat the Death (Amstrad Adventure PD Library)"
@@ -3428,8 +3428,8 @@ game (
 game (
 	name "Corruption (Rainbird Software)"
 	description "Corruption (Rainbird Software)"
-	rom ( name "Corruption (1988)(Rainbird Software)(Side A).dsk" size 195635 crc 92CE11B2 md5 653452EE36624ACC02209E287A02F91F sha1 23735C9182D07314398B0078B235FBC7F703A5A1 )
 	rom ( name "Corruption (1988)(Rainbird Software)(Side B).dsk" size 195635 crc 6587DC17 md5 5536947E23B652626DC65F64CE510FF0 sha1 5E7BA6171C429B5F14D229BFAB111A6582FD73C0 )
+	rom ( name "Corruption (1988)(Rainbird Software)(Side A).dsk" size 195635 crc 92CE11B2 md5 653452EE36624ACC02209E287A02F91F sha1 23735C9182D07314398B0078B235FBC7F703A5A1 )
 )
 game (
 	name "City Slicker (Hewson)"
@@ -3494,8 +3494,8 @@ game (
 game (
 	name "Crash Garrett (ERE Informatique) (France)"
 	description "Crash Garrett (ERE Informatique) (France)"
-	rom ( name "Crash Garrett (1987)(ERE Informatique)(fr)(Side A).dsk" size 273753 crc 76CD8F28 md5 DE29099C8D6D315726B6FC37BBEA29D7 sha1 3E737D618D36DA1E408CBC92E9413202D44D0E98 )
 	rom ( name "Crash Garrett (1987)(ERE Informatique)(fr)(Side B).dsk" size 200517 crc C2F9AC6C md5 5F2BD37A56C2FEA21C6B7CA51756C785 sha1 F8B40E984E2C8A65C9B1E669AA24441975C7AE04 )
+	rom ( name "Crash Garrett (1987)(ERE Informatique)(fr)(Side A).dsk" size 273753 crc 76CD8F28 md5 DE29099C8D6D315726B6FC37BBEA29D7 sha1 3E737D618D36DA1E408CBC92E9413202D44D0E98 )
 )
 game (
 	name "Cyrus II (Amsoft) (France)"
@@ -3570,8 +3570,8 @@ game (
 game (
 	name "Dan Silver (MBC Informatique) (France)"
 	description "Dan Silver (MBC Informatique) (France)"
-	rom ( name "Dan Silver (1989)(MBC Informatique)(fr)(Side A)[cr].dsk" size 194816 crc EBF36EE7 md5 894878D6728804C8C2839D2706E57DA4 sha1 45338B7968A1891F8745EAF333360C2C2477BD44 )
 	rom ( name "Dan Silver (1989)(MBC Informatique)(fr)(Side B)[cr].dsk" size 194816 crc 1AEBB6A6 md5 890A4860527E7AAE6516D278D00962A1 sha1 58EBBF52AB860AC4A8CCD3B20CC4C7F86E548979 )
+	rom ( name "Dan Silver (1989)(MBC Informatique)(fr)(Side A)[cr].dsk" size 194816 crc EBF36EE7 md5 894878D6728804C8C2839D2706E57DA4 sha1 45338B7968A1891F8745EAF333360C2C2477BD44 )
 )
 game (
 	name "Danger Street (Chip) (France)"
@@ -3591,8 +3591,8 @@ game (
 game (
 	name "Darkman (Ocean)"
 	description "Darkman (Ocean)"
-	rom ( name "Darkman (1991)(Ocean)(Side A).dsk" size 215685 crc D60D7D79 md5 15A3F3CDE7FCA8ECBFEF21FD4A35AAA7 sha1 463C888E9003ACBD397C2AA3A9468BD92C09A379 )
 	rom ( name "Darkman (1991)(Ocean)(Side B).dsk" size 216197 crc 4D6EB9BA md5 346CE57EC3A033DBD6EE1331C4DED2A4 sha1 D06121661CC5F6986A162DCFC56BF99CDC932CBB )
+	rom ( name "Darkman (1991)(Ocean)(Side A).dsk" size 215685 crc D60D7D79 md5 15A3F3CDE7FCA8ECBFEF21FD4A35AAA7 sha1 463C888E9003ACBD397C2AA3A9468BD92C09A379 )
 )
 game (
 	name "Defender (Amstrad Video-Play) (Spain)"
@@ -3607,8 +3607,8 @@ game (
 game (
 	name "Dragons of Flame (US Gold)"
 	description "Dragons of Flame (US Gold)"
-	rom ( name "Dragons of Flame (1990)(US Gold)(Side A).dsk" size 219136 crc C519182D md5 3D8F299A4EA3D0BBECC2C707A499F801 sha1 6950CE1E56BB66DF2D427834A959700608F04C27 )
 	rom ( name "Dragons of Flame (1990)(US Gold)(Side B).dsk" size 219136 crc 852B80DF md5 0849514CB5BB269F07BAF242E642C5BD sha1 56C99571C806A881AAF0A1B73F6E7764D8CC8EA2 )
+	rom ( name "Dragons of Flame (1990)(US Gold)(Side A).dsk" size 219136 crc C519182D md5 3D8F299A4EA3D0BBECC2C707A499F801 sha1 6950CE1E56BB66DF2D427834A959700608F04C27 )
 )
 game (
 	name "Danger Mouse in Double Trouble (Creative Sparks)"
@@ -3633,8 +3633,8 @@ game (
 game (
 	name "Devilry 2 (Eric Cubizolle - Emmanuel Rigot) (France)"
 	description "Devilry 2 (Eric Cubizolle - Emmanuel Rigot) (France)"
-	rom ( name "Devilry 2 (1989)(Eric Cubizolle - Emmanuel Rigot)(fr)(Side A).dsk" size 194816 crc 76F1D396 md5 099457E443564CE635B9C6F3600BD5EA sha1 DB073ECC79C0AE04EAD1139384848F57EB638E43 )
 	rom ( name "Devilry 2 (1989)(Eric Cubizolle - Emmanuel Rigot)(fr)(Side B).dsk" size 194816 crc 18464AC0 md5 CBDB4359785F4A42C630488AAE6B1723 sha1 6E1E7F6225FBAF5B84B0CA0F16F10FFAA843C139 )
+	rom ( name "Devilry 2 (1989)(Eric Cubizolle - Emmanuel Rigot)(fr)(Side A).dsk" size 194816 crc 76F1D396 md5 099457E443564CE635B9C6F3600BD5EA sha1 DB073ECC79C0AE04EAD1139384848F57EB638E43 )
 )
 game (
 	name "Digger Barnes (Cable Software)"
@@ -3744,8 +3744,8 @@ game (
 game (
 	name "Desperado (Topo Soft)"
 	description "Desperado (Topo Soft)"
-	rom ( name "Desperado (1987)(Topo Soft)(Side A)[cr][f].dsk" size 204544 crc CB00CC73 md5 DBD4063B2393B0A9D5D7905942FB9FB5 sha1 6F6BBC1CDF636A004320864E565CF66F874A9702 )
 	rom ( name "Desperado (1987)(Topo Soft)(Side B)[cr].dsk" size 204544 crc D8584470 md5 828C83609C9E8EAE54FBA36A0A0742E8 sha1 D6FE3D142AAA2DAA189A22B1054FFEB4E534062A )
+	rom ( name "Desperado (1987)(Topo Soft)(Side A)[cr][f].dsk" size 204544 crc CB00CC73 md5 DBD4063B2393B0A9D5D7905942FB9FB5 sha1 6F6BBC1CDF636A004320864E565CF66F874A9702 )
 )
 game (
 	name "Domino (Idealogic) (Spain)"
@@ -3760,8 +3760,8 @@ game (
 game (
 	name "Diamant de l'Ile Maudite, Le (Loriciels) (France)"
 	description "Diamant de l'Ile Maudite, Le (Loriciels) (France)"
-	rom ( name "Diamant de l'Ile Maudite, Le (1985)(Loriciels)(fr)(Side A).dsk" size 195635 crc C00BE31A md5 1A5E63E3C78BAF249755E9B66149A44D sha1 86A318094FBA29FF8ABA5460DDADDC08A712AA67 )
 	rom ( name "Diamant de l'Ile Maudite, Le (1985)(Loriciels)(fr)(Side B).dsk" size 195635 crc 2C20E400 md5 F0622DA9B7B0F379610517BB2292629E sha1 4CA658123EF6211926F9D2C51F309FC872B05F14 )
+	rom ( name "Diamant de l'Ile Maudite, Le (1985)(Loriciels)(fr)(Side A).dsk" size 195635 crc C00BE31A md5 1A5E63E3C78BAF249755E9B66149A44D sha1 86A318094FBA29FF8ABA5460DDADDC08A712AA67 )
 )
 game (
 	name "Daleks (Amstrad Action)"
@@ -3811,8 +3811,8 @@ game (
 game (
 	name "Donde Esta Carmen Sandiego (Broderbund Software) (Spain) (Codes)"
 	description "Donde Esta Carmen Sandiego (Broderbund Software) (Spain) (Codes)"
-	rom ( name "Donde Esta Carmen Sandiego (1990)(Broderbund Software)(es)(Side A)[codes].dsk" size 205399 crc 2C5B434 md5 B3CFA6E4AA832206D47F033502E65A8B sha1 D4ACF21C01913CCFF80D87576285B16284378E6E )
 	rom ( name "Donde Esta Carmen Sandiego (1990)(Broderbund Software)(es)(Side B)[codes].dsk" size 205399 crc DC8A705F md5 A2F76585E14870928300C4D3C003B2F5 sha1 E4D31BD1D9DF620F2DB2BDD76A89BE22BF2231E6 )
+	rom ( name "Donde Esta Carmen Sandiego (1990)(Broderbund Software)(es)(Side A)[codes].dsk" size 205399 crc 2C5B434 md5 B3CFA6E4AA832206D47F033502E65A8B sha1 D4ACF21C01913CCFF80D87576285B16284378E6E )
 )
 game (
 	name "Dynamic Duo (Firebird)"
@@ -3917,8 +3917,8 @@ game (
 game (
 	name "Double Dragon III - The Rosetta Stone (Storm Software)"
 	description "Double Dragon III - The Rosetta Stone (Storm Software)"
-	rom ( name "Double Dragon III - The Rosetta Stone (1991)(Storm Software)(Side A).dsk" size 195635 crc AED90545 md5 6F175B6901EC0D5B394D2BDA2DE82E07 sha1 6797B3ACDDB29113F3400BC202BE99AB7308E07F )
 	rom ( name "Double Dragon III - The Rosetta Stone (1991)(Storm Software)(Side B).dsk" size 195635 crc E9B8A1F9 md5 A6F8B7B5E568CDC1A6516A4B5DAF0A30 sha1 6F97D8C2ED5A0399CDF123630F5B94542E6FA45B )
+	rom ( name "Double Dragon III - The Rosetta Stone (1991)(Storm Software)(Side A).dsk" size 195635 crc AED90545 md5 6F175B6901EC0D5B394D2BDA2DE82E07 sha1 6797B3ACDDB29113F3400BC202BE99AB7308E07F )
 )
 game (
 	name "Devil's Castle (Chip) (France)"
@@ -3938,14 +3938,14 @@ game (
 game (
 	name "Dragon Spirit (Domark)"
 	description "Dragon Spirit (Domark)"
-	rom ( name "Dragon Spirit (1989)(Domark)(Side A).dsk" size 195635 crc C53E8BE1 md5 19E2B1A0DDCD865F6931529EF68371FE sha1 0723D4A217C5E2A6036C0B47A1161C2A47603965 )
 	rom ( name "Dragon Spirit (1989)(Domark)(Side B).dsk" size 195635 crc 88AA6A8E md5 31B601966B45E605A1B395CBD3E4BF3A sha1 DBD194EF22D754AC2CDE56D08962EC557DF682BA )
+	rom ( name "Dragon Spirit (1989)(Domark)(Side A).dsk" size 195635 crc C53E8BE1 md5 19E2B1A0DDCD865F6931529EF68371FE sha1 0723D4A217C5E2A6036C0B47A1161C2A47603965 )
 )
 game (
 	name "Donald's Alphabet Chase (Disney) (M5) (Codes)"
 	description "Donald's Alphabet Chase (Disney) (M5) (Codes)"
-	rom ( name "Donald's Alphabet Chase (1988)(Disney)(M5)(Side A)[codes].dsk" size 195635 crc 98021E34 md5 3772FFAD6F49B034336F6D5F4AE51F21 sha1 583BDD2282300B189C71F8F74FBD857EAAFCA1DB )
 	rom ( name "Donald's Alphabet Chase (1988)(Disney)(M5)(Side B)[codes].dsk" size 195635 crc 6E1A4DA1 md5 3C9E13514F239C566DF542FB3212DD49 sha1 DE30AFE613718B07F1E5AA384B07A3E7745B3F90 )
+	rom ( name "Donald's Alphabet Chase (1988)(Disney)(M5)(Side A)[codes].dsk" size 195635 crc 98021E34 md5 3772FFAD6F49B034336F6D5F4AE51F21 sha1 583BDD2282300B189C71F8F74FBD857EAAFCA1DB )
 )
 game (
 	name "Diamond Trap (Computing With The Amstrad)"
@@ -4000,8 +4000,8 @@ game (
 game (
 	name "Dragon World (4-Mation Educational Resources)"
 	description "Dragon World (4-Mation Educational Resources)"
-	rom ( name "Dragon World (1989)(4-Mation Educational Resources)(Side A)[cr].dsk" size 194816 crc C2C59A45 md5 A6EAB2D8A31CCA6E5B0DDE60D7E21321 sha1 CF6E5BA87DDE5F57A6A04552F90DAC6F225EDC15 )
 	rom ( name "Dragon World (1989)(4-Mation Educational Resources)(Side B)[cr].dsk" size 194816 crc 3C2111E0 md5 5B27C8869B4E549BEE5BAEE643A4F06A sha1 D1C297D2D6A57D66A1219B60E5BF5A7F1A719C88 )
+	rom ( name "Dragon World (1989)(4-Mation Educational Resources)(Side A)[cr].dsk" size 194816 crc C2C59A45 md5 A6EAB2D8A31CCA6E5B0DDE60D7E21321 sha1 CF6E5BA87DDE5F57A6A04552F90DAC6F225EDC15 )
 )
 game (
 	name "Don't Panic (Firebird Software)"
@@ -4156,8 +4156,8 @@ game (
 game (
 	name "Dynamite Dux (Activision)"
 	description "Dynamite Dux (Activision)"
-	rom ( name "Dynamite Dux (1989)(Activision)(Side A).dsk" size 175589 crc B9D58E05 md5 A1390EA6A2387244DD024A5D4E096929 sha1 DFF2545F946D1944D1D5595178AD46B946AF0E71 )
 	rom ( name "Dynamite Dux (1989)(Activision)(Side B).dsk" size 175589 crc 78F2CE58 md5 DA4175E79D6BC4AEF47475EE0A62C307 sha1 7307C20F996595F08ADD613BE7F34BBF286976E3 )
+	rom ( name "Dynamite Dux (1989)(Activision)(Side A).dsk" size 175589 crc B9D58E05 md5 A1390EA6A2387244DD024A5D4E096929 sha1 DFF2545F946D1944D1D5595178AD46B946AF0E71 )
 )
 game (
 	name "Deflektor (Gremlin Graphics Software)"
@@ -4192,8 +4192,8 @@ game (
 game (
 	name "Dr. Doom's Revenge (Empire Software) (M4) (Codes)"
 	description "Dr. Doom's Revenge (Empire Software) (M4) (Codes)"
-	rom ( name "Dr. Doom's Revenge (1989)(Empire Software)(M4)(Side A)[codes].dsk" size 194816 crc 3443AC53 md5 7D7FB3223539BC5FD13B8A1F6C0C02A4 sha1 B0EF4D68F772580F0A0A0A11C034B18C0870CBBF )
 	rom ( name "Dr. Doom's Revenge (1989)(Empire Software)(M4)(Side B)[codes].dsk" size 194816 crc 7EA86998 md5 58647112EDD44734CC099349D4E15932 sha1 C224673D38411B96C270A1239AB73DBD6A8F210A )
+	rom ( name "Dr. Doom's Revenge (1989)(Empire Software)(M4)(Side A)[codes].dsk" size 194816 crc 3443AC53 md5 7D7FB3223539BC5FD13B8A1F6C0C02A4 sha1 B0EF4D68F772580F0A0A0A11C034B18C0870CBBF )
 )
 game (
 	name "Dun Darach (Gargoyle Games)"
@@ -4213,8 +4213,8 @@ game (
 game (
 	name "Derniere Mission, La (MBC Informatique) (France)"
 	description "Derniere Mission, La (MBC Informatique) (France)"
-	rom ( name "Derniere Mission, La (1988)(MBC Informatique)(fr)(Side A).dsk" size 219776 crc 6B36FB72 md5 60B8DB6196F40D396B5BA35A9F66B501 sha1 9CE00A2F578F144883A63C6EB2A8E7AEDAB66708 )
 	rom ( name "Derniere Mission, La (1988)(MBC Informatique)(fr)(Side B).dsk" size 200517 crc 7B411704 md5 965901D684CCFF442E1B2A9451266BFD sha1 F9419521B11BB96138A83A555C642BE859022916 )
+	rom ( name "Derniere Mission, La (1988)(MBC Informatique)(fr)(Side A).dsk" size 219776 crc 6B36FB72 md5 60B8DB6196F40D396B5BA35A9F66B501 sha1 9CE00A2F578F144883A63C6EB2A8E7AEDAB66708 )
 )
 game (
 	name "Dynamix (Virgin Games)"
@@ -4239,8 +4239,8 @@ game (
 game (
 	name "Defender of the Crown (Cinemaware) (France)"
 	description "Defender of the Crown (Cinemaware) (France)"
-	rom ( name "Defender of the Crown (1987)(Cinemaware)(fr)(Side A).dsk" size 267520 crc B857F5CA md5 D959688A3B61ADA9884CC5309237FA77 sha1 E014E92B0EACC400A8C1D58701611769A68200DC )
 	rom ( name "Defender of the Crown (1987)(Cinemaware)(fr)(Side B).dsk" size 267520 crc FF0A5212 md5 1D23CB4780F041A948AF4F46D8F00D4F sha1 F42600FF6C1AAA60F0633D8B5BC863B628D1BBB6 )
+	rom ( name "Defender of the Crown (1987)(Cinemaware)(fr)(Side A).dsk" size 267520 crc B857F5CA md5 D959688A3B61ADA9884CC5309237FA77 sha1 E014E92B0EACC400A8C1D58701611769A68200DC )
 )
 game (
 	name "Dick Tracy (Titus)"
@@ -4340,8 +4340,8 @@ game (
 game (
 	name "Elite (Firebird)"
 	description "Elite (Firebird)"
-	rom ( name "Elite (1985)(Firebird)(Side A)[GOLD].dsk" size 200517 crc 327572F5 md5 5F2503615133938A2ED09087F2B4DA57 sha1 4D0C2EEA0C1C2CCE541F19D49D377A9F26D56475 )
 	rom ( name "Elite (1985)(Firebird)(Side B)[GOLD].dsk" size 194816 crc 334EA46A md5 BBC8E23685CB72B95CD98776BF8433DA sha1 9C231E1065862682CF15699460D4058FD49115A1 )
+	rom ( name "Elite (1985)(Firebird)(Side A)[GOLD].dsk" size 200517 crc 327572F5 md5 5F2503615133938A2ED09087F2B4DA57 sha1 4D0C2EEA0C1C2CCE541F19D49D377A9F26D56475 )
 )
 game (
 	name "Esgrima Electrico (Amstrad Computer User) (Spain)"
@@ -4451,8 +4451,8 @@ game (
 game (
 	name "Evasion (Alain Massoumipour) (France)"
 	description "Evasion (Alain Massoumipour) (France)"
-	rom ( name "Evasion (1987)(Alain Massoumipour)(fr)(Side A)[cr].dsk" size 194816 crc 525CB704 md5 32809AC0BEA1C3419C5196AC11502080 sha1 7B583A4F5C03331DED6164B48D0AB8F39E4180C1 )
 	rom ( name "Evasion (1987)(Alain Massoumipour)(fr)(Side B)[cr].dsk" size 194816 crc 599212BD md5 171B9D152AC9AC0501930CAEECF57CE0 sha1 B0C50AFF6175D4AF3DE858D464EC585E82EDDA01 )
+	rom ( name "Evasion (1987)(Alain Massoumipour)(fr)(Side A)[cr].dsk" size 194816 crc 525CB704 md5 32809AC0BEA1C3419C5196AC11502080 sha1 7B583A4F5C03331DED6164B48D0AB8F39E4180C1 )
 )
 game (
 	name "Elidon (Orpheus)"
@@ -4487,8 +4487,8 @@ game (
 game (
 	name "Exit (Ubi Soft) (France)"
 	description "Exit (Ubi Soft) (France)"
-	rom ( name "Exit (1988)(Ubi Soft)(fr)(Side A).dsk" size 196347 crc 8442D3BB md5 ECB854988295470FB5A39CA00D439756 sha1 B9E3B12E522B2CAD75C0CAE1699B04042BF01C61 )
 	rom ( name "Exit (1988)(Ubi Soft)(fr)(Side B).dsk" size 204544 crc E6DE21C md5 2E323CDDE7BF6FEBB5EBEA0CD1F31CA8 sha1 21E37C5D11B187CD85DABBFE0A5B172755125372 )
+	rom ( name "Exit (1988)(Ubi Soft)(fr)(Side A).dsk" size 196347 crc 8442D3BB md5 ECB854988295470FB5A39CA00D439756 sha1 B9E3B12E522B2CAD75C0CAE1699B04042BF01C61 )
 )
 game (
 	name "Every Second Counts (Domark)"
@@ -4593,8 +4593,8 @@ game (
 game (
 	name "Excalibur Quest (Excalibur) (France)"
 	description "Excalibur Quest (Excalibur) (France)"
-	rom ( name "Excalibur Quest (1988)(Excalibur)(fr)(Side A).dsk" size 267263 crc AC0091EA md5 67B2670ED77E78F91F27F1A08074855C sha1 45767FE36FBBA971EF4BCF7B237D95F01A1C6C45 )
 	rom ( name "Excalibur Quest (1988)(Excalibur)(fr)(Side B).dsk" size 267331 crc EC2A7E20 md5 62758C2B8C0DA0F4D876C5D32E141D62 sha1 8EDC7100E3FC0D42CF232846319643321DB9A083 )
+	rom ( name "Excalibur Quest (1988)(Excalibur)(fr)(Side A).dsk" size 267263 crc AC0091EA md5 67B2670ED77E78F91F27F1A08074855C sha1 45767FE36FBBA971EF4BCF7B237D95F01A1C6C45 )
 )
 game (
 	name "Electro Freddy (Amsoft)"
@@ -4649,8 +4649,8 @@ game (
 game (
 	name "Flimbo's Quest (System 3)"
 	description "Flimbo's Quest (System 3)"
-	rom ( name "Flimbo's Quest (1990)(System 3)(Side A).dsk" size 212999 crc 3978C90E md5 78102D7DE6D822A44F01A2518D70952E sha1 04788517770F4491C250433B89502907F0C1DC22 )
 	rom ( name "Flimbo's Quest (1990)(System 3)(Side B).dsk" size 201289 crc 2A36C58B md5 34D806BF63E3DEDB8D4166C4B07A7C58 sha1 707E62C5E6E721627F361979B0AC0402F10E44F5 )
+	rom ( name "Flimbo's Quest (1990)(System 3)(Side A).dsk" size 212999 crc 3978C90E md5 78102D7DE6D822A44F01A2518D70952E sha1 04788517770F4491C250433B89502907F0C1DC22 )
 )
 game (
 	name "Five A Side Soccer (Mastertronic)"
@@ -4925,10 +4925,10 @@ game (
 game (
 	name "Fer & Flamme (Ubi Soft) (France)"
 	description "Fer & Flamme (Ubi Soft) (France)"
-	rom ( name "Fer & Flamme (1986)(Ubi Soft)(fr)(Disk 1 Side A).dsk" size 203597 crc BC7B47C3 md5 AF3DD8C14E7382DE414BF85FA8B99050 sha1 12CC081FE95CC829D1C4BA28D313DBCAA6638A74 )
 	rom ( name "Fer & Flamme (1986)(Ubi Soft)(fr)(Disk 1 Side B).dsk" size 205399 crc 7E46BA9D md5 0A6E848B1606451F84B6714B00514543 sha1 79CBCC47246F18EC125361269570A6080457D14D )
 	rom ( name "Fer & Flamme (1986)(Ubi Soft)(fr)(Disk 2 Side A).dsk" size 195635 crc 3F36917A md5 1529239F88482154B329914DFCA09293 sha1 00207C2FAB1A9C66DBD6B9F6F64CA8AB8FD6BA57 )
 	rom ( name "Fer & Flamme (1986)(Ubi Soft)(fr)(Disk 2 Side B).dsk" size 195635 crc 4BC9D603 md5 54928293725A502AB4E2A66ABC2D7021 sha1 E63F447BEB093539CD9E6EE3356068F0D5FCD4EC )
+	rom ( name "Fer & Flamme (1986)(Ubi Soft)(fr)(Disk 1 Side A).dsk" size 203597 crc BC7B47C3 md5 AF3DD8C14E7382DE414BF85FA8B99050 sha1 12CC081FE95CC829D1C4BA28D313DBCAA6638A74 )
 )
 game (
 	name "Fallout (Amstrad Action Magazine)"
@@ -4983,8 +4983,8 @@ game (
 game (
 	name "Faial (Excalibur) (France)"
 	description "Faial (Excalibur) (France)"
-	rom ( name "Faial (1986)(Excalibur)(fr)(Side A).dsk" size 198211 crc BCA5ACB2 md5 56FE7E75E3D287E949C20E98B3EC0088 sha1 7AFF0592E7BEB9F9B87147D6FAE1A29CA4940F75 )
 	rom ( name "Faial (1986)(Excalibur)(fr)(Side B).dsk" size 198211 crc CA2062F6 md5 7AD20CDBF59B6D33ADB7481C179B05DA sha1 A1044BD0B762C3C3850C905F25A7D1C28184BA00 )
+	rom ( name "Faial (1986)(Excalibur)(fr)(Side A).dsk" size 198211 crc BCA5ACB2 md5 56FE7E75E3D287E949C20E98B3EC0088 sha1 7AFF0592E7BEB9F9B87147D6FAE1A29CA4940F75 )
 )
 game (
 	name "Foso Del Dragon, El (Geasa) (Spain)"
@@ -5049,10 +5049,10 @@ game (
 game (
 	name "Fres Fighter II Turbo v1.5 (Bollaware)"
 	description "Fres Fighter II Turbo v1.5 (Bollaware)"
-	rom ( name "Fres Fighter II Turbo v1.5 (1999)(Bollaware)(PD)(Disk 1 Side A)[cr].dsk" size 225024 crc EB63B31B md5 5D943B0F98D2CA8AB97779593311FE74 sha1 40ECC9E02FAA2B25E1C3312C9B5F0B8A03A1EF8D )
 	rom ( name "Fres Fighter II Turbo v1.5 (1999)(Bollaware)(PD)(Disk 1 Side B)[cr].dsk" size 226048 crc F8BB19BE md5 BB794AE4966828F8F2AD881357266C73 sha1 7466A97EAF85EEA7E85C62573335D6883005248F )
 	rom ( name "Fres Fighter II Turbo v1.5 (1999)(Bollaware)(PD)(Disk 2 Side A)[cr].dsk" size 226048 crc 56EFF60D md5 1D6CA06697520DCF9EA96D087795DE95 sha1 D11CFB46F17F09347A8F68F59A82FFF43757CC36 )
 	rom ( name "Fres Fighter II Turbo v1.5 (1999)(Bollaware)(PD)(Disk 2 Side B)[cr].dsk" size 226048 crc 58E3E90C md5 B6612BAF34147058F7A7E36FB615E55D sha1 96232D0A26EF8F363965991A20CB5A87FDACCFB6 )
+	rom ( name "Fres Fighter II Turbo v1.5 (1999)(Bollaware)(PD)(Disk 1 Side A)[cr].dsk" size 225024 crc EB63B31B md5 5D943B0F98D2CA8AB97779593311FE74 sha1 40ECC9E02FAA2B25E1C3312C9B5F0B8A03A1EF8D )
 )
 game (
 	name "Frank Bruno's Boxing (Elite Systems)"
@@ -5067,8 +5067,8 @@ game (
 game (
 	name "Freedom (Coktel Vision) (France)"
 	description "Freedom (Coktel Vision) (France)"
-	rom ( name "Freedom (1988)(Coktel Vision)(fr)(Side A).dsk" size 201817 crc 9B449B3B md5 843742D937148652745A4049BD68324E sha1 0153662736D968CAB60EC32D657CF21179FE1F02 )
 	rom ( name "Freedom (1988)(Coktel Vision)(fr)(Side B).dsk" size 195635 crc DC40FFFA md5 BC15458D94724166A7FF6F8C7F3B2A88 sha1 214B80135B422A0954704EA56DD46368652E21BE )
+	rom ( name "Freedom (1988)(Coktel Vision)(fr)(Side A).dsk" size 201817 crc 9B449B3B md5 843742D937148652745A4049BD68324E sha1 0153662736D968CAB60EC32D657CF21179FE1F02 )
 )
 game (
 	name "Flight Path 737 (Anirog Software) (M5)"
@@ -5103,8 +5103,8 @@ game (
 game (
 	name "Frankie Crashed on Jupiter (Kingsoft)"
 	description "Frankie Crashed on Jupiter (Kingsoft)"
-	rom ( name "Frankie Crashed on Jupiter (1985)(Kingsoft)(Side A).dsk" size 195381 crc 165BF3EA md5 1189C82D808AB9C44D598E748741900A sha1 BEE64CAC13A9E0E570C4CCA38042CB02AEB32392 )
 	rom ( name "Frankie Crashed on Jupiter (1985)(Kingsoft)(Side B).dsk" size 195637 crc 6F473E32 md5 D35D228F75032AB844DB10F570AF4F40 sha1 8FEE0BEBF4B7A803C2BB22B122E98223B21BED1F )
+	rom ( name "Frankie Crashed on Jupiter (1985)(Kingsoft)(Side A).dsk" size 195381 crc 165BF3EA md5 1189C82D808AB9C44D598E748741900A sha1 BEE64CAC13A9E0E570C4CCA38042CB02AEB32392 )
 )
 game (
 	name "Fast Food Dizzy (Codemasters Software)"
@@ -5144,8 +5144,8 @@ game (
 game (
 	name "Fiendish Freddy's Big Top O' Fun (Mindscape) (Codes)"
 	description "Fiendish Freddy's Big Top O' Fun (Mindscape) (Codes)"
-	rom ( name "Fiendish Freddy's Big Top O' Fun (1990)(Mindscape)(Side A)[codes].dsk" size 211179 crc DF73E59F md5 A40DE8331FECBB27A66E711709B5FAA5 sha1 0BFE13A72226155BCBC0A1A217E39087B4E6BBEE )
 	rom ( name "Fiendish Freddy's Big Top O' Fun (1990)(Mindscape)(Side B)[codes].dsk" size 211179 crc 9F51A10D md5 D60CE2D8DC4A787576DEC4B28126840B sha1 FBE82223E4642BFB6BDFD48EF601F1D381FE5931 )
+	rom ( name "Fiendish Freddy's Big Top O' Fun (1990)(Mindscape)(Side A)[codes].dsk" size 211179 crc DF73E59F md5 A40DE8331FECBB27A66E711709B5FAA5 sha1 0BFE13A72226155BCBC0A1A217E39087B4E6BBEE )
 )
 game (
 	name "Football Manager World Cup Edition (Addictive Games) (de)"
@@ -5185,8 +5185,8 @@ game (
 game (
 	name "Fighter Bomber (Activision)"
 	description "Fighter Bomber (Activision)"
-	rom ( name "Fighter Bomber (1990)(Activision)(Side A).dsk" size 202739 crc 66AC0BB2 md5 23E78361513CA98200F222CB0DE9764B sha1 D09C639F8D673F092DD701B06817FC294A1C50D6 )
 	rom ( name "Fighter Bomber (1990)(Activision)(Side B).dsk" size 195635 crc DFE64E49 md5 07726538C305B652642048F766CAA03D sha1 9F5E64CD5B553D2805FA5FF1E5C4EBF82D446DD9 )
+	rom ( name "Fighter Bomber (1990)(Activision)(Side A).dsk" size 202739 crc 66AC0BB2 md5 23E78361513CA98200F222CB0DE9764B sha1 D09C639F8D673F092DD701B06817FC294A1C50D6 )
 )
 game (
 	name "Fox (Hebdogiciel) (France)"
@@ -5221,8 +5221,8 @@ game (
 game (
 	name "Griffes de la Nuit, Les (Bruno Fonters) (France)"
 	description "Griffes de la Nuit, Les (Bruno Fonters) (France)"
-	rom ( name "Griffes de la Nuit, Les (1993)(Bruno Fonters)(fr)(Side A)[cr].dsk" size 194816 crc 12A1EFEA md5 B3A2E12B9DCC81A6CD3117038AD94261 sha1 4B0FA28F0164CB7C4633BFC2C2E0DA43C11105A9 )
 	rom ( name "Griffes de la Nuit, Les (1993)(Bruno Fonters)(fr)(Side B)[cr].dsk" size 194816 crc CBF78B75 md5 17970FD3DADD2CAE0FB9EA13CD84B707 sha1 3E3FD1A8BBC7BB3BDE0C38C1F422CCD6783B6AAF )
+	rom ( name "Griffes de la Nuit, Les (1993)(Bruno Fonters)(fr)(Side A)[cr].dsk" size 194816 crc 12A1EFEA md5 B3A2E12B9DCC81A6CD3117038AD94261 sha1 4B0FA28F0164CB7C4633BFC2C2E0DA43C11105A9 )
 )
 game (
 	name "Galactic Plague, The (Amsoft)"
@@ -5242,8 +5242,8 @@ game (
 game (
 	name "Games, The - Winter Edition (US Gold)"
 	description "Games, The - Winter Edition (US Gold)"
-	rom ( name "Games, The - Winter Edition (1988)(US Gold)(Side A).dsk" size 195653 crc ED14021D md5 51EF1347E442EFF43C8164BB64923C1A sha1 904EE39A2438B7504ED8247B224D5F71BBE31A30 )
 	rom ( name "Games, The - Winter Edition (1988)(US Gold)(Side B).dsk" size 195653 crc 75F9C549 md5 1222B000A2408989699E4BA2295AE956 sha1 F5C9D80B1130BED58E06ED286F18AE456398ED9F )
+	rom ( name "Games, The - Winter Edition (1988)(US Gold)(Side A).dsk" size 195653 crc ED14021D md5 51EF1347E442EFF43C8164BB64923C1A sha1 904EE39A2438B7504ED8247B224D5F71BBE31A30 )
 )
 game (
 	name "Gabrielle (Ubi Soft) (France)"
@@ -5268,8 +5268,8 @@ game (
 game (
 	name "Gnome Ranger (Level 9 Computing)"
 	description "Gnome Ranger (Level 9 Computing)"
-	rom ( name "Gnome Ranger (1987)(Level 9 Computing)(Side A).dsk" size 195635 crc B0A79287 md5 7850D3A9F549B8F8F3245F8AAE8F91A3 sha1 CDD80AA533A24ABF6ACFF0D11A7E072E50897900 )
 	rom ( name "Gnome Ranger (1987)(Level 9 Computing)(Side B).dsk" size 195635 crc 98AA854B md5 80189675B5D4CE5128011F0A846B4FB5 sha1 6F2192BE9ED37BC98DFDEFB5F1C045E9A9C282C2 )
+	rom ( name "Gnome Ranger (1987)(Level 9 Computing)(Side A).dsk" size 195635 crc B0A79287 md5 7850D3A9F549B8F8F3245F8AAE8F91A3 sha1 CDD80AA533A24ABF6ACFF0D11A7E072E50897900 )
 )
 game (
 	name "Gob (TJC)"
@@ -5349,8 +5349,8 @@ game (
 game (
 	name "Guild of Thieves, The (Rainbird Software)"
 	description "Guild of Thieves, The (Rainbird Software)"
-	rom ( name "Guild of Thieves, The (1988)(Rainbird Software)(v2)(Side A).dsk" size 195637 crc 429F78F6 md5 AC560E623EA571B7F52753844D854BAA sha1 9D272D0921F49D29A4DDDE9103E01DB5DFC13FC3 )
 	rom ( name "Guild of Thieves, The (1988)(Rainbird Software)(v2)(Side B).dsk" size 195637 crc E9DDD253 md5 86AEAA7626DE2DD4298CBA87D984D0A9 sha1 72024E27CA23920ACB1077A3E17C012C9A8B045C )
+	rom ( name "Guild of Thieves, The (1988)(Rainbird Software)(v2)(Side A).dsk" size 195637 crc 429F78F6 md5 AC560E623EA571B7F52753844D854BAA sha1 9D272D0921F49D29A4DDDE9103E01DB5DFC13FC3 )
 )
 game (
 	name "Gridrider (PC Amstrad International)"
@@ -5380,8 +5380,8 @@ game (
 game (
 	name "Games, The - Summer Edition (US Gold)"
 	description "Games, The - Summer Edition (US Gold)"
-	rom ( name "Games, The - Summer Edition (1989)(US Gold)(Side A).dsk" size 220581 crc F10EE3FC md5 49313D74A2B6F9190D1AEAFDC0BECA01 sha1 942BB77F7CEE71EC7D92FFD08E04EE8C79759A09 )
 	rom ( name "Games, The - Summer Edition (1989)(US Gold)(Side B).dsk" size 220581 crc 271A1461 md5 C64C1C6270113DEE872686EDC39B82FE sha1 4A7703A4E50FA2DAF7C81F2EA896742128E82E9F )
+	rom ( name "Games, The - Summer Edition (1989)(US Gold)(Side A).dsk" size 220581 crc F10EE3FC md5 49313D74A2B6F9190D1AEAFDC0BECA01 sha1 942BB77F7CEE71EC7D92FFD08E04EE8C79759A09 )
 )
 game (
 	name "Glen Hoddle Soccer (Amsoft) (Spain)"
@@ -5471,8 +5471,8 @@ game (
 game (
 	name "Galactic Games (Activision)"
 	description "Galactic Games (Activision)"
-	rom ( name "Galactic Games (1987)(Activision)(Side A).dsk" size 195379 crc E963B88F md5 6DC4A56448D1E2DA96F67820CF991199 sha1 F76DA87419129FDBFED8B475E8A2CCD7930C0D09 )
 	rom ( name "Galactic Games (1987)(Activision)(Side B).dsk" size 195379 crc 445C6C5D md5 92607F878392F00F865D20866595EF9F sha1 BB9C45419E33C66D394F68F314A3862986E94ADF )
+	rom ( name "Galactic Games (1987)(Activision)(Side A).dsk" size 195379 crc E963B88F md5 6DC4A56448D1E2DA96F67820CF991199 sha1 F76DA87419129FDBFED8B475E8A2CCD7930C0D09 )
 )
 game (
 	name "Galaxias (Delta 4 Software)"
@@ -5552,8 +5552,8 @@ game (
 game (
 	name "Gunship (Microprose Software)"
 	description "Gunship (Microprose Software)"
-	rom ( name "Gunship (1988)(Microprose Software)(Side A).dsk" size 195328 crc 7F1E18B6 md5 E073EC265CC216D3399C631238B3A017 sha1 48DCF4D277E6E484153787AD20F2F24EEF97D410 )
 	rom ( name "Gunship (1988)(Microprose Software)(Side B).dsk" size 194816 crc 648096F9 md5 DBAC26F85FC8B8DC27CEB574B0F8CACB sha1 951A1209283C779DA9B3E33581A2A7DC5843BF41 )
+	rom ( name "Gunship (1988)(Microprose Software)(Side A).dsk" size 195328 crc 7F1E18B6 md5 E073EC265CC216D3399C631238B3A017 sha1 48DCF4D277E6E484153787AD20F2F24EEF97D410 )
 )
 game (
 	name "Gladiator (Domark)"
@@ -5658,16 +5658,16 @@ game (
 game (
 	name "Globe-Trotter (Excalibur) (France)"
 	description "Globe-Trotter (Excalibur) (France)"
-	rom ( name "Globe-Trotter (1986)(Excalibur)(fr)(Disk 1 Side A).dsk" size 207104 crc C8D40FE6 md5 5AFE6F62C1AB0474EFA381BB378DDB8F sha1 07597D362EE40FD24AB7C12B9A0A563EF2CD417F )
 	rom ( name "Globe-Trotter (1986)(Excalibur)(fr)(Disk 1 Side B).dsk" size 207104 crc 9951E870 md5 D02D0912CBD3437067A969A8961895AF sha1 F91D3FCD953960520D10C1A2DE66AD8DB98EC837 )
 	rom ( name "Globe-Trotter (1986)(Excalibur)(fr)(Disk 2 Side A).dsk" size 207104 crc FBE93C98 md5 5744568DB26EBEBB59CDC4389971A183 sha1 7F771BA621C3264E7F42B414CFA0826E6439BF83 )
 	rom ( name "Globe-Trotter (1986)(Excalibur)(fr)(Disk 2 Side B).dsk" size 207104 crc 1A07C6CC md5 3467D92CC761799627DCDE021DB68092 sha1 9429D5CD1E5C2C6C30E1C57B04BCCDA4537EF5C0 )
+	rom ( name "Globe-Trotter (1986)(Excalibur)(fr)(Disk 1 Side A).dsk" size 207104 crc C8D40FE6 md5 5AFE6F62C1AB0474EFA381BB378DDB8F sha1 07597D362EE40FD24AB7C12B9A0A563EF2CD417F )
 )
 game (
 	name "Gunsmoke (Topo Soft)"
 	description "Gunsmoke (Topo Soft)"
-	rom ( name "Gunsmoke (1987)(Topo Soft)(Side A).dsk" size 195653 crc D75D55F7 md5 B23F272A7E53B43ADD3F3EA6C8E62182 sha1 A3FDDC9BEE30E5F0081E349F61031E76F665AEB6 )
 	rom ( name "Gunsmoke (1987)(Topo Soft)(Side B).dsk" size 195635 crc 1C3B929E md5 31CAC4DFEF379CDE1D973763DC6A4658 sha1 00584186BF6D42844CB5AC7EAEEF346FDD237D1E )
+	rom ( name "Gunsmoke (1987)(Topo Soft)(Side A).dsk" size 195653 crc D75D55F7 md5 B23F272A7E53B43ADD3F3EA6C8E62182 sha1 A3FDDC9BEE30E5F0081E349F61031E76F665AEB6 )
 )
 game (
 	name "Ghostbusters II (Activision)"
@@ -5682,8 +5682,8 @@ game (
 game (
 	name "Gunship (Microprose Software) (France)"
 	description "Gunship (Microprose Software) (France)"
-	rom ( name "Gunship (1988)(Microprose Software)(fr)(v3)(Side A).dsk" size 200261 crc CA159214 md5 CB7194300C27097199D2CB321F25240D sha1 69F1C4E6C7B9FDDF07D21D1454B2EDD1DAA3851A )
 	rom ( name "Gunship (1988)(Microprose Software)(fr)(v3)(Side B).dsk" size 195635 crc 43D7ECE6 md5 351BB17EF331F0EB9BEF7AA7AD128747 sha1 3A3D9485FC97A282C32A456B0F919E13EE3D6E87 )
+	rom ( name "Gunship (1988)(Microprose Software)(fr)(v3)(Side A).dsk" size 200261 crc CA159214 md5 CB7194300C27097199D2CB321F25240D sha1 69F1C4E6C7B9FDDF07D21D1454B2EDD1DAA3851A )
 )
 game (
 	name "Grell and Falla (Codemasters Software)"
@@ -5698,8 +5698,8 @@ game (
 game (
 	name "Golden Axe (Virgin Games)"
 	description "Golden Axe (Virgin Games)"
-	rom ( name "Golden Axe (1990)(Virgin Games)(Side A).dsk" size 194816 crc AD37A08F md5 4EAB60E633BA9F812D1F15D431304EDC sha1 89E1A766E4DE456B3DE3F925F79FDB66F766C44C )
 	rom ( name "Golden Axe (1990)(Virgin Games)(Side B).dsk" size 194816 crc 7B7AB214 md5 1DBAA178CDEE9162CA791858E3B3386A sha1 ABA509C662E128BD0F7F62B7E636F37B6F8DD1AD )
+	rom ( name "Golden Axe (1990)(Virgin Games)(Side A).dsk" size 194816 crc AD37A08F md5 4EAB60E633BA9F812D1F15D431304EDC sha1 89E1A766E4DE456B3DE3F925F79FDB66F766C44C )
 )
 game (
 	name "Growing Pains of Adrian Mole, The (Virgin Games)"
@@ -5749,8 +5749,8 @@ game (
 game (
 	name "Golden Path (Amsoft)"
 	description "Golden Path (Amsoft)"
-	rom ( name "Golden Path (1986)(Amsoft)(Side A).dsk" size 195635 crc 7B14ADE8 md5 1BAEEC93D10DF50E643C6F952B4D31C9 sha1 9490D5469DFF1B325B8328D0EDF68C9C8C782DD7 )
 	rom ( name "Golden Path (1986)(Amsoft)(Side B).dsk" size 195635 crc 33CF7B85 md5 D3F3C150D0F35EB798CCA61E668D9255 sha1 95828119E1B8D8D9759E1D40E6D0A3F50E0B4B2E )
+	rom ( name "Golden Path (1986)(Amsoft)(Side A).dsk" size 195635 crc 7B14ADE8 md5 1BAEEC93D10DF50E643C6F952B4D31C9 sha1 9490D5469DFF1B325B8328D0EDF68C9C8C782DD7 )
 )
 game (
 	name "Grand Prix Driver (Amsoft)"
@@ -5765,8 +5765,8 @@ game (
 game (
 	name "Gauntlet III - The Final Quest (US Gold)"
 	description "Gauntlet III - The Final Quest (US Gold)"
-	rom ( name "Gauntlet III - The Final Quest (1991)(US Gold)(Side A).dsk" size 265413 crc 966760B8 md5 246C385BCA354681370C6358C7BEAEEE sha1 CFD47DCF91F5CE651B0C2DB0C555E7688AAE206E )
 	rom ( name "Gauntlet III - The Final Quest (1991)(US Gold)(Side B).dsk" size 266675 crc 4327D6F2 md5 DD2894071640545E0AC6B6F7D3C2CA7C sha1 98D40A428778EE538FE33B7906CC8BF4171037ED )
+	rom ( name "Gauntlet III - The Final Quest (1991)(US Gold)(Side A).dsk" size 265413 crc 966760B8 md5 246C385BCA354681370C6358C7BEAEEE sha1 CFD47DCF91F5CE651B0C2DB0C555E7688AAE206E )
 )
 game (
 	name "Gremlins (Adventure International) (de)"
@@ -5871,8 +5871,8 @@ game (
 game (
 	name "Heroes of the Lance (US Gold) (Codes)"
 	description "Heroes of the Lance (US Gold) (Codes)"
-	rom ( name "Heroes of the Lance (1988)(US Gold)(Side A)[codes].dsk" size 195635 crc 5D038C8E md5 8831E872F138A36FCFE7CD7453B26065 sha1 D1510850076E5A8594C7B2F9EF611CEC62A7E492 )
 	rom ( name "Heroes of the Lance (1988)(US Gold)(Side B)[codes].dsk" size 195635 crc 593B4ABD md5 F29B8D4304826D929DBB07E56B4E07FA sha1 94BBF033276E13D6306F7D06A04AC3E9078C7178 )
+	rom ( name "Heroes of the Lance (1988)(US Gold)(Side A)[codes].dsk" size 195635 crc 5D038C8E md5 8831E872F138A36FCFE7CD7453B26065 sha1 D1510850076E5A8594C7B2F9EF611CEC62A7E492 )
 )
 game (
 	name "Hawk Storm (Players Premier)"
@@ -5907,8 +5907,8 @@ game (
 game (
 	name "Hunt for Red October, The - Based on the Movie (Grandslam Entertainments)"
 	description "Hunt for Red October, The - Based on the Movie (Grandslam Entertainments)"
-	rom ( name "Hunt for Red October, The - Based on the Movie (1991)(Grandslam Entertainments)(Side A).dsk" size 195635 crc 555335B1 md5 31661D36D3D46559F847E3FBEA71137C sha1 6EFF073A44287367DFB1F42213DEFBD4A8F2FFB3 )
 	rom ( name "Hunt for Red October, The - Based on the Movie (1991)(Grandslam Entertainments)(Side B).dsk" size 195635 crc 4E784626 md5 5345F05EDC820267EABC130BE1552395 sha1 FD17153E65376DF5888977DE5A9587818788628A )
+	rom ( name "Hunt for Red October, The - Based on the Movie (1991)(Grandslam Entertainments)(Side A).dsk" size 195635 crc 555335B1 md5 31661D36D3D46559F847E3FBEA71137C sha1 6EFF073A44287367DFB1F42213DEFBD4A8F2FFB3 )
 )
 game (
 	name "Howard the Duck (Activision)"
@@ -5918,8 +5918,8 @@ game (
 game (
 	name "Hostages - Operation Jupiter (Infogrames)"
 	description "Hostages - Operation Jupiter (Infogrames)"
-	rom ( name "Hostages - Operation Jupiter (1990)(Infogrames)(v2)(Side A).dsk" size 202315 crc 2EEE44C4 md5 7C03A55D66EFE3C13E224ED8DA4C7E02 sha1 45AB0D26FDC7E5678CCB5ECF9A5C455AF9464830 )
 	rom ( name "Hostages - Operation Jupiter (1990)(Infogrames)(v2)(Side B).dsk" size 169984 crc 94340E6F md5 DF9F64BD18FB8CC81C40E15A14E22E97 sha1 A9E657CC23F3CD8473196EEEEF74C02D21666A22 )
+	rom ( name "Hostages - Operation Jupiter (1990)(Infogrames)(v2)(Side A).dsk" size 202315 crc 2EEE44C4 md5 7C03A55D66EFE3C13E224ED8DA4C7E02 sha1 45AB0D26FDC7E5678CCB5ECF9A5C455AF9464830 )
 )
 game (
 	name "High Epidemy (FIL) (France)"
@@ -5964,8 +5964,8 @@ game (
 game (
 	name "Han d'Islande (Loriciels) (France)"
 	description "Han d'Islande (Loriciels) (France)"
-	rom ( name "Han d'Islande (1988)(Loriciels)(fr)(Side A).dsk" size 269911 crc 1551412E md5 14EEBA8357AF406B3AF787DB0305EBF6 sha1 4D6E89A8C9EB9E0FC9A0208F51B5B15962FE1F63 )
 	rom ( name "Han d'Islande (1988)(Loriciels)(fr)(Side B).dsk" size 280663 crc 58399CB9 md5 E273EAB4FD5E2E77D539D008F3E91FEB sha1 50D5782C4B13ACE3E31DE76DAA28D982F42B44E0 )
+	rom ( name "Han d'Islande (1988)(Loriciels)(fr)(Side A).dsk" size 269911 crc 1551412E md5 14EEBA8357AF406B3AF787DB0305EBF6 sha1 4D6E89A8C9EB9E0FC9A0208F51B5B15962FE1F63 )
 )
 game (
 	name "Harvey Headbanger (Firebird)"
@@ -6015,14 +6015,14 @@ game (
 game (
 	name "Harry & Harry - Mission Torpedo (ERE Informatique) (France)"
 	description "Harry & Harry - Mission Torpedo (ERE Informatique) (France)"
-	rom ( name "Harry & Harry - Mission Torpedo (1986)(ERE Informatique)(fr)(Side A).dsk" size 267315 crc 3F6DBD27 md5 4DBE6A57ED0218929EE08D496EC58021 sha1 1944F82AC43EFCDE30D223D8558384B7D2C8B271 )
 	rom ( name "Harry & Harry - Mission Torpedo (1986)(ERE Informatique)(fr)(Side B).dsk" size 267315 crc B4A56FBB md5 6F27425AC2B38CFF87B5348A47358385 sha1 EDE218C2F9081DE94DAD17CB7EF7ABEFE72D076B )
+	rom ( name "Harry & Harry - Mission Torpedo (1986)(ERE Informatique)(fr)(Side A).dsk" size 267315 crc 3F6DBD27 md5 4DBE6A57ED0218929EE08D496EC58021 sha1 1944F82AC43EFCDE30D223D8558384B7D2C8B271 )
 )
 game (
 	name "Holocauste (MBC Informatique) (France)"
 	description "Holocauste (MBC Informatique) (France)"
-	rom ( name "Holocauste (1988)(MBC Informatique)(fr)(Side A).dsk" size 219904 crc A59BC588 md5 4CDE01DFF0A745760F9585D2E74C85DD sha1 AAC98A70C31CA3A2B1E238B99CE2D1ED3FF5227C )
 	rom ( name "Holocauste (1988)(MBC Informatique)(fr)(Side B).dsk" size 205399 crc 50032521 md5 CC4817D4BA08082C14C5D08A2D89371A sha1 1ACBE57E7988ECD7A388F1A28944E275801A91EA )
+	rom ( name "Holocauste (1988)(MBC Informatique)(fr)(Side A).dsk" size 219904 crc A59BC588 md5 4CDE01DFF0A745760F9585D2E74C85DD sha1 AAC98A70C31CA3A2B1E238B99CE2D1ED3FF5227C )
 )
 game (
 	name "Hero of the Golden Talisman (Mastertronic)"
@@ -6222,8 +6222,8 @@ game (
 game (
 	name "Hawaii (Excalibur) (France)"
 	description "Hawaii (Excalibur) (France)"
-	rom ( name "Hawaii (1987)(Excalibur)(fr)(Side A)[cr].dsk" size 194816 crc 74B874E2 md5 9514B4289C7C7273BCF8AE7ABB18EAC3 sha1 320BFDBC8BF5B7FBA15010E5DD93C8E0820ED1F1 )
 	rom ( name "Hawaii (1987)(Excalibur)(fr)(Side B)[cr].dsk" size 194816 crc AD2BA1B2 md5 FF2E2130518B04172CF2BE0FC19ECF41 sha1 D9004F1E195521AE03A117C6BD93239F3D1C65E1 )
+	rom ( name "Hawaii (1987)(Excalibur)(fr)(Side A)[cr].dsk" size 194816 crc 74B874E2 md5 9514B4289C7C7273BCF8AE7ABB18EAC3 sha1 320BFDBC8BF5B7FBA15010E5DD93C8E0820ED1F1 )
 )
 game (
 	name "Hyperspace - Time-Space Adventures (Cobra Soft) (Hack)"
@@ -6243,8 +6243,8 @@ game (
 game (
 	name "Hydra (Domark)"
 	description "Hydra (Domark)"
-	rom ( name "Hydra (1991)(Domark)(Side A).dsk" size 217457 crc 86F6ACFB md5 B08C89F9F87AA9538BE8799245FDC219 sha1 313EBDD0B8BBF856942DCFF545AA99AEB2AD61E8 )
 	rom ( name "Hydra (1991)(Domark)(Side B).dsk" size 217713 crc B555ADE6 md5 EE43E494FD0552B2BFC39C2B2715D97A sha1 99D82B4A378FF0EC3F28505516E33E833051E86E )
+	rom ( name "Hydra (1991)(Domark)(Side A).dsk" size 217457 crc 86F6ACFB md5 B08C89F9F87AA9538BE8799245FDC219 sha1 313EBDD0B8BBF856942DCFF545AA99AEB2AD61E8 )
 )
 game (
 	name "Hard Drivin' (Domark)"
@@ -6309,8 +6309,8 @@ game (
 game (
 	name "Helter Skelter (Audiogenic Software)"
 	description "Helter Skelter (Audiogenic Software)"
-	rom ( name "Helter Skelter (1990)(Audiogenic Software)(Side A).dsk" size 194816 crc 83C9554 md5 F88CF717F9A8B37EB17F922E277299F6 sha1 CE449FE66AB94F89757E3D47C30ECD829E72C44A )
 	rom ( name "Helter Skelter (1990)(Audiogenic Software)(Side B).dsk" size 194816 crc EF57BA22 md5 B9C6C540958F830F62ED618D177058B8 sha1 61DFDD246252C25FF3B051DFD0FD59E099D3ABCF )
+	rom ( name "Helter Skelter (1990)(Audiogenic Software)(Side A).dsk" size 194816 crc 83C9554 md5 F88CF717F9A8B37EB17F922E277299F6 sha1 CE449FE66AB94F89757E3D47C30ECD829E72C44A )
 )
 game (
 	name "Highway Encounter (Vortex Software)"
@@ -6320,8 +6320,8 @@ game (
 game (
 	name "Hurlements (Ubi Soft) (France)"
 	description "Hurlements (Ubi Soft) (France)"
-	rom ( name "Hurlements (1988)(Ubi Soft)(fr)(Side A).dsk" size 195635 crc 37376EBA md5 F864B9DB011C2A1CA7DC8E49B2C9CFE6 sha1 00BE6C254957810CDE3910A1BE048953A8DB4AB6 )
 	rom ( name "Hurlements (1988)(Ubi Soft)(fr)(Side B).dsk" size 273755 crc 7FED0FD7 md5 171A772B5250C7C1512DA8468E7FFFB3 sha1 410AA53E897FCE92F91AE0B176248B7B5212F0F2 )
+	rom ( name "Hurlements (1988)(Ubi Soft)(fr)(Side A).dsk" size 195635 crc 37376EBA md5 F864B9DB011C2A1CA7DC8E49B2C9CFE6 sha1 00BE6C254957810CDE3910A1BE048953A8DB4AB6 )
 )
 game (
 	name "Hyperspace - Aventures Spatio-Temporelles (Cobra Soft) (Spain) (Hack)"
@@ -6351,14 +6351,14 @@ game (
 game (
 	name "Histoire d'Or (Cobra Soft) (France)"
 	description "Histoire d'Or (Cobra Soft) (France)"
-	rom ( name "Histoire d'Or (1987)(Cobra Soft)(fr)(Side A).dsk" size 198211 crc 53FDB930 md5 B324637BA52BBD41A40613BF94B6E409 sha1 2AF7994B770825343BEEDA72CAC46F7CF7C88A84 )
 	rom ( name "Histoire d'Or (1987)(Cobra Soft)(fr)(Side B).dsk" size 198723 crc 7E49A54B md5 70E836DB63CA9D8306ED954278BA96B6 sha1 EBCB84564A2E41326E4926CD0D377BCA69A5427A )
+	rom ( name "Histoire d'Or (1987)(Cobra Soft)(fr)(Side A).dsk" size 198211 crc 53FDB930 md5 B324637BA52BBD41A40613BF94B6E409 sha1 2AF7994B770825343BEEDA72CAC46F7CF7C88A84 )
 )
 game (
 	name "Harry & Harry - La Boite De Rajmahal (ERE Informatique) (France)"
 	description "Harry & Harry - La Boite De Rajmahal (ERE Informatique) (France)"
-	rom ( name "Harry & Harry - La Boite De Rajmahal (1986)(ERE Informatique)(fr)(Side A).dsk" size 260123 crc 45B84584 md5 81CA8272BEB4DF07EF1548F78DC65740 sha1 5ADCDE5D6A3D661A901342DBFE90F96DE5AFA13C )
 	rom ( name "Harry & Harry - La Boite De Rajmahal (1986)(ERE Informatique)(fr)(Side B).dsk" size 100139 crc F2E8B8B8 md5 0E5A5117235E520A150C8D837B78D0A7 sha1 CCC7E6C2BEDE9E23A715265C0F7E44FA057DDE2E )
+	rom ( name "Harry & Harry - La Boite De Rajmahal (1986)(ERE Informatique)(fr)(Side A).dsk" size 260123 crc 45B84584 md5 81CA8272BEB4DF07EF1548F78DC65740 sha1 5ADCDE5D6A3D661A901342DBFE90F96DE5AFA13C )
 )
 game (
 	name "Hercules - Slayer of the Damned (Gremlin Graphics Software)"
@@ -6368,8 +6368,8 @@ game (
 game (
 	name "Hardball (Accolade)"
 	description "Hardball (Accolade)"
-	rom ( name "Hardball (1986)(Accolade)(Side A).dsk" size 195635 crc 357E7B6E md5 170783EF8709FC4B3335E408ECF981AD sha1 99AFC2EB3BFB4750EB19A520B6C121BCE1CFE1AF )
 	rom ( name "Hardball (1986)(Accolade)(Side B).dsk" size 195635 crc A8D83E1A md5 DDD57A1C52D131B9B421EFD3E811823A sha1 20F4BE9659654D2EC078225B3C7AB0AADF10D168 )
+	rom ( name "Hardball (1986)(Accolade)(Side A).dsk" size 195635 crc 357E7B6E md5 170783EF8709FC4B3335E408ECF981AD sha1 99AFC2EB3BFB4750EB19A520B6C121BCE1CFE1AF )
 )
 game (
 	name "Hunter-Killer (Amsoft)"
@@ -6399,8 +6399,8 @@ game (
 game (
 	name "Hopital Danger (B. & J. Dissoubret) (France)"
 	description "Hopital Danger (B. & J. Dissoubret) (France)"
-	rom ( name "Hopital Danger (1989)(B. & J. Dissoubret)(fr)(Side A)(PD)[cr].dsk" size 194816 crc 90668523 md5 040FBEF44CA41E52AABAA1C16F2D3439 sha1 351C3C8FC61B121F8203191A6D906D093948CA83 )
 	rom ( name "Hopital Danger (1989)(B. & J. Dissoubret)(fr)(Side B)(PD)[cr].dsk" size 215296 crc A0EF0055 md5 B09FB298B92FD92277F7CCA759BB4E00 sha1 EC063231ACA085B1CC3C4DF2232C9F1289F8A1A7 )
+	rom ( name "Hopital Danger (1989)(B. & J. Dissoubret)(fr)(Side A)(PD)[cr].dsk" size 194816 crc 90668523 md5 040FBEF44CA41E52AABAA1C16F2D3439 sha1 351C3C8FC61B121F8203191A6D906D093948CA83 )
 )
 game (
 	name "Humphrey (Zigurat Software) (Spain)"
@@ -6470,8 +6470,8 @@ game (
 game (
 	name "Ingrid's Back (Level 9 Computing)"
 	description "Ingrid's Back (Level 9 Computing)"
-	rom ( name "Ingrid's Back (1988)(Level 9 Computing)(Side A).dsk" size 195635 crc 2CCBCA1D md5 77C71395C01AE61A0529FD9F47DEAB40 sha1 E2D3ADEDDBAAD8BE145A5641106445E533C47429 )
 	rom ( name "Ingrid's Back (1988)(Level 9 Computing)(Side B).dsk" size 195635 crc 6C0EECE6 md5 32076232265D413109E735F15F4F5ABD sha1 3DC11779D020DC337D122D39DDD1553CBF375F20 )
+	rom ( name "Ingrid's Back (1988)(Level 9 Computing)(Side A).dsk" size 195635 crc 2CCBCA1D md5 77C71395C01AE61A0529FD9F47DEAB40 sha1 E2D3ADEDDBAAD8BE145A5641106445E533C47429 )
 )
 game (
 	name "Into Oblivion (Mastertronic)"
@@ -6491,14 +6491,14 @@ game (
 game (
 	name "Ice Guardian, The (Strategy Software)"
 	description "Ice Guardian, The (Strategy Software)"
-	rom ( name "Ice Guardian, The (1991)(Strategy Software)(Side A)[cr].dsk" size 194816 crc 453B613C md5 23C383F5D5BB03ECBF6CDC25B89E2534 sha1 DB9F2F93F6E7019CB813A075725590EA274DE06D )
 	rom ( name "Ice Guardian, The (1991)(Strategy Software)(Side B)[cr].dsk" size 194816 crc BF060A3A md5 25913DE1A77E9B6B2925D3F7DD7D6F9D sha1 23B1AD484EE163628E61408CAF881242B94B6007 )
+	rom ( name "Ice Guardian, The (1991)(Strategy Software)(Side A)[cr].dsk" size 194816 crc 453B613C md5 23C383F5D5BB03ECBF6CDC25B89E2534 sha1 DB9F2F93F6E7019CB813A075725590EA274DE06D )
 )
 game (
 	name "Infernal House (Lankhor) (France)"
 	description "Infernal House (Lankhor) (France)"
-	rom ( name "Infernal House (1991)(Lankhor)(fr)(Side A).dsk" size 274009 crc 1AC09F99 md5 3F0720B9ECB2DAF6053B51595C0EC616 sha1 74865B5737D496E721BCA213302BFC45AF0748AA )
 	rom ( name "Infernal House (1991)(Lankhor)(fr)(Side B).dsk" size 195635 crc CE141C60 md5 0AC15E8B8224FDF0C8C4FA825F9DAA92 sha1 41F2711805A35F3DEB4267E15B3012EA18D8ED07 )
+	rom ( name "Infernal House (1991)(Lankhor)(fr)(Side A).dsk" size 274009 crc 1AC09F99 md5 3F0720B9ECB2DAF6053B51595C0EC616 sha1 74865B5737D496E721BCA213302BFC45AF0748AA )
 )
 game (
 	name "Ikari Warriors (Elite Systems)"
@@ -6538,8 +6538,8 @@ game (
 game (
 	name "Iron Trackers (Microids)"
 	description "Iron Trackers (Microids)"
-	rom ( name "Iron Trackers (1989)(Microids)(Side A).dsk" size 194816 crc 67048019 md5 00CD2132A414C1A600D8E4DE242E0D70 sha1 BB0AEE063411B17632576D811CB9261C93335D06 )
 	rom ( name "Iron Trackers (1989)(Microids)(Side B).dsk" size 194816 crc 66956AFA md5 324164E6861934BDF9CCE20AD73437B9 sha1 3F170E7190954BB658FDEA050EF7961CB05C1DD3 )
+	rom ( name "Iron Trackers (1989)(Microids)(Side A).dsk" size 194816 crc 67048019 md5 00CD2132A414C1A600D8E4DE242E0D70 sha1 BB0AEE063411B17632576D811CB9261C93335D06 )
 )
 game (
 	name "Infection (Virgin Mastertronic)"
@@ -6549,8 +6549,8 @@ game (
 game (
 	name "Incantation (Softhawk) (France)"
 	description "Incantation (Softhawk) (France)"
-	rom ( name "Incantation (1987)(Softhawk)(fr)(Side A).dsk" size 197427 crc 3EA95CE1 md5 D404044F3F84BACD78E004ACC450AEF4 sha1 27C70193CB01EFD4A1C3337209E4462AEFBCA5E5 )
 	rom ( name "Incantation (1987)(Softhawk)(fr)(Side B).dsk" size 197427 crc DA8301AB md5 3A9D0CE21421E154F2C323516398B4A2 sha1 D7981389ACDCD6C91FA439A080420669FE7206FB )
+	rom ( name "Incantation (1987)(Softhawk)(fr)(Side A).dsk" size 197427 crc 3EA95CE1 md5 D404044F3F84BACD78E004ACC450AEF4 sha1 27C70193CB01EFD4A1C3337209E4462AEFBCA5E5 )
 )
 game (
 	name "Iznogoud (Infogrames) (France)"
@@ -6580,8 +6580,8 @@ game (
 game (
 	name "Ile Oubliee, L' (Bruno Fonters) (France)"
 	description "Ile Oubliee, L' (Bruno Fonters) (France)"
-	rom ( name "Ile Oubliee, L' (1993)(Bruno Fonters)(fr)(Side A).dsk" size 204544 crc 3FEBCDF8 md5 A77A35F30023D06930A79F088A937F29 sha1 29F67A1DB0DE558C2A9B01983D907E6D397D3109 )
 	rom ( name "Ile Oubliee, L' (1993)(Bruno Fonters)(fr)(Side B).dsk" size 204544 crc 5CB00041 md5 645D83893207A9A4DFA86AA8DA3D0390 sha1 892334E319C1267B834BCFB87FC374F0C27BC466 )
+	rom ( name "Ile Oubliee, L' (1993)(Bruno Fonters)(fr)(Side A).dsk" size 204544 crc 3FEBCDF8 md5 A77A35F30023D06930A79F088A937F29 sha1 29F67A1DB0DE558C2A9B01983D907E6D397D3109 )
 )
 game (
 	name "Icon Jon (Mirrorsoft)"
@@ -6616,10 +6616,10 @@ game (
 game (
 	name "Iron Lord (Ubi Soft) (France)"
 	description "Iron Lord (Ubi Soft) (France)"
-	rom ( name "Iron Lord (1990)(Ubi Soft)(fr)(Disk 1 Side A).dsk" size 195635 crc FB7739C8 md5 74EAF564312249E15CA42960C2FE893A sha1 895CC4FE9A6853E7EB6B6507F1E29683E526F13F )
 	rom ( name "Iron Lord (1990)(Ubi Soft)(fr)(Disk 1 Side B).dsk" size 195635 crc 8753A866 md5 98C8E8331C340A3D6B650AA2F4623B02 sha1 018C8BBA7A382CC757E6525088559D24BFC4ECDD )
 	rom ( name "Iron Lord (1990)(Ubi Soft)(fr)(Disk 2 Side A).dsk" size 195635 crc DE6B8FC1 md5 D18CEB12B659B97A649AE854D6EF6ABC sha1 464BBADF848BCA9F541E62BEE4BE558EFD2305AA )
 	rom ( name "Iron Lord (1990)(Ubi Soft)(fr)(Disk 2 Side B).dsk" size 195635 crc 6D93B106 md5 B5F9040BFCB7FC7368176A247DEFD626 sha1 E636F3F0526FB82BE8B6EC23A275267B9D99F98D )
+	rom ( name "Iron Lord (1990)(Ubi Soft)(fr)(Disk 1 Side A).dsk" size 195635 crc FB7739C8 md5 74EAF564312249E15CA42960C2FE893A sha1 895CC4FE9A6853E7EB6B6507F1E29683E526F13F )
 )
 game (
 	name "ISS - Incredible Shrinking Sphere (Activision)"
@@ -6669,8 +6669,8 @@ game (
 game (
 	name "Inertie (Ubi Soft) (France)"
 	description "Inertie (Ubi Soft) (France)"
-	rom ( name "Inertie (1987)(Ubi Soft)(fr)(Side A).dsk" size 195891 crc 5084E823 md5 A61ECC495C4486B43884CE6113929C3A sha1 D27D3E64BA545E1FF581910CA7A242FEF85977DF )
 	rom ( name "Inertie (1987)(Ubi Soft)(fr)(Side B).dsk" size 195635 crc 343D3776 md5 0241FC46443A734EEDB2A3FE8CC5B145 sha1 4715ADA4BD2833080F181C8756E3BA2D217F659B )
+	rom ( name "Inertie (1987)(Ubi Soft)(fr)(Side A).dsk" size 195891 crc 5084E823 md5 A61ECC495C4486B43884CE6113929C3A sha1 D27D3E64BA545E1FF581910CA7A242FEF85977DF )
 )
 game (
 	name "International Karate (Endurance Games)"
@@ -6700,8 +6700,8 @@ game (
 game (
 	name "Indiana Jones and the Fate of Atlantis (US Gold)"
 	description "Indiana Jones and the Fate of Atlantis (US Gold)"
-	rom ( name "Indiana Jones and the Fate of Atlantis (1993)(US Gold)(Side A).dsk" size 282311 crc 8FB048A1 md5 6B143BFCB137D80B619202047D56C228 sha1 7F43DD104B7E6499A1E0A95B46CE68E38A8C5B82 )
 	rom ( name "Indiana Jones and the Fate of Atlantis (1993)(US Gold)(Side B).dsk" size 276915 crc EDDF9C73 md5 C7E85B0093BBC7AE3B1908AABAC5404C sha1 93ACF5CDAFACA2E2BFA6A27E7FB818293B4D19F2 )
+	rom ( name "Indiana Jones and the Fate of Atlantis (1993)(US Gold)(Side A).dsk" size 282311 crc 8FB048A1 md5 6B143BFCB137D80B619202047D56C228 sha1 7F43DD104B7E6499A1E0A95B46CE68E38A8C5B82 )
 )
 game (
 	name "I, Ball (Firebird)"
@@ -6776,20 +6776,20 @@ game (
 game (
 	name "Jinxter (Rainbird Software)"
 	description "Jinxter (Rainbird Software)"
-	rom ( name "Jinxter (1988)(Rainbird Software)(Side A).dsk" size 194816 crc 9F177D9B md5 3AD09B7F1C8F6755877BE53B1872F19D sha1 7C34018703BC3B791D6050F768593774FE7AC4D1 )
 	rom ( name "Jinxter (1988)(Rainbird Software)(Side B).dsk" size 194816 crc 403735DD md5 2FED6D82926A305DDDA05E94D799C38D sha1 E70EC5DCFF6AA43DE179DA0F5638B146996C3775 )
+	rom ( name "Jinxter (1988)(Rainbird Software)(Side A).dsk" size 194816 crc 9F177D9B md5 3AD09B7F1C8F6755877BE53B1872F19D sha1 7C34018703BC3B791D6050F768593774FE7AC4D1 )
 )
 game (
 	name "Jungle Book (Coktel Vision)"
 	description "Jungle Book (Coktel Vision)"
-	rom ( name "Jungle Book (1989)(Coktel Vision)(Side A).dsk" size 204544 crc CCC3A70B md5 C2947448DEA522695CDDB0757A819954 sha1 12957B44F6BD19E5BFA09921461B40C9C622EA40 )
 	rom ( name "Jungle Book (1989)(Coktel Vision)(Side B).dsk" size 204544 crc 13D90B7F md5 AD8E1B69A5EF0EAB2F28ED0BC61C4C47 sha1 9A85B30A92AF781BD09D8BA86AE8659F5186350D )
+	rom ( name "Jungle Book (1989)(Coktel Vision)(Side A).dsk" size 204544 crc CCC3A70B md5 C2947448DEA522695CDDB0757A819954 sha1 12957B44F6BD19E5BFA09921461B40C9C622EA40 )
 )
 game (
 	name "Jahangir Khan World Championship Squash (Krisalis Software) (M3)"
 	description "Jahangir Khan World Championship Squash (Krisalis Software) (M3)"
-	rom ( name "Jahangir Khan World Championship Squash (1991)(Krisalis Software)(M3)(Side A)[Club].dsk" size 194816 crc F4548F27 md5 7D7F6E6AAF62B2946ADF30BCB50180DC sha1 B1BC32171CB5AC20976B1BD9740770FF315CE61B )
 	rom ( name "Jahangir Khan World Championship Squash (1991)(Krisalis Software)(M3)(Side B)[Tournament].dsk" size 194816 crc 26D80460 md5 0C427325A6DDB19F3D0E5DB43D1D532C sha1 79534BBB9DAD61210C8BB0F5B3A873D08DEFD3DC )
+	rom ( name "Jahangir Khan World Championship Squash (1991)(Krisalis Software)(M3)(Side A)[Club].dsk" size 194816 crc F4548F27 md5 7D7F6E6AAF62B2946ADF30BCB50180DC sha1 B1BC32171CB5AC20976B1BD9740770FF315CE61B )
 )
 game (
 	name "Jet-Boot Jack (Amsoft)"
@@ -6859,8 +6859,8 @@ game (
 game (
 	name "Jaws - Le Dernier Etalon (MBC Informatique) (France)"
 	description "Jaws - Le Dernier Etalon (MBC Informatique) (France)"
-	rom ( name "Jaws - Le Dernier Etalon (1988)(MBC Informatique)(fr)(Side A).dsk" size 220583 crc B21FB6B0 md5 C790A60C3CDFF26E3E38E0B822427C6F sha1 2540FAF305BDB79CEE8860B753FCE9937EB62BC2 )
 	rom ( name "Jaws - Le Dernier Etalon (1988)(MBC Informatique)(fr)(Side B).dsk" size 226473 crc C874FC01 md5 AA55116DDDA59E40D53798058A7EB1DC sha1 93A177D55F644D99C62F4B135891F425D4D630A4 )
+	rom ( name "Jaws - Le Dernier Etalon (1988)(MBC Informatique)(fr)(Side A).dsk" size 220583 crc B21FB6B0 md5 C790A60C3CDFF26E3E38E0B822427C6F sha1 2540FAF305BDB79CEE8860B753FCE9937EB62BC2 )
 )
 game (
 	name "Jinks (Rainbow Arts)"
@@ -6890,16 +6890,16 @@ game (
 game (
 	name "Jim Power in Mutant Planet (Loriciels)"
 	description "Jim Power in Mutant Planet (Loriciels)"
-	rom ( name "Jim Power in Mutant Planet (1992)(Loriciels)(Side A).dsk" size 202053 crc 4A3E1D19 md5 3A53441D0137D705BFE1275C9611A190 sha1 0FC2984A5B4DAB9644993FD38CD7EF1245E44E73 )
 	rom ( name "Jim Power in Mutant Planet (1992)(Loriciels)(Side B).dsk" size 202053 crc AAFC2F5F md5 5B3097F17692032F9014DA32FBA2D9EB sha1 495CCAE4B8DCF62C45967E8E81CBBE168843516A )
+	rom ( name "Jim Power in Mutant Planet (1992)(Loriciels)(Side A).dsk" size 202053 crc 4A3E1D19 md5 3A53441D0137D705BFE1275C9611A190 sha1 0FC2984A5B4DAB9644993FD38CD7EF1245E44E73 )
 )
 game (
 	name "Jack Nicklaus Golf (Accolade)"
 	description "Jack Nicklaus Golf (Accolade)"
-	rom ( name "Jack Nicklaus Golf (1989)(Accolade)(v2)(Disk 1 Side A)[Program].dsk" size 73585 crc 3DB4AF9C md5 629CB6B30A7AA1D00DA1E5BB2BACC2FC sha1 710EE3B76F8733C382641F3F3AA2C5B479EFC8DD )
 	rom ( name "Jack Nicklaus Golf (1989)(Accolade)(v2)(Disk 1 Side B)[Greatest].dsk" size 196096 crc B0EB63E7 md5 A7F40048C540FDD3FBBFE7F3F08300FE sha1 FCF720F414CB0E6913D93DBEDF8EF0F3931E8DED )
 	rom ( name "Jack Nicklaus Golf (1989)(Accolade)(v2)(Disk 2 Side A)[Castle Pines].dsk" size 194816 crc 388EA7D md5 659F7E5281CBAC61058117C15321D360 sha1 55C6D77023FABF71DB40D44B9A10F7918FC0F433 )
 	rom ( name "Jack Nicklaus Golf (1989)(Accolade)(v2)(Disk 2 Side B)[Desert Mountain].dsk" size 194816 crc 1E427001 md5 AC6C6C9AC3A1FFC195D10F2F5213134B sha1 A5AB00EC08F3A08597FF3D81FE406286762F9590 )
+	rom ( name "Jack Nicklaus Golf (1989)(Accolade)(v2)(Disk 1 Side A)[Program].dsk" size 73585 crc 3DB4AF9C md5 629CB6B30A7AA1D00DA1E5BB2BACC2FC sha1 710EE3B76F8733C382641F3F3AA2C5B479EFC8DD )
 )
 game (
 	name "Joyaux De Babylone, Les (Interceptor Software)"
@@ -6984,8 +6984,8 @@ game (
 game (
 	name "Karateka (Broderbund Software) (Spain)"
 	description "Karateka (Broderbund Software) (Spain)"
-	rom ( name "Karateka (1986)(Broderbund Software)(es)(Side A).dsk" size 97997 crc B73C418B md5 CCE66C598B2A64F7B5D58EE08D66A317 sha1 1FF07CACA24C73FEC9B0C50779E2B03EDC54E6D8 )
 	rom ( name "Karateka (1986)(Broderbund Software)(es)(Side B).dsk" size 156581 crc 5FB2A6BE md5 F0A6FEAE3046B146F58C27FAA6BADCB9 sha1 97B9A1D5E85025FEB72958E2C173F381B95FDD81 )
+	rom ( name "Karateka (1986)(Broderbund Software)(es)(Side A).dsk" size 97997 crc B73C418B md5 CCE66C598B2A64F7B5D58EE08D66A317 sha1 1FF07CACA24C73FEC9B0C50779E2B03EDC54E6D8 )
 )
 game (
 	name "K.Y.A. (Loriciels) (France)"
@@ -6995,8 +6995,8 @@ game (
 game (
 	name "Krypton Factor, The (Domark)"
 	description "Krypton Factor, The (Domark)"
-	rom ( name "Krypton Factor, The (1987)(Domark)(Side A)[f].dsk" size 176617 crc 4D2044C4 md5 10D3711BA59C9BD70BE96E13F2BD4DB6 sha1 9D6B59AA2461D81A14B00C412FE4C5649C80A56F )
 	rom ( name "Krypton Factor, The (1987)(Domark)(Side B).dsk" size 63049 crc 7DBBEED0 md5 988711BE2DEBE3D065ACDA270B740901 sha1 788C2D76D78BA64B460CDE0418FD37879D798D08 )
+	rom ( name "Krypton Factor, The (1987)(Domark)(Side A)[f].dsk" size 176617 crc 4D2044C4 md5 10D3711BA59C9BD70BE96E13F2BD4DB6 sha1 9D6B59AA2461D81A14B00C412FE4C5649C80A56F )
 )
 game (
 	name "KTris (Richard Wilson)"
@@ -7011,8 +7011,8 @@ game (
 game (
 	name "Knight Games (English Software)"
 	description "Knight Games (English Software)"
-	rom ( name "Knight Games (1986)(English Software)(v2)(Side A).dsk" size 195379 crc 36C62E3A md5 41FF236F79E89983B31CF5EA4E292ABC sha1 7E8D9AB7ADBCE69C6AFEBC0295856085FEDC6B82 )
 	rom ( name "Knight Games (1986)(English Software)(v2)(Side B).dsk" size 195635 crc F6442AF9 md5 5443D3CC496B86A841851D44E4A3A5B2 sha1 00BC80191260AD521FFC4434B6769A4F405B058D )
+	rom ( name "Knight Games (1986)(English Software)(v2)(Side A).dsk" size 195379 crc 36C62E3A md5 41FF236F79E89983B31CF5EA4E292ABC sha1 7E8D9AB7ADBCE69C6AFEBC0295856085FEDC6B82 )
 )
 game (
 	name "Kiloroid (Richard Wilson)"
@@ -7022,8 +7022,8 @@ game (
 game (
 	name "Knight Games (English Software) (Spain) (Hack)"
 	description "Knight Games (English Software) (Spain) (Hack)"
-	rom ( name "Knight Games (1986)(English Software)(es)(Hack)(Side A)[cr].dsk" size 204544 crc E0987148 md5 569A54188763B49AFB03C854D2F9822F sha1 88F80053932FEC9DB863979EE15650E1F3B4276E )
 	rom ( name "Knight Games (1986)(English Software)(es)(Hack)(Side B)[cr].dsk" size 204544 crc F47B9241 md5 CBDD6DEC21CE25E96CACCDCD8679072E sha1 1A5079646F72621A67794B5395474FB0F9F16C71 )
+	rom ( name "Knight Games (1986)(English Software)(es)(Hack)(Side A)[cr].dsk" size 204544 crc E0987148 md5 569A54188763B49AFB03C854D2F9822F sha1 88F80053932FEC9DB863979EE15650E1F3B4276E )
 )
 game (
 	name "K.Y.A. (Loriciels) (Spain)"
@@ -7073,8 +7073,8 @@ game (
 game (
 	name "Knight Orc (Level 9 Computing)"
 	description "Knight Orc (Level 9 Computing)"
-	rom ( name "Knight Orc (1987)(Level 9 Computing)(Side A).dsk" size 195635 crc 934C463 md5 B23753E6D50A61E5B49F6B779E2DDC7B sha1 72CB16907F50976045BE33549D083C8088C17976 )
 	rom ( name "Knight Orc (1987)(Level 9 Computing)(Side B).dsk" size 195635 crc 13F89B91 md5 0E6C4CA0BCC1A2257CED0A9A76FE6A6D sha1 3A30982F1CB5080D764E884D66E8C3538712469E )
+	rom ( name "Knight Orc (1987)(Level 9 Computing)(Side A).dsk" size 195635 crc 934C463 md5 B23753E6D50A61E5B49F6B779E2DDC7B sha1 72CB16907F50976045BE33549D083C8088C17976 )
 )
 game (
 	name "Kinetik (Firebird)"
@@ -7099,8 +7099,8 @@ game (
 game (
 	name "Killer Star (Loisitech) (France) (Bugs)"
 	description "Killer Star (Loisitech) (France) (Bugs)"
-	rom ( name "Killer Star (1986)(Loisitech)(fr)(Side A)[b].dsk" size 247552 crc DC4F94CA md5 F81CC32646817B98A1F1263DE398DA5B sha1 B1D984B9373F1F7F6FD394A84B9527E2C40C233D )
 	rom ( name "Killer Star (1986)(Loisitech)(fr)(Side B)[b].dsk" size 247552 crc D447D1C4 md5 705D86D5729740F78DE2453C21529B2D sha1 9DDD8F904B437F706761383D5E84DE2B20A5775C )
+	rom ( name "Killer Star (1986)(Loisitech)(fr)(Side A)[b].dsk" size 247552 crc DC4F94CA md5 F81CC32646817B98A1F1263DE398DA5B sha1 B1D984B9373F1F7F6FD394A84B9527E2C40C233D )
 )
 game (
 	name "Kong Strikes Back (Ocean Software)"
@@ -7130,14 +7130,14 @@ game (
 game (
 	name "Killed Until Dead (US Gold)"
 	description "Killed Until Dead (US Gold)"
-	rom ( name "Killed Until Dead (1987)(US Gold)(Side A).dsk" size 195379 crc C6628383 md5 56220806229D3A5322F9E2AE416687EA sha1 5D5A331AF5AAAF83C1269F0B19A380A910900675 )
 	rom ( name "Killed Until Dead (1987)(US Gold)(Side B).dsk" size 195379 crc 9D5C9E25 md5 0993C85120CE4DE5227BB90AFCA536D6 sha1 0ED8DAE5B0B91591865857C648E7AD6B2A833929 )
+	rom ( name "Killed Until Dead (1987)(US Gold)(Side A).dsk" size 195379 crc C6628383 md5 56220806229D3A5322F9E2AE416687EA sha1 5D5A331AF5AAAF83C1269F0B19A380A910900675 )
 )
 game (
 	name "Knight Force (Titus)"
 	description "Knight Force (Titus)"
-	rom ( name "Knight Force (1989)(Titus)(Side A).dsk" size 274097 crc E81F696 md5 CE5F0663D3CCDAF75FCEBC92A4826E29 sha1 F9F6E317A384D2C9D46D262089919EAC507EF679 )
 	rom ( name "Knight Force (1989)(Titus)(Side B).dsk" size 236755 crc FB10B3BB md5 D1B3E6C0A82952FF531C885A0ACA36C9 sha1 DE193CC9604DF8BA254DC41D730535E7C621521B )
+	rom ( name "Knight Force (1989)(Titus)(Side A).dsk" size 274097 crc E81F696 md5 CE5F0663D3CCDAF75FCEBC92A4826E29 sha1 F9F6E317A384D2C9D46D262089919EAC507EF679 )
 )
 game (
 	name "Kenny Dalglish Soccer Manager (Cognito)"
@@ -7207,8 +7207,8 @@ game (
 game (
 	name "Kick Off 2 (Anco Software) (France)"
 	description "Kick Off 2 (Anco Software) (France)"
-	rom ( name "Kick Off 2 (1990)(Anco Software)(fr)(Side A).dsk" size 157033 crc BC4F103D md5 0A2E5592DF4DBC20527FF6A8210AB287 sha1 0DD204C2D87F1B0D9BEC84822E42FFABC42827C2 )
 	rom ( name "Kick Off 2 (1990)(Anco Software)(fr)(Side B).dsk" size 157033 crc 6EB988CF md5 1C62F3B9F3931C30AE9BC28D169E4EA0 sha1 103CAF66E6A0358313E78A60334FB20F073212B2 )
+	rom ( name "Kick Off 2 (1990)(Anco Software)(fr)(Side A).dsk" size 157033 crc BC4F103D md5 0A2E5592DF4DBC20527FF6A8210AB287 sha1 0DD204C2D87F1B0D9BEC84822E42FFABC42827C2 )
 )
 game (
 	name "Knight Rider (Ocean Software)"
@@ -7243,8 +7243,8 @@ game (
 game (
 	name "Karnov (Activision)"
 	description "Karnov (Activision)"
-	rom ( name "Karnov (1988)(Activision)(Side A).dsk" size 220049 crc 6CA93012 md5 F8CC505375BAD3E8C46E00C7CDF86A7D sha1 A2E78EA6760889BEB9791D44E5432BE1926A9AD7 )
 	rom ( name "Karnov (1988)(Activision)(Side B).dsk" size 220049 crc 35C91CEC md5 72AEEE5A7536EDE74B8E792064278339 sha1 7B04F4017CEEA261CB979FB4C9CDCCDCF6BCD249 )
+	rom ( name "Karnov (1988)(Activision)(Side A).dsk" size 220049 crc 6CA93012 md5 F8CC505375BAD3E8C46E00C7CDF86A7D sha1 A2E78EA6760889BEB9791D44E5432BE1926A9AD7 )
 )
 game (
 	name "Kristal (Core)"
@@ -7254,8 +7254,8 @@ game (
 game (
 	name "Kick Off 2 (Anco Software)"
 	description "Kick Off 2 (Anco Software)"
-	rom ( name "Kick Off 2 (1990)(Anco Software)(Side A).dsk" size 156672 crc 79B9B585 md5 4C0F3807DDD472E4051B5E4B7275DDEC sha1 0605554056D6FB97EC1E5B4E0DE8188EC82E228D )
 	rom ( name "Kick Off 2 (1990)(Anco Software)(Side B).dsk" size 156672 crc 872B06FA md5 C346EA319638CCCBEB176AD7B042200E sha1 0E590AE50D6ABD9810FC677D4CF789BBF28FCF7B )
+	rom ( name "Kick Off 2 (1990)(Anco Software)(Side A).dsk" size 156672 crc 79B9B585 md5 4C0F3807DDD472E4051B5E4B7275DDEC sha1 0605554056D6FB97EC1E5B4E0DE8188EC82E228D )
 )
 game (
 	name "Leviathan (English Software)"
@@ -7290,10 +7290,10 @@ game (
 game (
 	name "Labyrinthe aux Mille Calculs, Le - College (Retz) (France)"
 	description "Labyrinthe aux Mille Calculs, Le - College (Retz) (France)"
-	rom ( name "Labyrinthe aux Mille Calculs, Le - College (1989)(Retz)(fr)(Disk 1 Side A)[CPM].dsk" size 195635 crc F6943A86 md5 59A1C002E00A5866E1D80B5CF07DBB2B sha1 17D369893A87033A896C92F8C3A2FFC72E4D6AEB )
 	rom ( name "Labyrinthe aux Mille Calculs, Le - College (1989)(Retz)(fr)(Disk 1 Side B).dsk" size 195635 crc 26239B63 md5 026ECD5F7E30E4C877AA619C6DE7C4CD sha1 E30CFD593633342C2D01638D7E0689D8E2E3369D )
 	rom ( name "Labyrinthe aux Mille Calculs, Le - College (1989)(Retz)(fr)(Disk 2 Side A).dsk" size 195635 crc 539DFC6A md5 0D9D3A0D47E08AC23AF53B336E9EB650 sha1 124E7EFCB36EAA2D1913C7BBE2D761B0E05BD0FB )
 	rom ( name "Labyrinthe aux Mille Calculs, Le - College (1989)(Retz)(fr)(Disk 2 Side B).dsk" size 195635 crc 7C599575 md5 000F9751F09B1C6BF1BA67A8F08C00B6 sha1 682772777B030A4ABDA358FCC80ED7627C85358B )
+	rom ( name "Labyrinthe aux Mille Calculs, Le - College (1989)(Retz)(fr)(Disk 1 Side A)[CPM].dsk" size 195635 crc F6943A86 md5 59A1C002E00A5866E1D80B5CF07DBB2B sha1 17D369893A87033A896C92F8C3A2FFC72E4D6AEB )
 )
 game (
 	name "Lifeterm (Alternative Software)"
@@ -7308,10 +7308,10 @@ game (
 game (
 	name "Labyrinthe d'Errare, Le - College (Retz) (France)"
 	description "Labyrinthe d'Errare, Le - College (Retz) (France)"
-	rom ( name "Labyrinthe d'Errare, Le - College (1989)(Retz)(fr)(Disk 1 Side A)[CPM].dsk" size 195635 crc A4F28175 md5 E307072A675525A9486E7F671FC3F393 sha1 79854A77554EC29EF8FB889F99ED770996C9B2DC )
 	rom ( name "Labyrinthe d'Errare, Le - College (1989)(Retz)(fr)(Disk 1 Side B).dsk" size 195635 crc D096F9FD md5 227091AF103F2C6A39D1BD7A1BC55082 sha1 BD7D50EB18B61DCB4C0A55F35DE5D18347AE2271 )
 	rom ( name "Labyrinthe d'Errare, Le - College (1989)(Retz)(fr)(Disk 2 Side A).dsk" size 195635 crc 77ADF13C md5 36310BAB7F9AD13E7F1562A310087636 sha1 CA34D7C12330B29FE5F5D123B65CFB6AD4C28824 )
 	rom ( name "Labyrinthe d'Errare, Le - College (1989)(Retz)(fr)(Disk 2 Side B).dsk" size 195635 crc CC3C59ED md5 966E7C550C8E912C6467B5EEE5E32B59 sha1 21DCAA290B27442B9A40B85C875041FF1BAFE45A )
+	rom ( name "Labyrinthe d'Errare, Le - College (1989)(Retz)(fr)(Disk 1 Side A)[CPM].dsk" size 195635 crc A4F28175 md5 E307072A675525A9486E7F671FC3F393 sha1 79854A77554EC29EF8FB889F99ED770996C9B2DC )
 )
 game (
 	name "Lurking Horror, The (Infocom)"
@@ -7321,10 +7321,10 @@ game (
 game (
 	name "Labyrinthe aux Cent Calculs, Le - Ecole (Retz) (France)"
 	description "Labyrinthe aux Cent Calculs, Le - Ecole (Retz) (France)"
-	rom ( name "Labyrinthe aux Cent Calculs, Le - Ecole (1989)(Retz)(fr)(Disk 1 Side A)[CPM].dsk" size 195635 crc 92B6A819 md5 0A0B32D712A5DA982A7BA29752046C5D sha1 02C638A3FC3486DB7283889D2CBE0173DB38ADFE )
 	rom ( name "Labyrinthe aux Cent Calculs, Le - Ecole (1989)(Retz)(fr)(Disk 1 Side B).dsk" size 195635 crc E3955D4D md5 26CAF345DF45A550EDA69DE6E204204E sha1 EB06FDA3631BA75F6FC6B1BA6B8324686B3FA01A )
 	rom ( name "Labyrinthe aux Cent Calculs, Le - Ecole (1989)(Retz)(fr)(Disk 2 Side A).dsk" size 195635 crc DA04BC18 md5 4D3E7698A3CBC74ED3CE8654559FC25C sha1 FF16C8C024BEF9F816EB36B2062D615166520D60 )
 	rom ( name "Labyrinthe aux Cent Calculs, Le - Ecole (1989)(Retz)(fr)(Disk 2 Side B).dsk" size 195635 crc D7AD58E3 md5 135BCBC9C75D9E3394ABE20DD49C18BF sha1 D026AA9D8E9E4F6C4E951DB155C44C7DB269C950 )
+	rom ( name "Labyrinthe aux Cent Calculs, Le - Ecole (1989)(Retz)(fr)(Disk 1 Side A)[CPM].dsk" size 195635 crc 92B6A819 md5 0A0B32D712A5DA982A7BA29752046C5D sha1 02C638A3FC3486DB7283889D2CBE0173DB38ADFE )
 )
 game (
 	name "Livingstone Supongo (Opera Soft) (Spain)"
@@ -7334,8 +7334,8 @@ game (
 game (
 	name "Lancelot (Level 9 Computing)"
 	description "Lancelot (Level 9 Computing)"
-	rom ( name "Lancelot (1988)(Level 9 Computing)(Side A).dsk" size 194816 crc C5AD3E3E md5 83090F57D36C262FB457F31E377FF8E0 sha1 137C65F45B5130EBE04B24C0ED67B7107E14A176 )
 	rom ( name "Lancelot (1988)(Level 9 Computing)(Side B).dsk" size 194816 crc 2943604C md5 4B94EBB9DA77E5A5C59114EC76E83F9D sha1 571AD9CE99545A072E8C31CCDCFF1E52AA313CEF )
+	rom ( name "Lancelot (1988)(Level 9 Computing)(Side A).dsk" size 194816 crc C5AD3E3E md5 83090F57D36C262FB457F31E377FF8E0 sha1 137C65F45B5130EBE04B24C0ED67B7107E14A176 )
 )
 game (
 	name "Legions of Death (MC Lothlorien) (Spain)"
@@ -7370,8 +7370,8 @@ game (
 game (
 	name "Lucky Luke - Nitroglycerine (Coktel Vision) (Spain)"
 	description "Lucky Luke - Nitroglycerine (Coktel Vision) (Spain)"
-	rom ( name "Lucky Luke - Nitroglycerine (1987)(Coktel Vision)(es)(Side A).dsk" size 196407 crc 1F8CE03A md5 5221FB02B7E10A60F6E3C7E815B0C91A sha1 4A0E7C5EAC7751AC8A0D7E144E6F1346356F791E )
 	rom ( name "Lucky Luke - Nitroglycerine (1987)(Coktel Vision)(es)(Side B).dsk" size 195637 crc 33307848 md5 CC986E3C0171DE6BA9F191E565F09663 sha1 0627A04297D0DB23919840D367188FC74396BD86 )
+	rom ( name "Lucky Luke - Nitroglycerine (1987)(Coktel Vision)(es)(Side A).dsk" size 196407 crc 1F8CE03A md5 5221FB02B7E10A60F6E3C7E815B0C91A sha1 4A0E7C5EAC7751AC8A0D7E144E6F1346356F791E )
 )
 game (
 	name "Laser Squad (Blade Software) (M2)"
@@ -7401,9 +7401,9 @@ game (
 game (
 	name "Labyrinthe des Pharaons, Le (Retz) (France)"
 	description "Labyrinthe des Pharaons, Le (Retz) (France)"
-	rom ( name "Labyrinthe des Pharaons, Le (1990)(Retz)(fr)(Disk 1 Side A).dsk" size 221591 crc 695B81D3 md5 B4B4339A4EEDC24D7726840FA896B5A3 sha1 3B3CDD2549FBF147ACB010F6F2CD3EF9FBFDB31F )
 	rom ( name "Labyrinthe des Pharaons, Le (1990)(Retz)(fr)(Disk 2 Side A).dsk" size 221591 crc D3D374EE md5 CED542A1B33E1FAC5ED07489F71238AB sha1 6AA254F707CF735E17155F419E2760C7466456F6 )
 	rom ( name "Labyrinthe des Pharaons, Le (1990)(Retz)(fr)(Disk 2 Side B).dsk" size 221591 crc D22C323C md5 3FC203C78D3A23F5F841F1070F268F17 sha1 9C81C635A7A8CDA38100077C072C4556EA308604 )
+	rom ( name "Labyrinthe des Pharaons, Le (1990)(Retz)(fr)(Disk 1 Side A).dsk" size 221591 crc 695B81D3 md5 B4B4339A4EEDC24D7726840FA896B5A3 sha1 3B3CDD2549FBF147ACB010F6F2CD3EF9FBFDB31F )
 )
 game (
 	name "Light Force (FTL)"
@@ -7418,28 +7418,28 @@ game (
 game (
 	name "Last Ninja 2 Remix (System 3)"
 	description "Last Ninja 2 Remix (System 3)"
-	rom ( name "Last Ninja 2 Remix (1990)(System 3)(Side A).dsk" size 218791 crc 7E0090AA md5 0D3A478279F087885A9B551139233433 sha1 F43E568F61E579D3AB6ECD57C5B398E5A9373728 )
 	rom ( name "Last Ninja 2 Remix (1990)(System 3)(Side B).dsk" size 174313 crc 1F6B8C98 md5 42243C83E4ACF3702B2047C33F2D7284 sha1 CB49FF6E5A04A149DF95FC0A224808593FD591CC )
+	rom ( name "Last Ninja 2 Remix (1990)(System 3)(Side A).dsk" size 218791 crc 7E0090AA md5 0D3A478279F087885A9B551139233433 sha1 F43E568F61E579D3AB6ECD57C5B398E5A9373728 )
 )
 game (
 	name "Labyrinthe d'Orthophus, Le - Ecole (Retz) (France)"
 	description "Labyrinthe d'Orthophus, Le - Ecole (Retz) (France)"
-	rom ( name "Labyrinthe d'Orthophus, Le - Ecole (1989)(Retz)(fr)(Disk 1 Side A)[CPM].dsk" size 195635 crc 342C720E md5 597CCE8E438023A8E300167FF1E66E94 sha1 4CEF1E256514B47AFA26C08B6493080F092CE192 )
 	rom ( name "Labyrinthe d'Orthophus, Le - Ecole (1989)(Retz)(fr)(Disk 1 Side B).dsk" size 195635 crc 4235F7CA md5 B9D7ED11D80AF8E3520E2C6B92D33744 sha1 564660CA0A062B4778C6F66AB36F0CE261A3DBE6 )
 	rom ( name "Labyrinthe d'Orthophus, Le - Ecole (1989)(Retz)(fr)(Disk 2 Side A).dsk" size 195635 crc E3F994F0 md5 D19FA629000C8C5337179269ECE0B344 sha1 60B94DED0CEDB25BF45014BA4A928C447B3534D8 )
 	rom ( name "Labyrinthe d'Orthophus, Le - Ecole (1989)(Retz)(fr)(Disk 2 Side B).dsk" size 195635 crc D5555594 md5 9F82ED274E486BBE443510BA0345C066 sha1 E3DF18963248E7F9990F9169ED10CC74476E6EB3 )
+	rom ( name "Labyrinthe d'Orthophus, Le - Ecole (1989)(Retz)(fr)(Disk 1 Side A)[CPM].dsk" size 195635 crc 342C720E md5 597CCE8E438023A8E300167FF1E66E94 sha1 4CEF1E256514B47AFA26C08B6493080F092CE192 )
 )
 game (
 	name "Labyrinthe D'Anglomania 1, Le (Retz) (France)"
 	description "Labyrinthe D'Anglomania 1, Le (Retz) (France)"
-	rom ( name "Labyrinthe D'Anglomania 1, Le (1990)(Retz)(fr)(Side A).dsk" size 221077 crc 5F963C09 md5 911016C71BCC326693D093513FBDA054 sha1 F951B97EDDB3C44A5C7E3F6C154350D5453EE331 )
 	rom ( name "Labyrinthe D'Anglomania 1, Le (1990)(Retz)(fr)(Side B).dsk" size 221077 crc 372019A4 md5 3A597F9E391B3A7538C8C17AC63AD8EA sha1 8C98A904311947CC99BC9681227A41374C79C4DB )
+	rom ( name "Labyrinthe D'Anglomania 1, Le (1990)(Retz)(fr)(Side A).dsk" size 221077 crc 5F963C09 md5 911016C71BCC326693D093513FBDA054 sha1 F951B97EDDB3C44A5C7E3F6C154350D5453EE331 )
 )
 game (
 	name "Lucky Luke - Nitroglycerine (Coktel Vision) (France)"
 	description "Lucky Luke - Nitroglycerine (Coktel Vision) (France)"
-	rom ( name "Lucky Luke - Nitroglycerine (1987)(Coktel Vision)(fr)(Side A)[CPM].dsk" size 198211 crc 1DAB581 md5 346403DA7F6EE1FF45BCAC10C94DB586 sha1 B1319DAE0216EDE66146B5488150A5DBBE51A58C )
 	rom ( name "Lucky Luke - Nitroglycerine (1987)(Coktel Vision)(fr)(Side B).dsk" size 195635 crc 71A30503 md5 113E68D8D77E3C98D3E1EB3D3D0FFB94 sha1 3737BC3EB2D646499F8CB3F1A5C8BD08444D0AEF )
+	rom ( name "Lucky Luke - Nitroglycerine (1987)(Coktel Vision)(fr)(Side A)[CPM].dsk" size 198211 crc 1DAB581 md5 346403DA7F6EE1FF45BCAC10C94DB586 sha1 B1319DAE0216EDE66146B5488150A5DBBE51A58C )
 )
 game (
 	name "Lisa Strip Pot (Ludo's Software Distribution) (France)"
@@ -7474,8 +7474,8 @@ game (
 game (
 	name "Labyrinthe D'Anglomania 2, Le (Retz) (France)"
 	description "Labyrinthe D'Anglomania 2, Le (Retz) (France)"
-	rom ( name "Labyrinthe D'Anglomania 2, Le (1990)(Retz)(fr)(Side A).dsk" size 221077 crc B0A1E816 md5 94F44D7E5CDCE1F20DE61D8E335850D7 sha1 01FB6B14A110FFA42C15CCB253E5E0489CEB3050 )
 	rom ( name "Labyrinthe D'Anglomania 2, Le (1990)(Retz)(fr)(Side B).dsk" size 221077 crc 70021B43 md5 555115D70B706D5E63D57E9C4012C45D sha1 F1342F83943C83BE25197CFBC56970682B326544 )
+	rom ( name "Labyrinthe D'Anglomania 2, Le (1990)(Retz)(fr)(Side A).dsk" size 221077 crc B0A1E816 md5 94F44D7E5CDCE1F20DE61D8E335850D7 sha1 01FB6B14A110FFA42C15CCB253E5E0489CEB3050 )
 )
 game (
 	name "Labynotaure (Amstrad Magazine) (France)"
@@ -7485,8 +7485,8 @@ game (
 game (
 	name "Lemmings (Psygnosis)"
 	description "Lemmings (Psygnosis)"
-	rom ( name "Lemmings (1992)(Psygnosis)(Side A).dsk" size 217457 crc C5714F20 md5 B0E0D22C40DDE7A773C99340CEA72687 sha1 7B614685BDE5EAC29061B3178D02BE038E8F51BA )
 	rom ( name "Lemmings (1992)(Psygnosis)(Side B).dsk" size 217457 crc 3E02A4E md5 29CC7C6A25235A612A5A75F63CB6D8E7 sha1 5CCBB12DF6BE2C2EBEE0073A2B10F0D3A49F765E )
+	rom ( name "Lemmings (1992)(Psygnosis)(Side A).dsk" size 217457 crc C5714F20 md5 B0E0D22C40DDE7A773C99340CEA72687 sha1 7B614685BDE5EAC29061B3178D02BE038E8F51BA )
 )
 game (
 	name "Lost Caves (Players Premier)"
@@ -7561,8 +7561,8 @@ game (
 game (
 	name "Legend (Delta Software) (Spain)"
 	description "Legend (Delta Software) (Spain)"
-	rom ( name "Legend (1990)(Delta Software)(es)(v2)(Side A).dsk" size 205399 crc D65ED5E md5 0B4E7CE7C100DB133093AB5DAFC17A51 sha1 3D27F8B12BEE633BEE8D4E230D1249B60C809AA0 )
 	rom ( name "Legend (1990)(Delta Software)(es)(v2)(Side B).dsk" size 205399 crc 6BCC211 md5 D38346BD94482C5C19BD18C37C2207F3 sha1 D5F7CCB3434DF6102EEFC9FE924ECFEEDA308A81 )
+	rom ( name "Legend (1990)(Delta Software)(es)(v2)(Side A).dsk" size 205399 crc D65ED5E md5 0B4E7CE7C100DB133093AB5DAFC17A51 sha1 3D27F8B12BEE633BEE8D4E230D1249B60C809AA0 )
 )
 game (
 	name "Lorna (Topo Soft) (Spain)"
@@ -7572,8 +7572,8 @@ game (
 game (
 	name "Lord of the Rings - Game One (Melbourne House)"
 	description "Lord of the Rings - Game One (Melbourne House)"
-	rom ( name "Lord of the Rings - Game One (1986)(Melbourne House)(Side A).dsk" size 189952 crc 7C2489EC md5 26AFAE5655C29DB8C1C0651342724C25 sha1 202D5B5FDC0E0D8A6CC4138C54FBE40E49972C5C )
 	rom ( name "Lord of the Rings - Game One (1986)(Melbourne House)(Side B).dsk" size 194816 crc FA983B46 md5 484F945E8EF5A3E14BE23EF0C6D15DF7 sha1 855CC3BAA4AEC04B419E3FEC284B055EE86F34EB )
+	rom ( name "Lord of the Rings - Game One (1986)(Melbourne House)(Side A).dsk" size 189952 crc 7C2489EC md5 26AFAE5655C29DB8C1C0651342724C25 sha1 202D5B5FDC0E0D8A6CC4138C54FBE40E49972C5C )
 )
 game (
 	name "Lords of Chaos (Blade Software) (M2)"
@@ -7613,14 +7613,14 @@ game (
 game (
 	name "Last Ninja 2 (System 3)"
 	description "Last Ninja 2 (System 3)"
-	rom ( name "Last Ninja 2 (1988)(System 3)(Side A).dsk" size 198157 crc 2E386BA7 md5 C63460C9D799382A60A65F2EDB9525D7 sha1 A91F1B5E2A946668421BFFCBFAFC7A5EB16AE234 )
 	rom ( name "Last Ninja 2 (1988)(System 3)(Side B).dsk" size 195637 crc FB24D9AC md5 8D4E6820575ACA16826A6218BCD1462D sha1 4C55DAE8D0FEE40566FF77733AB6FA5F9572DDDB )
+	rom ( name "Last Ninja 2 (1988)(System 3)(Side A).dsk" size 198157 crc 2E386BA7 md5 C63460C9D799382A60A65F2EDB9525D7 sha1 A91F1B5E2A946668421BFFCBFAFC7A5EB16AE234 )
 )
 game (
 	name "Labyrinthe de Lexicos, Le (Retz) (France)"
 	description "Labyrinthe de Lexicos, Le (Retz) (France)"
-	rom ( name "Labyrinthe de Lexicos, Le (1990)(Retz)(fr)(Side A).dsk" size 221591 crc D21C33A6 md5 060603B0211005CC13302A201BD4FD11 sha1 7B7186650815E89C8683B49CE4C573423321D0E9 )
 	rom ( name "Labyrinthe de Lexicos, Le (1990)(Retz)(fr)(Side B).dsk" size 221591 crc 873E1294 md5 2F60E3E6CD5A1050784988F74677A4DE sha1 6E21507AD863BEAD10AE65F697E91FF8D2179ED9 )
+	rom ( name "Labyrinthe de Lexicos, Le (1990)(Retz)(fr)(Side A).dsk" size 221591 crc D21C33A6 md5 060603B0211005CC13302A201BD4FD11 sha1 7B7186650815E89C8683B49CE4C573423321D0E9 )
 )
 game (
 	name "Leaderboard Tournament (US Gold)"
@@ -7635,8 +7635,8 @@ game (
 game (
 	name "Legende (FIL) (France)"
 	description "Legende (FIL) (France)"
-	rom ( name "Legende (1987)(FIL)(fr)(Side A).dsk" size 195072 crc 99ACFF55 md5 F20EF9AE01A33E2100983BE26EE58A26 sha1 CAFBC26409BDAC4D7FD115AA624D833A1368B8A7 )
 	rom ( name "Legende (1987)(FIL)(fr)(Side B).dsk" size 194816 crc 6ABD42C9 md5 8D7FEC62298E648F5029705686E10254 sha1 BDB56401A19BFC3981327E2E79281B45711C1043 )
+	rom ( name "Legende (1987)(FIL)(fr)(Side A).dsk" size 195072 crc 99ACFF55 md5 F20EF9AE01A33E2100983BE26EE58A26 sha1 CAFBC26409BDAC4D7FD115AA624D833A1368B8A7 )
 )
 game (
 	name "Lee Enfield - The Tournament Of Death (Infogrames)"
@@ -7691,8 +7691,8 @@ game (
 game (
 	name "Marque Jaune, La (Cobra Soft) (France)"
 	description "Marque Jaune, La (Cobra Soft) (France)"
-	rom ( name "Marque Jaune, La (1988)(Cobra Soft)(fr)(Side A).dsk" size 197427 crc 51210F22 md5 05D252087EE54929AC5B7FBBFB3B0D6F sha1 3950EA76F853CC0E05B926785412F92C50CE60E5 )
 	rom ( name "Marque Jaune, La (1988)(Cobra Soft)(fr)(Side B).dsk" size 195635 crc 3E2B2F77 md5 D44AE5B8484560F052515705254D2101 sha1 9B5BBAB7359207DD8B35D4CC45AA0B0880ABD6B9 )
+	rom ( name "Marque Jaune, La (1988)(Cobra Soft)(fr)(Side A).dsk" size 197427 crc 51210F22 md5 05D252087EE54929AC5B7FBBFB3B0D6F sha1 3950EA76F853CC0E05B926785412F92C50CE60E5 )
 )
 game (
 	name "Movie (Ocean Software)"
@@ -7742,8 +7742,8 @@ game (
 game (
 	name "Mondes Paralleles, Les (Mchtml) (France)"
 	description "Mondes Paralleles, Les (Mchtml) (France)"
-	rom ( name "Mondes Paralleles, Les (1993)(Mchtml)(fr)(Side A)[cr].dsk" size 226048 crc 6B8D3058 md5 91939D30E83E3089A4A2F14642D06EB8 sha1 373BA34A57DD871CDE8C4130BCBB84F9AC97D313 )
 	rom ( name "Mondes Paralleles, Les (1993)(Mchtml)(fr)(Side B)[cr].dsk" size 226048 crc BE4E34B2 md5 B5E9F6702D05693A684D73C10BC6A219 sha1 CD3B69EF5699AA3CEEF9318B48633D859E9F4D7A )
+	rom ( name "Mondes Paralleles, Les (1993)(Mchtml)(fr)(Side A)[cr].dsk" size 226048 crc 6B8D3058 md5 91939D30E83E3089A4A2F14642D06EB8 sha1 373BA34A57DD871CDE8C4130BCBB84F9AC97D313 )
 )
 game (
 	name "Maze Mania (Hewson)"
@@ -7763,8 +7763,8 @@ game (
 game (
 	name "Mewilo (Coktel Vision) (de)"
 	description "Mewilo (Coktel Vision) (de)"
-	rom ( name "Mewilo (1987)(Coktel Vision)(de)(Side A)[CPM].dsk" size 210283 crc 5339E1D md5 F20F713D3A2DE93F19B9223E535C6C5E sha1 8055D7BF0E8DDAA90BB00DFCFEE259D0B68B0426 )
 	rom ( name "Mewilo (1987)(Coktel Vision)(de)(Side B).dsk" size 210283 crc 8C14FCDD md5 9D07EE78587E401AEF970A8F78559F0D sha1 C8AA243C0880D066793C1980F7DAA0589840F69F )
+	rom ( name "Mewilo (1987)(Coktel Vision)(de)(Side A)[CPM].dsk" size 210283 crc 5339E1D md5 F20F713D3A2DE93F19B9223E535C6C5E sha1 8055D7BF0E8DDAA90BB00DFCFEE259D0B68B0426 )
 )
 game (
 	name "Munsters, The (Again Again)"
@@ -7864,8 +7864,8 @@ game (
 game (
 	name "Myth - History in the Making (System 3)"
 	description "Myth - History in the Making (System 3)"
-	rom ( name "Myth - History in the Making (1989)(System 3)(Side A).dsk" size 38527 crc 4D8464D3 md5 6A9C1B9D2E4E9803CA57D61E2D0ABCD0 sha1 98C79CE73DBCE232EF3B29887D2C5180D05AD909 )
 	rom ( name "Myth - History in the Making (1989)(System 3)(Side B).dsk" size 161461 crc C4F3D1AA md5 FA565DF5F4CBE6DEA81616CB493B78D9 sha1 6E6C8E4F3E43BD5E15290FF59383E2817CB4F8B8 )
+	rom ( name "Myth - History in the Making (1989)(System 3)(Side A).dsk" size 38527 crc 4D8464D3 md5 6A9C1B9D2E4E9803CA57D61E2D0ABCD0 sha1 98C79CE73DBCE232EF3B29887D2C5180D05AD909 )
 )
 game (
 	name "Mission (Loriciels) (France)"
@@ -7895,8 +7895,8 @@ game (
 game (
 	name "Mandragore (Infogrames)"
 	description "Mandragore (Infogrames)"
-	rom ( name "Mandragore (1985)(Infogrames)(Side A).dsk" size 167887 crc 5D037C5C md5 6FAB68E5F5A4EF4E561A09165D093F90 sha1 5E2E568A911B5357EE43F5D825079D26E66C6864 )
 	rom ( name "Mandragore (1985)(Infogrames)(Side B).dsk" size 158895 crc 801969A5 md5 810DFB4BC18477E2BC4987B5F299EEA0 sha1 0081D74C86AC605127ABE07BCD9E9535954A720C )
+	rom ( name "Mandragore (1985)(Infogrames)(Side A).dsk" size 167887 crc 5D037C5C md5 6FAB68E5F5A4EF4E561A09165D093F90 sha1 5E2E568A911B5357EE43F5D825079D26E66C6864 )
 )
 game (
 	name "Mickey Mouse (Gremlin Graphics Software)"
@@ -7906,8 +7906,8 @@ game (
 game (
 	name "Mike & Moko (MBC Informatique)"
 	description "Mike & Moko (MBC Informatique)"
-	rom ( name "Mike & Moko (1988)(MBC Informatique)(Side A).dsk" size 248999 crc C70118BE md5 A981F0982F745F1B4052B76E765403A9 sha1 E2F5583773770655DB2845178FEDB69892224073 )
 	rom ( name "Mike & Moko (1988)(MBC Informatique)(Side B).dsk" size 205399 crc 9998BA8F md5 E42FA9CE93CEF34CED84A457DB6F9DE7 sha1 1DCE24F96B6C126CB8AF46014036C85D9B6F1F27 )
+	rom ( name "Mike & Moko (1988)(MBC Informatique)(Side A).dsk" size 248999 crc C70118BE md5 A981F0982F745F1B4052B76E765403A9 sha1 E2F5583773770655DB2845178FEDB69892224073 )
 )
 game (
 	name "Mission en Rafale (FIL) (M2)"
@@ -7927,8 +7927,8 @@ game (
 game (
 	name "Mot (Opera Soft) (M2)"
 	description "Mot (Opera Soft) (M2)"
-	rom ( name "Mot (1989)(Opera Soft)(M2)(Side A).dsk" size 219405 crc 8530C6E md5 C8A9BE3ABEF52D1CD041CC9B60DB8BC3 sha1 57266DE52468FFB22527B2824F2DC574B5401F1D )
 	rom ( name "Mot (1989)(Opera Soft)(M2)(Side B).dsk" size 218880 crc 14CC7504 md5 F1167E97FBEEE7E11B4139CFC5B7B878 sha1 A8D0181DEEB13E68066B347B5DCA13A777DDCB4D )
+	rom ( name "Mot (1989)(Opera Soft)(M2)(Side A).dsk" size 219405 crc 8530C6E md5 C8A9BE3ABEF52D1CD041CC9B60DB8BC3 sha1 57266DE52468FFB22527B2824F2DC574B5401F1D )
 )
 game (
 	name "Memotron (Magazin Players Dream) (de)"
@@ -7963,8 +7963,8 @@ game (
 game (
 	name "Monte Cristo (Coktel Vision) (France)"
 	description "Monte Cristo (Coktel Vision) (France)"
-	rom ( name "Monte Cristo (1988)(Coktel Vision)(fr)(Side A)[CPM].dsk" size 273753 crc 90F7F707 md5 C0D67FA471D4DE882B96DD9CB06AC2B9 sha1 27CA13AA1A85A796C6E118F08D8FEDD3E3628726 )
 	rom ( name "Monte Cristo (1988)(Coktel Vision)(fr)(Side B).dsk" size 195635 crc 3677D82C md5 5C10DEC93A28D3F4E7379F6EB832AD69 sha1 5987D1BCC39DBF848340F5CEE638173FF4850EB3 )
+	rom ( name "Monte Cristo (1988)(Coktel Vision)(fr)(Side A)[CPM].dsk" size 273753 crc 90F7F707 md5 C0D67FA471D4DE882B96DD9CB06AC2B9 sha1 27CA13AA1A85A796C6E118F08D8FEDD3E3628726 )
 )
 game (
 	name "Mad Ball (CPC Infos) (France)"
@@ -8019,8 +8019,8 @@ game (
 game (
 	name "Midnight Resistance (Ocean Software)"
 	description "Midnight Resistance (Ocean Software)"
-	rom ( name "Midnight Resistance (1990)(Ocean Software)(Side A).dsk" size 264899 crc A7BAA480 md5 68AAE4A0E6578973E927AE25DD95730A sha1 853D77BBCAD38191EB612D7110BDC82D5CC8F267 )
 	rom ( name "Midnight Resistance (1990)(Ocean Software)(Side B).dsk" size 176107 crc B7D57795 md5 0BBEC19B21F16EBB417EFBBF12689ABB sha1 628B12F54EC438317CEAB192B74250F79BF1EEE6 )
+	rom ( name "Midnight Resistance (1990)(Ocean Software)(Side A).dsk" size 264899 crc A7BAA480 md5 68AAE4A0E6578973E927AE25DD95730A sha1 853D77BBCAD38191EB612D7110BDC82D5CC8F267 )
 )
 game (
 	name "Mindfighter (Activision)"
@@ -8045,20 +8045,20 @@ game (
 game (
 	name "Mascotte (Coktel Vision) (France)"
 	description "Mascotte (Coktel Vision) (France)"
-	rom ( name "Mascotte (1988)(Coktel Vision)(fr)(Side A)[CPM].dsk" size 198211 crc 416D5ACD md5 D6CBF7A2A070FEBCFE69F32E07B906B7 sha1 8F4CC5E71D5F4C6CAC6FF4CD24F6D9568DF3F34C )
 	rom ( name "Mascotte (1988)(Coktel Vision)(fr)(Side B).dsk" size 195635 crc E4175460 md5 9BF8FE06B9BA20B41D39954442CF230B sha1 1BD74BB56F4662B4CCA70D697E6184347C4CD02A )
+	rom ( name "Mascotte (1988)(Coktel Vision)(fr)(Side A)[CPM].dsk" size 198211 crc 416D5ACD md5 D6CBF7A2A070FEBCFE69F32E07B906B7 sha1 8F4CC5E71D5F4C6CAC6FF4CD24F6D9568DF3F34C )
 )
 game (
 	name "Mewilo (Coktel Vision) (France)"
 	description "Mewilo (Coktel Vision) (France)"
-	rom ( name "Mewilo (1987)(Coktel Vision)(fr)(Side A)[CPM].dsk" size 274009 crc 815C762B md5 5D1D071BB881AF0CD023BA8865CA7C7F sha1 0BAAEF2B3AC191D10960D8CF1C385BB8C6AEA488 )
 	rom ( name "Mewilo (1987)(Coktel Vision)(fr)(Side B).dsk" size 273753 crc BA4DD479 md5 DB7C403F4A791BCA5740526131BA62AF sha1 4336CFC4F2CBE40BC115EA71FC5709D56B5F53F2 )
+	rom ( name "Mewilo (1987)(Coktel Vision)(fr)(Side A)[CPM].dsk" size 274009 crc 815C762B md5 5D1D071BB881AF0CD023BA8865CA7C7F sha1 0BAAEF2B3AC191D10960D8CF1C385BB8C6AEA488 )
 )
 game (
 	name "Malediction, La (Lankhor) (France)"
 	description "Malediction, La (Lankhor) (France)"
-	rom ( name "Malediction, La (1991)(Lankhor)(fr)(Side A).dsk" size 274009 crc 58ECB546 md5 71B5F9177D0AE534E8BAECA7331378B7 sha1 AE2EDCD8098CFFBC1C7B554BF3EE5191DC8BCDDD )
 	rom ( name "Malediction, La (1991)(Lankhor)(fr)(Side B).dsk" size 195635 crc 499E78F7 md5 ACBBEF8A7C86B9C571D7AD79A013CADA sha1 48B27F70F57060432614F2C2BA871A13A73BAC2B )
+	rom ( name "Malediction, La (1991)(Lankhor)(fr)(Side A).dsk" size 274009 crc 58ECB546 md5 71B5F9177D0AE534E8BAECA7331378B7 sha1 AE2EDCD8098CFFBC1C7B554BF3EE5191DC8BCDDD )
 )
 game (
 	name "Morris Meets the Biker (Automata UK)"
@@ -8128,8 +8128,8 @@ game (
 game (
 	name "Microprose Soccer (Microprose Software)"
 	description "Microprose Soccer (Microprose Software)"
-	rom ( name "Microprose Soccer (1989)(Microprose Software)(Side A)[Soccer].dsk" size 194816 crc 79799B5A md5 BEAB8600AB981AD3B31D86A8C8A34F10 sha1 595E47A82724C94F2B60932DDE79C648B0482A45 )
 	rom ( name "Microprose Soccer (1989)(Microprose Software)(Side B)[Six-a-Side].dsk" size 194816 crc 3C2CCFC9 md5 DF2514C2CD5D08CCBA20ABB741B71ACA sha1 610F600A4A53A6BF0A3D7B8C3D6DF88E22CA5B6C )
+	rom ( name "Microprose Soccer (1989)(Microprose Software)(Side A)[Soccer].dsk" size 194816 crc 79799B5A md5 BEAB8600AB981AD3B31D86A8C8A34F10 sha1 595E47A82724C94F2B60932DDE79C648B0482A45 )
 )
 game (
 	name "Martianoids (Ultimate Play The Game)"
@@ -8204,8 +8204,8 @@ game (
 game (
 	name "Mokowe (Lankhor) (France)"
 	description "Mokowe (Lankhor) (France)"
-	rom ( name "Mokowe (1991)(Lankhor)(fr)(Side A).dsk" size 274009 crc B45FB5B md5 D22799A69D53326C83D55241BF0D648B sha1 66E67CE67794D86549FA3893374FF119500855E8 )
 	rom ( name "Mokowe (1991)(Lankhor)(fr)(Side B).dsk" size 195635 crc 773E6AB7 md5 FA515FFB84CF1E6F8DFC2DFBDB84C853 sha1 0FA902EBFE6F896D4180E0F426CC302D6ED57498 )
+	rom ( name "Mokowe (1991)(Lankhor)(fr)(Side A).dsk" size 274009 crc B45FB5B md5 D22799A69D53326C83D55241BF0D648B sha1 66E67CE67794D86549FA3893374FF119500855E8 )
 )
 game (
 	name "Metropolis (The Power House)"
@@ -8215,8 +8215,8 @@ game (
 game (
 	name "Mandragore (Infogrames) (France)"
 	description "Mandragore (Infogrames) (France)"
-	rom ( name "Mandragore (1985)(Infogrames)(fr)(Side A).dsk" size 180989 crc AD5F8B5B md5 F8A6698658BC51195E0178FA3DB6D0E0 sha1 5608DBFD0A14A8355FE7B61E2BC6DC2B52619E8E )
 	rom ( name "Mandragore (1985)(Infogrames)(fr)(Side B).dsk" size 146059 crc 104B2669 md5 4EAC462726E51E63217A7424A2146790 sha1 2B386C46229902D2069D77B6AE59543581164A35 )
+	rom ( name "Mandragore (1985)(Infogrames)(fr)(Side A).dsk" size 180989 crc AD5F8B5B md5 F8A6698658BC51195E0178FA3DB6D0E0 sha1 5608DBFD0A14A8355FE7B61E2BC6DC2B52619E8E )
 )
 game (
 	name "Mission Elevator (Eurogold)"
@@ -8236,8 +8236,8 @@ game (
 game (
 	name "Manoir de Mortvielle, Le (Lankhor) (France)"
 	description "Manoir de Mortvielle, Le (Lankhor) (France)"
-	rom ( name "Manoir de Mortvielle, Le (1988)(Lankhor)(fr)(Side A).dsk" size 273753 crc 697D2D31 md5 70DD2A927034226293848293F6A4527D sha1 7A9A485BD44F6C4E57B7F81DDAB63E891A852596 )
 	rom ( name "Manoir de Mortvielle, Le (1988)(Lankhor)(fr)(Side B).dsk" size 200517 crc 6A0357E8 md5 1A20A76559012FBEC964452BDBAC00CD sha1 A0E37C6F8E40132D9B4DDD5792FD36505CADEB21 )
+	rom ( name "Manoir de Mortvielle, Le (1988)(Lankhor)(fr)(Side A).dsk" size 273753 crc 697D2D31 md5 70DD2A927034226293848293F6A4527D sha1 7A9A485BD44F6C4E57B7F81DDAB63E891A852596 )
 )
 game (
 	name "Magic Sword, The (Database Educational Software)"
@@ -8252,8 +8252,8 @@ game (
 game (
 	name "Meurtres a Venise (Cobra Soft) (France)"
 	description "Meurtres a Venise (Cobra Soft) (France)"
-	rom ( name "Meurtres a Venise (1988)(Cobra Soft)(fr)(Side A).dsk" size 195635 crc B13A3365 md5 BD4D33BCD468615442CCBB538C300B47 sha1 22217A65D7262537B6BEFE2DCA0FB7265222A755 )
 	rom ( name "Meurtres a Venise (1988)(Cobra Soft)(fr)(Side B).dsk" size 195635 crc C8676092 md5 5AEFBB58E5E9ACFF2AD365724CCCF86E sha1 59C685A537B3548130E09026CDAC18A0F273077D )
+	rom ( name "Meurtres a Venise (1988)(Cobra Soft)(fr)(Side A).dsk" size 195635 crc B13A3365 md5 BD4D33BCD468615442CCBB538C300B47 sha1 22217A65D7262537B6BEFE2DCA0FB7265222A755 )
 )
 game (
 	name "Mini-Centipede (PD)"
@@ -8283,10 +8283,10 @@ game (
 game (
 	name "Megablasters (Radical Software)"
 	description "Megablasters (Radical Software)"
-	rom ( name "Megablasters (1994)(Radical Software)(Disk 1 Side A).dsk" size 204544 crc 75A53BEC md5 BF0676D0AF94C9117EF7CBE3790EC02C sha1 FD4D694349A893DB449833664DB9DC0A32D5D634 )
 	rom ( name "Megablasters (1994)(Radical Software)(Disk 1 Side B).dsk" size 204544 crc 8F71B89C md5 E8E9D39F5217548C9A6783CAFAEC12F5 sha1 806AA78EE3783DE3C72B0DADD08883FA4DFA7109 )
 	rom ( name "Megablasters (1994)(Radical Software)(Disk 2 Side A).dsk" size 204544 crc 1EB1E1E1 md5 AE6894196CCF2D76D3FA0A1F0556DAF2 sha1 4DF62529BB493E49A441B82E99C060B7C06B5A8E )
 	rom ( name "Megablasters (1994)(Radical Software)(Disk 2 Side B).dsk" size 204544 crc D5FC1C36 md5 6376947ACE57E520630E2471303FF709 sha1 385042B18BB7ADFA5E704D2878EC1C6AC647AFD9 )
+	rom ( name "Megablasters (1994)(Radical Software)(Disk 1 Side A).dsk" size 204544 crc 75A53BEC md5 BF0676D0AF94C9117EF7CBE3790EC02C sha1 FD4D694349A893DB449833664DB9DC0A32D5D634 )
 )
 game (
 	name "Molecularr (Amstrad Cent Pour Cent)"
@@ -8306,8 +8306,8 @@ game (
 game (
 	name "M'enfin - Gaston (Ubi Soft) (France)"
 	description "M'enfin - Gaston (Ubi Soft) (France)"
-	rom ( name "M'enfin - Gaston (1987)(Ubi Soft)(fr)(Side A).dsk" size 195328 crc 34DC1FAA md5 591CA988B7B6F309B4F549238D48A69E sha1 F9D37C0B852FA1D500438C11D3CA9356DB3C2DE9 )
 	rom ( name "M'enfin - Gaston (1987)(Ubi Soft)(fr)(Side B).dsk" size 194816 crc B84F3627 md5 996F7E6CAE669A6E4FA6A5C8527AB78D sha1 073B631818E4BBC12C1C7066311167B101FD8367 )
+	rom ( name "M'enfin - Gaston (1987)(Ubi Soft)(fr)(Side A).dsk" size 195328 crc 34DC1FAA md5 591CA988B7B6F309B4F549238D48A69E sha1 F9D37C0B852FA1D500438C11D3CA9356DB3C2DE9 )
 )
 game (
 	name "Metro 2018 (Initiel) (France)"
@@ -8332,8 +8332,8 @@ game (
 game (
 	name "Meurtres en Serie (Cobra Soft) (France)"
 	description "Meurtres en Serie (Cobra Soft) (France)"
-	rom ( name "Meurtres en Serie (1987)(Cobra Soft)(fr)(Side A).dsk" size 195635 crc 5E917C38 md5 313BD4F573491B8A9A5339C89CDB5DF0 sha1 4F160158E47F3ED2B0D875C5749F372F581902E2 )
 	rom ( name "Meurtres en Serie (1987)(Cobra Soft)(fr)(Side B).dsk" size 195635 crc ECA69E3E md5 5E5A4D54AD23D056A67EE9D9EA88C5A3 sha1 40EBAF3DBA0A05B0B2FACFB2C34C8A4DFFF3BCCD )
+	rom ( name "Meurtres en Serie (1987)(Cobra Soft)(fr)(Side A).dsk" size 195635 crc 5E917C38 md5 313BD4F573491B8A9A5339C89CDB5DF0 sha1 4F160158E47F3ED2B0D875C5749F372F581902E2 )
 )
 game (
 	name "Mach 3 (Loriciels)"
@@ -8378,8 +8378,8 @@ game (
 game (
 	name "Maitre Absolu, Le (Ubi Soft) (France)"
 	description "Maitre Absolu, Le (Ubi Soft) (France)"
-	rom ( name "Maitre Absolu, Le (1989)(Ubi Soft)(fr)(Side A).dsk" size 208128 crc 23AF9EB4 md5 97F0EBF50DF99B139C1CDC4D9F0977A2 sha1 9EBE5889F19B9D19120DA8570C807481D734A81F )
 	rom ( name "Maitre Absolu, Le (1989)(Ubi Soft)(fr)(Side B).dsk" size 204544 crc AA6728E1 md5 FF1430E8C897F53F25BF7C3C592FD512 sha1 EE4BDFE4166451FB16E08D73B1E5226559C64D1F )
+	rom ( name "Maitre Absolu, Le (1989)(Ubi Soft)(fr)(Side A).dsk" size 208128 crc 23AF9EB4 md5 97F0EBF50DF99B139C1CDC4D9F0977A2 sha1 9EBE5889F19B9D19120DA8570C807481D734A81F )
 )
 game (
 	name "Miss Input (cpcretrodev.byterealms)"
@@ -8444,8 +8444,8 @@ game (
 game (
 	name "Mandragore (Infogrames) (de)"
 	description "Mandragore (Infogrames) (de)"
-	rom ( name "Mandragore (1986)(Infogrames)(de)(Side A).dsk" size 175599 crc A5302940 md5 89847121DF26B048BEC9E8607542A5EF sha1 5B5624163E3A6F64CA0A906B669ED6E026629720 )
 	rom ( name "Mandragore (1986)(Infogrames)(de)(Side B).dsk" size 159151 crc B9DFE4D5 md5 EFA52F402C1BBCCFBABAAB43583F0B99 sha1 E0249158D721F58FAAFC82E50E0D7A4D3E2F648B )
+	rom ( name "Mandragore (1986)(Infogrames)(de)(Side A).dsk" size 175599 crc A5302940 md5 89847121DF26B048BEC9E8607542A5EF sha1 5B5624163E3A6F64CA0A906B669ED6E026629720 )
 )
 game (
 	name "Mystery of Arkham Manor, The (Melbourne House)"
@@ -8505,8 +8505,8 @@ game (
 game (
 	name "Mille et un Voyages, Les (Carraz Editions) (France)"
 	description "Mille et un Voyages, Les (Carraz Editions) (France)"
-	rom ( name "Mille et un Voyages, Les (1989)(Carraz Editions)(fr)(Side A).dsk" size 195635 crc E002CF9C md5 C9D3B3BE9ED4A2136F408F3914023EC1 sha1 B9BF44E7F0DF41938A88A8482655C690B277B3B4 )
 	rom ( name "Mille et un Voyages, Les (1989)(Carraz Editions)(fr)(Side B).dsk" size 195635 crc D7167E35 md5 342F8879141D4CD82741E674C8B19EE4 sha1 EFFB0C5FCA4C36017CE155B48828A9F9334983AA )
+	rom ( name "Mille et un Voyages, Les (1989)(Carraz Editions)(fr)(Side A).dsk" size 195635 crc E002CF9C md5 C9D3B3BE9ED4A2136F408F3914023EC1 sha1 B9BF44E7F0DF41938A88A8482655C690B277B3B4 )
 )
 game (
 	name "Metaplex (Addictive Games)"
@@ -8576,8 +8576,8 @@ game (
 game (
 	name "Mot (Opera Soft) (Spain)"
 	description "Mot (Opera Soft) (Spain)"
-	rom ( name "Mot (1989)(Opera Soft)(es)(Side A).dsk" size 218880 crc 70DA91C0 md5 4BB680095FE68140F1887F60419EAFEF sha1 8436518F447E673A8543813721F1458BCB20DC54 )
 	rom ( name "Mot (1989)(Opera Soft)(es)(Side B).dsk" size 218880 crc FB0775C4 md5 E91BA1126336EBD235C0579749A67A23 sha1 FA40AC5116E9AC4CDBAE67DCAA04C25C3B012445 )
+	rom ( name "Mot (1989)(Opera Soft)(es)(Side A).dsk" size 218880 crc 70DA91C0 md5 4BB680095FE68140F1887F60419EAFEF sha1 8436518F447E673A8543813721F1458BCB20DC54 )
 )
 game (
 	name "Magic Johnson's Basketball (Dro Soft) (Spain)"
@@ -8632,8 +8632,8 @@ game (
 game (
 	name "Macadam Bumper (PSS)"
 	description "Macadam Bumper (PSS)"
-	rom ( name "Macadam Bumper (1985)(PSS)[cr].dsk" size 194816 crc AF62AB03 md5 B9DF7B537B39D07249C9153784FE4DBC sha1 B5F9FA860CD76464EA52A379BF0035A643627AD0 )
 	rom ( name "Macadam Bumper (1985)(PSS).dsk" size 83456 crc 65BDAADD md5 46DE2D498E52844D16C82B16FC23C33D sha1 36E74427C6F67065BD0E8540B31C30098C723E41 )
+	rom ( name "Macadam Bumper (1985)(PSS)[cr].dsk" size 194816 crc AF62AB03 md5 B9DF7B537B39D07249C9153784FE4DBC sha1 B5F9FA860CD76464EA52A379BF0035A643627AD0 )
 )
 game (
 	name "Monty on the Run (Gremlin Graphics Software)"
@@ -8693,8 +8693,8 @@ game (
 game (
 	name "Masque (Ubi Soft) (France)"
 	description "Masque (Ubi Soft) (France)"
-	rom ( name "Masque (1986)(Ubi Soft)(fr)(Side A).dsk" size 266815 crc FEB65EFF md5 3B6FFB6278F3F7BCE475AD63CB3FDD93 sha1 D26B7FD4435C2D8AEE373704485029E3B1798AE4 )
 	rom ( name "Masque (1986)(Ubi Soft)(fr)(Side B).dsk" size 267315 crc D50BB5A1 md5 D28E49CD3EA9B4EC2EC6943029CDE656 sha1 0E855F0A41020E4998EFE3427CA7161C8F772392 )
+	rom ( name "Masque (1986)(Ubi Soft)(fr)(Side A).dsk" size 266815 crc FEB65EFF md5 3B6FFB6278F3F7BCE475AD63CB3FDD93 sha1 D26B7FD4435C2D8AEE373704485029E3B1798AE4 )
 )
 game (
 	name "Manhattan 95 (Ubi Soft)"
@@ -8704,8 +8704,8 @@ game (
 game (
 	name "Murder on the Atlantic (Cobra Soft)"
 	description "Murder on the Atlantic (Cobra Soft)"
-	rom ( name "Murder on the Atlantic (1985)(Cobra Soft)(Side A).dsk" size 195635 crc B40C5CB2 md5 00E665FB814F49BB69C55E21FA47C2D3 sha1 740D26F3ABC2663B26567CCF4045DB8F5F16E2CB )
 	rom ( name "Murder on the Atlantic (1985)(Cobra Soft)(Side B).dsk" size 195635 crc 3C816404 md5 B5DBC53DD7BCF34A401FE67FAF9E9F9D sha1 EAE9DCD09E42947CB0A654034BFE7E01ACFCC9A6 )
+	rom ( name "Murder on the Atlantic (1985)(Cobra Soft)(Side A).dsk" size 195635 crc B40C5CB2 md5 00E665FB814F49BB69C55E21FA47C2D3 sha1 740D26F3ABC2663B26567CCF4045DB8F5F16E2CB )
 )
 game (
 	name "Masterchess (Amsoft)"
@@ -8740,8 +8740,8 @@ game (
 game (
 	name "Manchester United (Krisalis Software) (M5)"
 	description "Manchester United (Krisalis Software) (M5)"
-	rom ( name "Manchester United (1990)(Krisalis Software)(M5)(Side A).dsk" size 195635 crc 76225BD5 md5 A0FBC0863906D79FFB42CA4EC9EB336F sha1 00EF2EA91B3B68BEAB5293117E3B3EE925CDC0D4 )
 	rom ( name "Manchester United (1990)(Krisalis Software)(M5)(Side B).dsk" size 194816 crc AFC28CBF md5 F455061D24CEEE861A5D15631573C30B sha1 D8F09F6CA841E608205C302665BA77C4B43CE0DF )
+	rom ( name "Manchester United (1990)(Krisalis Software)(M5)(Side A).dsk" size 195635 crc 76225BD5 md5 A0FBC0863906D79FFB42CA4EC9EB336F sha1 00EF2EA91B3B68BEAB5293117E3B3EE925CDC0D4 )
 )
 game (
 	name "Manoir du Comte Frozarda, Le (MBC Informatique) (France)"
@@ -8756,8 +8756,8 @@ game (
 game (
 	name "Meurtre sur LAtlantique (Cobra Soft) (France)"
 	description "Meurtre sur LAtlantique (Cobra Soft) (France)"
-	rom ( name "Meurtre sur LAtlantique (1985)(Cobra Soft)(fr)(Side A)[cr].dsk" size 204544 crc 901E677F md5 2EB6CE48FB25B23106AF44293D644594 sha1 3D5B370460F852ADAF8D9E5F9EBE31CC731DC114 )
 	rom ( name "Meurtre sur LAtlantique (1985)(Cobra Soft)(fr)(Side B)[cr].dsk" size 204544 crc A637CD4E md5 B02A4B3F66D44521C54C1DF36D25AD97 sha1 5680127EFE421B4D793C6FEF8B66FE801071B11F )
+	rom ( name "Meurtre sur LAtlantique (1985)(Cobra Soft)(fr)(Side A)[cr].dsk" size 204544 crc 901E677F md5 2EB6CE48FB25B23106AF44293D644594 sha1 3D5B370460F852ADAF8D9E5F9EBE31CC731DC114 )
 )
 game (
 	name "Mythos (Opera Soft)"
@@ -8767,8 +8767,8 @@ game (
 game (
 	name "Malefices (Nicolas Cocaign) (France)"
 	description "Malefices (Nicolas Cocaign) (France)"
-	rom ( name "Malefices (1992)(Nicolas Cocaign)(fr)(Side A)[cr].dsk" size 194816 crc 73D376A3 md5 ED6504F7606AFC955DA851DE15380610 sha1 ABBE0AA1427DAA228BCC229C66B8526066902C0D )
 	rom ( name "Malefices (1992)(Nicolas Cocaign)(fr)(Side B)[cr].dsk" size 204544 crc EF8E9B95 md5 FF9D5FB893695883A8DF3A8118BF2063 sha1 C654AB6A5FF2B2AD3375DB5462419B71291954F3 )
+	rom ( name "Malefices (1992)(Nicolas Cocaign)(fr)(Side A)[cr].dsk" size 194816 crc 73D376A3 md5 ED6504F7606AFC955DA851DE15380610 sha1 ABBE0AA1427DAA228BCC229C66B8526066902C0D )
 )
 game (
 	name "Metro Cross (US Gold)"
@@ -8818,14 +8818,14 @@ game (
 game (
 	name "North & South (Infogrames) (M3)"
 	description "North & South (Infogrames) (M3)"
-	rom ( name "North & South (1989)(Infogrames)(M3)(Side A).dsk" size 215291 crc BF564629 md5 0869365AE60F6461ACBA6D213A30E1D8 sha1 B55B5ECAB2CA14EC93C5FD437AAE82D74C741067 )
 	rom ( name "North & South (1989)(Infogrames)(M3)(Side B).dsk" size 215795 crc D38A0194 md5 26037E37963854A8D06EE2B5135A8798 sha1 8A273C66B56D415C111EFDC90284A32142FEC826 )
+	rom ( name "North & South (1989)(Infogrames)(M3)(Side A).dsk" size 215291 crc BF564629 md5 0869365AE60F6461ACBA6D213A30E1D8 sha1 B55B5ECAB2CA14EC93C5FD437AAE82D74C741067 )
 )
 game (
 	name "Nigromante, El (Ubi Soft) (Spain) (Hack)"
 	description "Nigromante, El (Ubi Soft) (Spain) (Hack)"
-	rom ( name "Nigromante, El (2019)(Ubi Soft)(es)(Hack)(Side A)[cr].dsk" size 204544 crc EBD801CD md5 C74C20A7417892348918F9CCDE09CA63 sha1 F94850749C157968E6637BC6AE04611703A329F2 )
 	rom ( name "Nigromante, El (2019)(Ubi Soft)(es)(Hack)(Side B)[cr].dsk" size 204544 crc F7E07877 md5 997DE76E30AB6FAD2A28DB782325AB8A sha1 3646412B8FBBC231DB3072EA3AC35C9182FF80EC )
+	rom ( name "Nigromante, El (2019)(Ubi Soft)(es)(Hack)(Side A)[cr].dsk" size 204544 crc EBD801CD md5 C74C20A7417892348918F9CCDE09CA63 sha1 F94850749C157968E6637BC6AE04611703A329F2 )
 )
 game (
 	name "Navy Moves (Dinamic Software)"
@@ -8905,14 +8905,14 @@ game (
 game (
 	name "Necromancien, Le (Ubi Soft) (France)"
 	description "Necromancien, Le (Ubi Soft) (France)"
-	rom ( name "Necromancien, Le (1987)(Ubi Soft)(fr)(Side A).dsk" size 209229 crc 3D981755 md5 39E002B096F075F12760E52BFAA1DA6C sha1 9FE52B4026B8CCC09758BCFBC3C8FC120AAE9470 )
 	rom ( name "Necromancien, Le (1987)(Ubi Soft)(fr)(Side B).dsk" size 210105 crc 22DC1FB5 md5 71659D0DFAE332A88F0039B314677769 sha1 77E8E768A5257CBA47FEDBC37D40AF045686C99A )
+	rom ( name "Necromancien, Le (1987)(Ubi Soft)(fr)(Side A).dsk" size 209229 crc 3D981755 md5 39E002B096F075F12760E52BFAA1DA6C sha1 9FE52B4026B8CCC09758BCFBC3C8FC120AAE9470 )
 )
 game (
 	name "Narc (Ocean Software)"
 	description "Narc (Ocean Software)"
-	rom ( name "Narc (1990)(Ocean Software)(Side A).dsk" size 220672 crc ADC86F57 md5 D9D56313D3FD576730C85811184606E1 sha1 5C497970E44223881EB59B1E28529F6DBE699372 )
 	rom ( name "Narc (1990)(Ocean Software)(Side B).dsk" size 220672 crc D9091CEC md5 2A1F3CF0A390DFBF0AC90402DB41D04A sha1 5778242A7E2A3B778165B0F1C8FF0B9274DA3867 )
+	rom ( name "Narc (1990)(Ocean Software)(Side A).dsk" size 220672 crc ADC86F57 md5 D9D56313D3FD576730C85811184606E1 sha1 5C497970E44223881EB59B1E28529F6DBE699372 )
 )
 game (
 	name "Netherworld (Hewson)"
@@ -8922,8 +8922,8 @@ game (
 game (
 	name "New Zealand Story, The (Ocean Software)"
 	description "New Zealand Story, The (Ocean Software)"
-	rom ( name "New Zealand Story, The (1989)(Ocean Software)(Side A).dsk" size 264899 crc 99DCFD1B md5 81D3E0DC2E2A832F1941A62F7F02C4F8 sha1 0EF00154527B20CFDA5BF1CF0475F07FFEE36CBB )
 	rom ( name "New Zealand Story, The (1989)(Ocean Software)(Side B).dsk" size 195635 crc 8721CA59 md5 6EC03835CDC922B80DC36A425C26037D sha1 872D77B998E785C71696401AB4A67DF1C7F0C7F1 )
+	rom ( name "New Zealand Story, The (1989)(Ocean Software)(Side A).dsk" size 264899 crc 99DCFD1B md5 81D3E0DC2E2A832F1941A62F7F02C4F8 sha1 0EF00154527B20CFDA5BF1CF0475F07FFEE36CBB )
 )
 game (
 	name "Nebulus (Hewson Consultants)"
@@ -8933,8 +8933,8 @@ game (
 game (
 	name "Not a Penny More, Not a Penny Less (Domark)"
 	description "Not a Penny More, Not a Penny Less (Domark)"
-	rom ( name "Not a Penny More, Not a Penny Less (1987)(Domark)(Side A).dsk" size 195635 crc 5EBEFB4B md5 144432F5EF2C440BC24FBE64B70B6CC3 sha1 DC7AB3B09CEF3E0CA5AA59DF2A346B925E07C1FF )
 	rom ( name "Not a Penny More, Not a Penny Less (1987)(Domark)(Side B).dsk" size 195635 crc 22D4030A md5 EBD1926DE923B8758D4B89DD18FCA5F1 sha1 1462D16A47EB1C4B9C3DFFD6D83E23E33B9A38AF )
+	rom ( name "Not a Penny More, Not a Penny Less (1987)(Domark)(Side A).dsk" size 195635 crc 5EBEFB4B md5 144432F5EF2C440BC24FBE64B70B6CC3 sha1 DC7AB3B09CEF3E0CA5AA59DF2A346B925E07C1FF )
 )
 game (
 	name "Ninja Commando (Zeppelin Games)"
@@ -8959,8 +8959,8 @@ game (
 game (
 	name "Nigel Mansell's World Championship (Gremlin Graphics Software)"
 	description "Nigel Mansell's World Championship (Gremlin Graphics Software)"
-	rom ( name "Nigel Mansell's World Championship (1992)(Gremlin Graphics Software)(Side A).dsk" size 195635 crc A816B717 md5 C911F6E078AEF774263AADC425517CBE sha1 4D9F48E361A15FF0ED362AE073815FCC582B1706 )
 	rom ( name "Nigel Mansell's World Championship (1992)(Gremlin Graphics Software)(Side B).dsk" size 195635 crc 76EC59D1 md5 62FC04280C924247FEAD0A1E53E419AE sha1 1FB13277497386F71FF124956C95B70B5B16928B )
+	rom ( name "Nigel Mansell's World Championship (1992)(Gremlin Graphics Software)(Side A).dsk" size 195635 crc A816B717 md5 C911F6E078AEF774263AADC425517CBE sha1 4D9F48E361A15FF0ED362AE073815FCC582B1706 )
 )
 game (
 	name "NeverEnding Story, The (Ocean Software)"
@@ -8995,8 +8995,8 @@ game (
 game (
 	name "Night Breed (Ocean Software)"
 	description "Night Breed (Ocean Software)"
-	rom ( name "Night Breed (1990)(Ocean Software)(Side A).dsk" size 175589 crc F2F19689 md5 89D73FF2E4C5588196EFACAA33E55839 sha1 A26291559DF0B48A8F965CBA478DB06044F407ED )
 	rom ( name "Night Breed (1990)(Ocean Software)(Side B).dsk" size 175589 crc 5C2B72FD md5 D91B7AAE9D6F7205FFEDA04064ABAB0C sha1 B3299608640B533CE8D3468D4556F70354F6400E )
+	rom ( name "Night Breed (1990)(Ocean Software)(Side A).dsk" size 175589 crc F2F19689 md5 89D73FF2E4C5588196EFACAA33E55839 sha1 A26291559DF0B48A8F965CBA478DB06044F407ED )
 )
 game (
 	name "Number 1 (Bug-Byte)"
@@ -9061,8 +9061,8 @@ game (
 game (
 	name "Night Hunter (Ubi Soft) (Spain)"
 	description "Night Hunter (Ubi Soft) (Spain)"
-	rom ( name "Night Hunter (1990)(Ubi Soft)(es)(Side A).dsk" size 204544 crc 6761EE78 md5 E53C443785E4A2618ADE2DD4AA07D5CD sha1 5C5B92733C1F59E1043968BD6F5B4C328ABFF5F2 )
 	rom ( name "Night Hunter (1990)(Ubi Soft)(es)(Side B).dsk" size 199680 crc E63D8282 md5 BC56B9C33A40717330D75214BF3B6578 sha1 1B06E380B2E00A316BC04C49FEAD1256C7884B07 )
+	rom ( name "Night Hunter (1990)(Ubi Soft)(es)(Side A).dsk" size 204544 crc 6761EE78 md5 E53C443785E4A2618ADE2DD4AA07D5CD sha1 5C5B92733C1F59E1043968BD6F5B4C328ABFF5F2 )
 )
 game (
 	name "Nuclear Heist (Players)"
@@ -9092,8 +9092,8 @@ game (
 game (
 	name "Night Hunter (Ubi Soft) (France)"
 	description "Night Hunter (Ubi Soft) (France)"
-	rom ( name "Night Hunter (1990)(Ubi Soft)(fr)(Side A).dsk" size 216195 crc 159D5A2C md5 ACA8BD5FE6475243418A9E22E2D982CD sha1 310E489F9ED07C9FB59C084EAC7E3490A4B13AE5 )
 	rom ( name "Night Hunter (1990)(Ubi Soft)(fr)(Side B).dsk" size 216195 crc 414A19D4 md5 E5DDEE27D019CD9E8EE41611C0803924 sha1 8DABD8B54DD72201DADC1FA31B395700D62E45D3 )
+	rom ( name "Night Hunter (1990)(Ubi Soft)(fr)(Side A).dsk" size 216195 crc 159D5A2C md5 ACA8BD5FE6475243418A9E22E2D982CD sha1 310E489F9ED07C9FB59C084EAC7E3490A4B13AE5 )
 )
 game (
 	name "Oh Mummy! (Amsoft)"
@@ -9108,8 +9108,8 @@ game (
 game (
 	name "Oriental Games (Micro Style)"
 	description "Oriental Games (Micro Style)"
-	rom ( name "Oriental Games (1990)(Micro Style)(Side A).dsk" size 195635 crc 317E04E9 md5 08669862A8E93AA7390AA4C25D761201 sha1 A1DB176397ED3814DC8DA255C8F6AB68E2E3CD99 )
 	rom ( name "Oriental Games (1990)(Micro Style)(Side B).dsk" size 195635 crc 42EEDB86 md5 2229BAC0EF70B5F2BDD17484B36D0CD5 sha1 498C91B276472212FCA0AB4583546A0BFFA95579 )
+	rom ( name "Oriental Games (1990)(Micro Style)(Side A).dsk" size 195635 crc 317E04E9 md5 08669862A8E93AA7390AA4C25D761201 sha1 A1DB176397ED3814DC8DA255C8F6AB68E2E3CD99 )
 )
 game (
 	name "Omega Dimension (Positive) (Spain)"
@@ -9129,8 +9129,8 @@ game (
 game (
 	name "Out Run Europa (US Gold)"
 	description "Out Run Europa (US Gold)"
-	rom ( name "Out Run Europa (1991)(US Gold)(Side A).dsk" size 265413 crc 20DE516D md5 772F50615C7E7640CC8D71A8B6F9712F sha1 6A02BC16CBF0914A60C54E07B9F3FD9FD70D6C72 )
 	rom ( name "Out Run Europa (1991)(US Gold)(Side B).dsk" size 266675 crc 5138310B md5 8870C526F9674CFC6DD13837F05D02BF sha1 1DB86979E7F09A51E912AA36CFD02475C7389624 )
+	rom ( name "Out Run Europa (1991)(US Gold)(Side A).dsk" size 265413 crc 20DE516D md5 772F50615C7E7640CC8D71A8B6F9712F sha1 6A02BC16CBF0914A60C54E07B9F3FD9FD70D6C72 )
 )
 game (
 	name "On the Run (Design Design Software)"
@@ -9200,14 +9200,14 @@ game (
 game (
 	name "Omega Planete Invisible (Infogrames) (France)"
 	description "Omega Planete Invisible (Infogrames) (France)"
-	rom ( name "Omega Planete Invisible (1987)(Infogrames)(fr)(Side A).dsk" size 194879 crc 5A1D7D59 md5 606204C6244193B005F6C192A022F37B sha1 E97B48498175ABED2758D23727F5CE538439E34A )
 	rom ( name "Omega Planete Invisible (1987)(Infogrames)(fr)(Side B).dsk" size 196671 crc 1FC470B9 md5 D3107805CC2AC207B7476E530A3D70B8 sha1 7BDDD62F1CDC8E53748BDD71489C7CE467E3C560 )
+	rom ( name "Omega Planete Invisible (1987)(Infogrames)(fr)(Side A).dsk" size 194879 crc 5A1D7D59 md5 606204C6244193B005F6C192A022F37B sha1 E97B48498175ABED2758D23727F5CE538439E34A )
 )
 game (
 	name "Orphee (Loriciels) (France)"
 	description "Orphee (Loriciels) (France)"
-	rom ( name "Orphee (1985)(Loriciels)(fr)(Side A).dsk" size 192033 crc 2317E673 md5 14FDC9D88B55A020F083DA9BCAEC585E sha1 7523EAAB6022E33EE82FCBC0E0F4455706F6ACE9 )
 	rom ( name "Orphee (1985)(Loriciels)(fr)(Side B).dsk" size 195635 crc A5291E8C md5 3C836A3281278AA09838FFF32B2C1C52 sha1 6AB188F8CAE52C834D472449C375916100DC8090 )
+	rom ( name "Orphee (1985)(Loriciels)(fr)(Side A).dsk" size 192033 crc 2317E673 md5 14FDC9D88B55A020F083DA9BCAEC585E sha1 7523EAAB6022E33EE82FCBC0E0F4455706F6ACE9 )
 )
 game (
 	name "Operation Wolf (Ocean Software) (LightGun)"
@@ -9217,14 +9217,14 @@ game (
 game (
 	name "Operation Thunderbolt (Ocean Software)"
 	description "Operation Thunderbolt (Ocean Software)"
-	rom ( name "Operation Thunderbolt (1989)(Ocean Software)(Side A).dsk" size 65159 crc 523E055E md5 B682E02B656638FFE4B9CF33E4BD950A sha1 25E403F295BC01DC9AF4CA71490062C65CD03526 )
 	rom ( name "Operation Thunderbolt (1989)(Ocean Software)(Side B).dsk" size 156579 crc 5E0B98BB md5 184D5B40D45F72E966BE2ED603370388 sha1 451A03F7ADB16D19B734CCE301AD26C6EBBEC8BC )
+	rom ( name "Operation Thunderbolt (1989)(Ocean Software)(Side A).dsk" size 65159 crc 523E055E md5 B682E02B656638FFE4B9CF33E4BD950A sha1 25E403F295BC01DC9AF4CA71490062C65CD03526 )
 )
 game (
 	name "Out Run (US Gold)"
 	description "Out Run (US Gold)"
-	rom ( name "Out Run (1988)(US Gold)(Side A).dsk" size 213760 crc 6D119419 md5 93802EDFA270DC2A1F33514ACEA7DE2B sha1 73AA87817A76256D4CECFA1568483E53E4B95C37 )
 	rom ( name "Out Run (1988)(US Gold)(Side B).dsk" size 194816 crc 19F3E1C7 md5 D9EB053BE7FE45F36F86EFC5F25775A0 sha1 F82600CAB6B6123D341A03BCEA3BCD53122D8C36 )
+	rom ( name "Out Run (1988)(US Gold)(Side A).dsk" size 213760 crc 6D119419 md5 93802EDFA270DC2A1F33514ACEA7DE2B sha1 73AA87817A76256D4CECFA1568483E53E4B95C37 )
 )
 game (
 	name "On the Oche (Artic Computing)"
@@ -9259,8 +9259,8 @@ game (
 game (
 	name "Oxphar (ERE Informatique) (France)"
 	description "Oxphar (ERE Informatique) (France)"
-	rom ( name "Oxphar (1987)(ERE Informatique)(fr)(Side A).dsk" size 127087 crc 365D9220 md5 0464AFD0A88EA0A7D74B8E2841BCF1C4 sha1 0AE5A0D9031D1C942C500E236CC77D66803D6187 )
 	rom ( name "Oxphar (1987)(ERE Informatique)(fr)(Side B).dsk" size 195635 crc 5329E84 md5 38CC5072C796783C0E07BAE52E099027 sha1 516504A5B517768C91E2FBA09D68EC91F9878468 )
+	rom ( name "Oxphar (1987)(ERE Informatique)(fr)(Side A).dsk" size 127087 crc 365D9220 md5 0464AFD0A88EA0A7D74B8E2841BCF1C4 sha1 0AE5A0D9031D1C942C500E236CC77D66803D6187 )
 )
 game (
 	name "Operation Wolf (Ocean Software)"
@@ -9280,8 +9280,8 @@ game (
 game (
 	name "Oeil de Set, L' (Ubi Soft) (France)"
 	description "Oeil de Set, L' (Ubi Soft) (France)"
-	rom ( name "Oeil de Set, L' (1987)(Ubi Soft)(fr)(v2)(Side A).dsk" size 195891 crc 951A0C7D md5 3AB17C758CB14D043008FD9321C53F5E sha1 0B600CDBD52AAA350AFD85983116CDFFE663C0CD )
 	rom ( name "Oeil de Set, L' (1987)(Ubi Soft)(fr)(v2)(Side B).dsk" size 195891 crc 80BF6A46 md5 57E21134EE3534BC35FD9081A58AE147 sha1 4A6067CB1CE1E1D3395C8F80C9E8D4BBF56690C8 )
+	rom ( name "Oeil de Set, L' (1987)(Ubi Soft)(fr)(v2)(Side A).dsk" size 195891 crc 951A0C7D md5 3AB17C758CB14D043008FD9321C53F5E sha1 0B600CDBD52AAA350AFD85983116CDFFE663C0CD )
 )
 game (
 	name "Out of This World (Ariolasoft)"
@@ -9351,8 +9351,8 @@ game (
 game (
 	name "Pit-Fighter (Domark) (Bugs)"
 	description "Pit-Fighter (Domark) (Bugs)"
-	rom ( name "Pit-Fighter (1991)(Domark)(Side A)[b].dsk" size 175075 crc 8AF478EB md5 DDC9FD8EDAD10AA9D2AEE609BC1C2647 sha1 1B32DC626435D15ED56CA1D87E33873856378B5E )
 	rom ( name "Pit-Fighter (1991)(Domark)(Side B)[b].dsk" size 175075 crc 1F135FE1 md5 FE59443AFBF724840DA77DF3C3BFC52C sha1 D1E1C55B931DBD3722D7FB24E25198E92733D522 )
+	rom ( name "Pit-Fighter (1991)(Domark)(Side A)[b].dsk" size 175075 crc 8AF478EB md5 DDC9FD8EDAD10AA9D2AEE609BC1C2647 sha1 1B32DC626435D15ED56CA1D87E33873856378B5E )
 )
 game (
 	name "Paperboy 2 (Mindscape)"
@@ -9377,8 +9377,8 @@ game (
 game (
 	name "Passagers du Vent (Infogrames) (France)"
 	description "Passagers du Vent (Infogrames) (France)"
-	rom ( name "Passagers du Vent (1986)(Infogrames)(fr)(Side A).dsk" size 201041 crc D4680EE7 md5 303E83006BE374E3A7D32B788E791350 sha1 13DFFB15E4746D759B2652CE37A0673F7A3FA6FB )
 	rom ( name "Passagers du Vent (1986)(Infogrames)(fr)(Side B).dsk" size 201797 crc AB5C25CA md5 01CE4C896699D9586341643D20CD5B5D sha1 53A89E39F68E37B181A4D74FCAFFFAAFB35DE39F )
+	rom ( name "Passagers du Vent (1986)(Infogrames)(fr)(Side A).dsk" size 201041 crc D4680EE7 md5 303E83006BE374E3A7D32B788E791350 sha1 13DFFB15E4746D759B2652CE37A0673F7A3FA6FB )
 )
 game (
 	name "Pirate (Black System)"
@@ -9418,8 +9418,8 @@ game (
 game (
 	name "Pacte, Le (Loriciels) (France)"
 	description "Pacte, Le (Loriciels) (France)"
-	rom ( name "Pacte, Le (1986)(Loriciels)(fr)(Side A).dsk" size 196915 crc CC6A3F5 md5 DFF65B46C74B06223C11BD6599063167 sha1 2C45AE0F85676968B3383EC188EB49F1F5C0914E )
 	rom ( name "Pacte, Le (1986)(Loriciels)(fr)(Side B).dsk" size 196915 crc E3F1B5DB md5 EDF73D3B55E8ADCC9C3FC02DF7BC14EF sha1 9B25999BCE9F3BCEE10BC33D4D161D49BD6B50F0 )
+	rom ( name "Pacte, Le (1986)(Loriciels)(fr)(Side A).dsk" size 196915 crc CC6A3F5 md5 DFF65B46C74B06223C11BD6599063167 sha1 2C45AE0F85676968B3383EC188EB49F1F5C0914E )
 )
 game (
 	name "P-47 Thunderbolt - The Freedom Fighter (Firebird Software)"
@@ -9439,8 +9439,8 @@ game (
 game (
 	name "Puffy's Saga (Ubi Soft)"
 	description "Puffy's Saga (Ubi Soft)"
-	rom ( name "Puffy's Saga (1989)(Ubi Soft)(Side A).dsk" size 248029 crc D4DA0FB md5 F0D4567D6B405DCC5B7A7851378605BF sha1 F63F63E5B7257E4010B9363B65F9C93DB9F30D04 )
 	rom ( name "Puffy's Saga (1989)(Ubi Soft)(Side B).dsk" size 92087 crc 70CD64BC md5 F0C45DD4F9C0F14A0F799163B4D3E93A sha1 4B13FF89B0F089E373BC77B5648D5CFBE485B126 )
+	rom ( name "Puffy's Saga (1989)(Ubi Soft)(Side A).dsk" size 248029 crc D4DA0FB md5 F0D4567D6B405DCC5B7A7851378605BF sha1 F63F63E5B7257E4010B9363B65F9C93DB9F30D04 )
 )
 game (
 	name "Plate-Forme (MBC Informatique) (France)"
@@ -9495,8 +9495,8 @@ game (
 game (
 	name "Passagers du Vent 2 (Infogrames) (France)"
 	description "Passagers du Vent 2 (Infogrames) (France)"
-	rom ( name "Passagers du Vent 2 (1987)(Infogrames)(fr)(Side A).dsk" size 201297 crc 200C4423 md5 9680856A86B3553F80B19C55F597D496 sha1 137726CA4390771C3952CA40F2B516ED2B590B17 )
 	rom ( name "Passagers du Vent 2 (1987)(Infogrames)(fr)(Side B).dsk" size 202053 crc 4E5758D1 md5 8049046BF6D2537E2B019655D13E579E sha1 C887F9A4FCB50384ACD7979BEA83ED0CFAE850A7 )
+	rom ( name "Passagers du Vent 2 (1987)(Infogrames)(fr)(Side A).dsk" size 201297 crc 200C4423 md5 9680856A86B3553F80B19C55F597D496 sha1 137726CA4390771C3952CA40F2B516ED2B590B17 )
 )
 game (
 	name "Postman's Destiny (PC Amstrad International)"
@@ -9531,8 +9531,8 @@ game (
 game (
 	name "Peur Sur Amityville (Ubi Soft) (Spain) (Hack)"
 	description "Peur Sur Amityville (Ubi Soft) (Spain) (Hack)"
-	rom ( name "Peur Sur Amityville (2019)(Ubi Soft)(es)(Hack)(Side A)[cr].dsk" size 204544 crc C09CD00C md5 254D305A4B3E8DD71584A56043F4BAC2 sha1 E9755A761CBFC2B233B794AC7DACB576DAD170FF )
 	rom ( name "Peur Sur Amityville (2019)(Ubi Soft)(es)(Hack)(Side B)[cr].dsk" size 204544 crc AFFA2688 md5 3CF6B5F5ABABCAF0281B413DE082D63B sha1 BF6F9E0EDBF834E35335BDFEC1EF7709FD07B230 )
+	rom ( name "Peur Sur Amityville (2019)(Ubi Soft)(es)(Hack)(Side A)[cr].dsk" size 204544 crc C09CD00C md5 254D305A4B3E8DD71584A56043F4BAC2 sha1 E9755A761CBFC2B233B794AC7DACB576DAD170FF )
 )
 game (
 	name "Panza Kick Boxing (Loriciels)"
@@ -9552,8 +9552,8 @@ game (
 game (
 	name "Peur Sur Amityville (Ubi Soft) (France)"
 	description "Peur Sur Amityville (Ubi Soft) (France)"
-	rom ( name "Peur Sur Amityville (1987)(Ubi Soft)(fr)(Side A).dsk" size 204544 crc 72046022 md5 F83A51C7636F69AE89C4BF8A66FFF4E5 sha1 1C7C52D157759A05C350AFC2907EB448488BD03E )
 	rom ( name "Peur Sur Amityville (1987)(Ubi Soft)(fr)(Side B).dsk" size 204544 crc D3D2E2FA md5 FD5BA326B51B28F4DA11E6A830965BFD sha1 E1E288B59BCD8A0638B19B83D318FC98578F78B2 )
+	rom ( name "Peur Sur Amityville (1987)(Ubi Soft)(fr)(Side A).dsk" size 204544 crc 72046022 md5 F83A51C7636F69AE89C4BF8A66FFF4E5 sha1 1C7C52D157759A05C350AFC2907EB448488BD03E )
 )
 game (
 	name "Poli Diaz Boxeo (Opera Soft) (Codes)"
@@ -9618,8 +9618,8 @@ game (
 game (
 	name "Pirates (Microprose Software) (France)"
 	description "Pirates (Microprose Software) (France)"
-	rom ( name "Pirates (1987)(Microprose Software)(fr)(Side A).dsk" size 200517 crc 793E37F5 md5 7756B0C050548DB173297F9C6D50E0DC sha1 C95DC1A23725D8362FBEB3C91FE64FAA0136231F )
 	rom ( name "Pirates (1987)(Microprose Software)(fr)(Side B).dsk" size 195635 crc DB889D3C md5 6A86F3F49E0911DC097325D2989C8A7C sha1 2A613A52094C8B733FAA8C67FBFF44F5E3B390C7 )
+	rom ( name "Pirates (1987)(Microprose Software)(fr)(Side A).dsk" size 200517 crc 793E37F5 md5 7756B0C050548DB173297F9C6D50E0DC sha1 C95DC1A23725D8362FBEB3C91FE64FAA0136231F )
 )
 game (
 	name "Prokyon (Pride Soft) (de)"
@@ -9644,8 +9644,8 @@ game (
 game (
 	name "Pawn, The (Rainbird Software)"
 	description "Pawn, The (Rainbird Software)"
-	rom ( name "Pawn, The (1987)(Rainbird Software)(Side A).dsk" size 195635 crc 872B7D18 md5 93590AD02504F2DA40D3C44D5B5AF4C0 sha1 A8CF97616BAA7C9954B7BAB3DC85B626F42629EF )
 	rom ( name "Pawn, The (1987)(Rainbird Software)(Side B).dsk" size 195635 crc AD41E315 md5 F5AD360FC5CA64E8BF328B98304A47EA sha1 86CA7E5C4771C7BB0362A460CA4D96150B43F5C8 )
+	rom ( name "Pawn, The (1987)(Rainbird Software)(Side A).dsk" size 195635 crc 872B7D18 md5 93590AD02504F2DA40D3C44D5B5AF4C0 sha1 A8CF97616BAA7C9954B7BAB3DC85B626F42629EF )
 )
 game (
 	name "Puzznix (CPC Amstrad International)"
@@ -9690,8 +9690,8 @@ game (
 game (
 	name "Passagers du Vent 2 (Infogrames)"
 	description "Passagers du Vent 2 (Infogrames)"
-	rom ( name "Passagers du Vent 2 (1987)(Infogrames)(Side A).dsk" size 202240 crc D1C258D1 md5 A72D5594ACFBC96878CFDFC716CF496C sha1 E70BFF97BC9F6D3E359B6DCE14BDE8C1588B8414 )
 	rom ( name "Passagers du Vent 2 (1987)(Infogrames)(Side B).dsk" size 200960 crc 2475B163 md5 3D17F4FD08A3BD7AA1DB394658F29917 sha1 CD28FA6D8C100CFFD052BF6456C4032FB1E79B68 )
+	rom ( name "Passagers du Vent 2 (1987)(Infogrames)(Side A).dsk" size 202240 crc D1C258D1 md5 A72D5594ACFBC96878CFDFC716CF496C sha1 E70BFF97BC9F6D3E359B6DCE14BDE8C1588B8414 )
 )
 game (
 	name "Pilots (Bollaware) (de)"
@@ -9746,8 +9746,8 @@ game (
 game (
 	name "Pharaon (Loriciels) (Spain) (Hack)"
 	description "Pharaon (Loriciels) (Spain) (Hack)"
-	rom ( name "Pharaon (2012)(Loriciels)(es)(Hack)(Side A)[cr].dsk" size 204800 crc E0FC510B md5 1BFCDA17D0355065317DB912B36B2256 sha1 09BB82861F6EBE15C7F96B675103DF04221419F9 )
 	rom ( name "Pharaon (2012)(Loriciels)(es)(Hack)(Side B)[cr].dsk" size 204800 crc C5CD314D md5 BE150DCD8D516FBFE2E70D8AB87A65E1 sha1 304E7A69650B36F64FF81F8016D97345B1DD5B28 )
+	rom ( name "Pharaon (2012)(Loriciels)(es)(Hack)(Side A)[cr].dsk" size 204800 crc E0FC510B md5 1BFCDA17D0355065317DB912B36B2256 sha1 09BB82861F6EBE15C7F96B675103DF04221419F9 )
 )
 game (
 	name "Phantom Club (Ocean)"
@@ -9807,8 +9807,8 @@ game (
 game (
 	name "Play Bac (Microids) (France)"
 	description "Play Bac (Microids) (France)"
-	rom ( name "Play Bac (1987)(Microids)(fr)(Side A).dsk" size 195635 crc CBAB7A0D md5 05554ADD8EBA8D9B521956587A842016 sha1 BFA0A830BA4FE57DB9E00934646087B39B793DB1 )
 	rom ( name "Play Bac (1987)(Microids)(fr)(Side B).dsk" size 195635 crc D93DD522 md5 A82124BF41394D9E319FDA872672291E sha1 6A7F684862927E89952C630413318796D2C0910A )
+	rom ( name "Play Bac (1987)(Microids)(fr)(Side A).dsk" size 195635 crc CBAB7A0D md5 05554ADD8EBA8D9B521956587A842016 sha1 BFA0A830BA4FE57DB9E00934646087B39B793DB1 )
 )
 game (
 	name "Puzznic (Ocean Software)"
@@ -9853,8 +9853,8 @@ game (
 game (
 	name "Pirates (Microprose Software)"
 	description "Pirates (Microprose Software)"
-	rom ( name "Pirates (1987)(Microprose Software)(Side A).dsk" size 200517 crc F1684E55 md5 39460E1EEF69C1E9B25AFD7FC485E3BE sha1 E4B74E5C4E86B854A4CD3CBB206DF900D74A161E )
 	rom ( name "Pirates (1987)(Microprose Software)(Side B).dsk" size 195635 crc 632AF5D7 md5 81A70C1D78F3C8FDC7BDC0DE02BAF19D sha1 DDCCD20AAE8C5555A3EFD676CB6529549C29F617 )
+	rom ( name "Pirates (1987)(Microprose Software)(Side A).dsk" size 200517 crc F1684E55 md5 39460E1EEF69C1E9B25AFD7FC485E3BE sha1 E4B74E5C4E86B854A4CD3CBB206DF900D74A161E )
 )
 game (
 	name "Pro Golf - Sunningdale (Atlantis Software)"
@@ -9884,14 +9884,14 @@ game (
 game (
 	name "Passengers On The Wind (Infogrames)"
 	description "Passengers On The Wind (Infogrames)"
-	rom ( name "Passengers On The Wind (1987) (Infogrames)(Side A).dsk" size 201297 crc 24B0497A md5 14877706C6C7F2213FACDA042DEC6941 sha1 44F1392E45BB35FF25FCBEEA0EA4EBEC1CC85F59 )
 	rom ( name "Passengers On The Wind (1987) (Infogrames)(Side B).dsk" size 202053 crc 603876E6 md5 EBBFEE81C115A919272585E485747505 sha1 DA79093B997A293F55D559B44D7CF4DAA3C7F374 )
+	rom ( name "Passengers On The Wind (1987) (Infogrames)(Side A).dsk" size 201297 crc 24B0497A md5 14877706C6C7F2213FACDA042DEC6941 sha1 44F1392E45BB35FF25FCBEEA0EA4EBEC1CC85F59 )
 )
 game (
 	name "Professional BMX Simulator (Codemasters Software)"
 	description "Professional BMX Simulator (Codemasters Software)"
-	rom ( name "Professional BMX Simulator (1988)(Codemasters Software)(Side A)[cr].dsk" size 204544 crc 9AAE636E md5 544E00BB4FA061FDAD7C64A3835579F4 sha1 683D9C8F9F42CDD4D1C52EAD5C79676634D34E3C )
 	rom ( name "Professional BMX Simulator (1988)(Codemasters Software)(Side B)[cr].dsk" size 194816 crc 8C511282 md5 4A6CB19924EA77E2E25230E2E6F1F1E0 sha1 FF23865C2F4214B402ABC96D2A210F804848A3C9 )
+	rom ( name "Professional BMX Simulator (1988)(Codemasters Software)(Side A)[cr].dsk" size 204544 crc 9AAE636E md5 544E00BB4FA061FDAD7C64A3835579F4 sha1 683D9C8F9F42CDD4D1C52EAD5C79676634D34E3C )
 )
 game (
 	name "Pipe Mania (Empire)"
@@ -9916,8 +9916,8 @@ game (
 game (
 	name "Pharaon (Loriciels) (France)"
 	description "Pharaon (Loriciels) (France)"
-	rom ( name "Pharaon (1987)(Loriciels)(fr)(Side A).dsk" size 270167 crc A811651D md5 0D02E728B3D5B8B75DC25B522042E9C5 sha1 F8207699E823F3E81B0E9EA1D7ACED2F114943D9 )
 	rom ( name "Pharaon (1987)(Loriciels)(fr)(Side B).dsk" size 269911 crc 99D29F4F md5 4714E58440E58FBE627DD30671D3DB2F sha1 4860FDEA5367618D264653EB64D79C6DD36B156D )
+	rom ( name "Pharaon (1987)(Loriciels)(fr)(Side A).dsk" size 270167 crc A811651D md5 0D02E728B3D5B8B75DC25B522042E9C5 sha1 F8207699E823F3E81B0E9EA1D7ACED2F114943D9 )
 )
 game (
 	name "Pacplant (Potplant Productions)"
@@ -9932,8 +9932,8 @@ game (
 game (
 	name "Plumpy (CPC Infos) (France)"
 	description "Plumpy (CPC Infos) (France)"
-	rom ( name "Plumpy (1990)(CPC Infos)(fr)(Side A)[cr].dsk" size 194816 crc AE4A38AD md5 50B685BCF644199A0474FD4680E4BDA3 sha1 D5F057529D3A30AA60997A8F10D8ECD836EF394B )
 	rom ( name "Plumpy (1990)(CPC Infos)(fr)(Side B)[cr].dsk" size 194816 crc 409193AD md5 BF19880418009C1DEE84DA3211E1D77F sha1 5BAD223A295AB4120968D1D6B0E7BE6017D4D408 )
+	rom ( name "Plumpy (1990)(CPC Infos)(fr)(Side A)[cr].dsk" size 194816 crc AE4A38AD md5 50B685BCF644199A0474FD4680E4BDA3 sha1 D5F057529D3A30AA60997A8F10D8ECD836EF394B )
 )
 game (
 	name "Passing Shot (Image Works)"
@@ -10033,20 +10033,20 @@ game (
 game (
 	name "Pinball Magic (Loriciels) (M2)"
 	description "Pinball Magic (Loriciels) (M2)"
-	rom ( name "Pinball Magic (1990)(Loriciels)(M2)(v2)(Side A).dsk" size 202053 crc 5DCE5C79 md5 0C3F28625ADB5B2FA777FA3452E09D11 sha1 100207C38954D2B830B4756BE1DCE933FC40B226 )
 	rom ( name "Pinball Magic (1990)(Loriciels)(M2)(v2)(Side B).dsk" size 195635 crc F5E8002E md5 944F3234A6D1C8A84DCDCA233E49CDA8 sha1 D2514A0594DE97F190B6114CAD9465888B6D1151 )
+	rom ( name "Pinball Magic (1990)(Loriciels)(M2)(v2)(Side A).dsk" size 202053 crc 5DCE5C79 md5 0C3F28625ADB5B2FA777FA3452E09D11 sha1 100207C38954D2B830B4756BE1DCE933FC40B226 )
 )
 game (
 	name "Passager du Temps, Le (ERE Informatique) (France)"
 	description "Passager du Temps, Le (ERE Informatique) (France)"
-	rom ( name "Passager du Temps, Le (1987)(ERE Informatique)(fr)(Side A).dsk" size 198211 crc FC391FD4 md5 AD9E947114D29AF5201CF76DD2E66586 sha1 D177CB2BEA857037F667C3EC32A847AC4CD80A5B )
 	rom ( name "Passager du Temps, Le (1987)(ERE Informatique)(fr)(Side B).dsk" size 195635 crc B279C7EA md5 DCA5404CBAC93685185658233F19FDD3 sha1 390FFDFE5D21079F12232F43217F6585B425CE7B )
+	rom ( name "Passager du Temps, Le (1987)(ERE Informatique)(fr)(Side A).dsk" size 198211 crc FC391FD4 md5 AD9E947114D29AF5201CF76DD2E66586 sha1 D177CB2BEA857037F667C3EC32A847AC4CD80A5B )
 )
 game (
 	name "Peter Pan (Coktel Vision)"
 	description "Peter Pan (Coktel Vision)"
-	rom ( name "Peter Pan (1988)(Coktel Vision)(Side A)[CPM].dsk" size 201817 crc 10548A7A md5 39260F3DAC3E750603D1B2542FDA7EB3 sha1 FDEC499E76E7EAE65325F99B08B4772D8D915CEA )
 	rom ( name "Peter Pan (1988)(Coktel Vision)(Side B).dsk" size 195635 crc D6D70B73 md5 452B9EF9490B89164E05B097D1A520EB sha1 EF11B50824C904CEBB5BF676699253D601CAE007 )
+	rom ( name "Peter Pan (1988)(Coktel Vision)(Side A)[CPM].dsk" size 201817 crc 10548A7A md5 39260F3DAC3E750603D1B2542FDA7EB3 sha1 FDEC499E76E7EAE65325F99B08B4772D8D915CEA )
 )
 game (
 	name "Poogaboo (Opera Soft) (Spain) (Codes)"
@@ -10056,8 +10056,8 @@ game (
 game (
 	name "Pop-Up (Loriciels) (France)"
 	description "Pop-Up (Loriciels) (France)"
-	rom ( name "Pop-Up (1990)(Loriciels)(fr)(Side A).dsk" size 195637 crc C93EB89B md5 75A3BB40274508D996CC01DC2240CCD1 sha1 B89EC901A9754836ACB31F35AFACC07EC76654B6 )
 	rom ( name "Pop-Up (1990)(Loriciels)(fr)(Side B).dsk" size 199680 crc CB25934F md5 ED7237B46045085EFC8E79282D4D6BA6 sha1 9164417B1AB8E0B4C29AF2FE6EA59EFFF4D0D2E2 )
+	rom ( name "Pop-Up (1990)(Loriciels)(fr)(Side A).dsk" size 195637 crc C93EB89B md5 75A3BB40274508D996CC01DC2240CCD1 sha1 B89EC901A9754836ACB31F35AFACC07EC76654B6 )
 )
 game (
 	name "Postman Pat (Alternative Software)"
@@ -10132,16 +10132,16 @@ game (
 game (
 	name "Qin (ERE Informatique) (France)"
 	description "Qin (ERE Informatique) (France)"
-	rom ( name "Qin (1987)(ERE Informatique)(fr)(Disk 1 Side A).dsk" size 105345 crc F9521465 md5 9D775222C9573F1D2FD85CBA7C0A3A1A sha1 1D7C77BE8F10F58B3CF30542E978F93D5790C724 )
 	rom ( name "Qin (1987)(ERE Informatique)(fr)(Disk 1 Side B).dsk" size 195635 crc DC7255B4 md5 8B1F61551D8AE43DF73C05CF2DBE04C1 sha1 EAE6A05268005F2D181E88EB3EDEFF6C308963A9 )
 	rom ( name "Qin (1987)(ERE Informatique)(fr)(Disk 2 Side A).dsk" size 195635 crc 7CAD58FD md5 222DD6073F5A3510A512C6E0387477AD sha1 6C1A9977C4FC951E28C5E6CAFEE2A4C6D577845B )
 	rom ( name "Qin (1987)(ERE Informatique)(fr)(Disk 2 Side B).dsk" size 195635 crc 39E1A11B md5 8457A5516B896E85EE7F25FE6DDD7544 sha1 E043B93F8AD98A09385553B57945D00A464887C2 )
+	rom ( name "Qin (1987)(ERE Informatique)(fr)(Disk 1 Side A).dsk" size 105345 crc F9521465 md5 9D775222C9573F1D2FD85CBA7C0A3A1A sha1 1D7C77BE8F10F58B3CF30542E978F93D5790C724 )
 )
 game (
 	name "Quiwi (Kingsoft) (de)"
 	description "Quiwi (Kingsoft) (de)"
-	rom ( name "Quiwi (1986)(Kingsoft)(de)(Side A)[BASIC 1.0].dsk" size 195637 crc 93B95448 md5 EE04D240B3D31B612793C39052EE29B3 sha1 F9F27346F1D7D1B00B9A58E637EF8EA7F5DB2560 )
 	rom ( name "Quiwi (1986)(Kingsoft)(de)(Side B)[BASIC 1.0].dsk" size 195637 crc 7196F5C3 md5 0F230CFEFD102A6D665040644EC56F8A sha1 C2B563CF0C1EC56DF2F109D297085D06AF968923 )
+	rom ( name "Quiwi (1986)(Kingsoft)(de)(Side A)[BASIC 1.0].dsk" size 195637 crc 93B95448 md5 EE04D240B3D31B612793C39052EE29B3 sha1 F9F27346F1D7D1B00B9A58E637EF8EA7F5DB2560 )
 )
 game (
 	name "Quaterne (Sprites) (France)"
@@ -10226,8 +10226,8 @@ game (
 game (
 	name "Ripoux, Les (Cobra Soft) (France)"
 	description "Ripoux, Les (Cobra Soft) (France)"
-	rom ( name "Ripoux, Les (1987)(Cobra Soft)(fr)(Side A).dsk" size 200192 crc 229083CC md5 11DB5BD7F96AE19C6A84CC876FC8B9D6 sha1 C5D802D3E6A1D7916FBA56DE18ECA910CAC49521 )
 	rom ( name "Ripoux, Les (1987)(Cobra Soft)(fr)(Side B).dsk" size 195635 crc 3AA1AD57 md5 AB7DB699E2037988D725F1384F742E8B sha1 1A02151C2DECE08830AEFAC8584A8240A2AB5516 )
+	rom ( name "Ripoux, Les (1987)(Cobra Soft)(fr)(Side A).dsk" size 200192 crc 229083CC md5 11DB5BD7F96AE19C6A84CC876FC8B9D6 sha1 C5D802D3E6A1D7916FBA56DE18ECA910CAC49521 )
 )
 game (
 	name "Robocop (Ocean Software)"
@@ -10257,8 +10257,8 @@ game (
 game (
 	name "Reisende im Wind 2 (Infogrames) (de)"
 	description "Reisende im Wind 2 (Infogrames) (de)"
-	rom ( name "Reisende im Wind 2 (1987)(Infogrames)(de)(Side A).dsk" size 201797 crc 72E302B8 md5 D21AF65C32D38C1AD239011DA1B67FF9 sha1 5CC98D02DDD9D56F5AF743FABBB212003BA48780 )
 	rom ( name "Reisende im Wind 2 (1987)(Infogrames)(de)(Side B).dsk" size 202309 crc CCE626DA md5 1F1B5A078565C64DEEC0AAE88E70E68E sha1 355B83A1C85FF0FC4A245195FE1E29326A604C62 )
+	rom ( name "Reisende im Wind 2 (1987)(Infogrames)(de)(Side A).dsk" size 201797 crc 72E302B8 md5 D21AF65C32D38C1AD239011DA1B67FF9 sha1 5CC98D02DDD9D56F5AF743FABBB212003BA48780 )
 )
 game (
 	name "Robot Ron (A-Team) (Spain)"
@@ -10383,8 +10383,8 @@ game (
 game (
 	name "Rody & Mastico (Lankhor) (France)"
 	description "Rody & Mastico (Lankhor) (France)"
-	rom ( name "Rody & Mastico (1988)(Lankhor)(fr)(Side A).dsk" size 201817 crc 29ACC063 md5 A08798F1DBB47FACB2E99CB74C417090 sha1 A9FFD65335A13A70359A97EFF5264B9583592D1A )
 	rom ( name "Rody & Mastico (1988)(Lankhor)(fr)(Side B).dsk" size 194816 crc C114BF28 md5 C007C794F46946790ED6AC99CADC4148 sha1 31B28692D7E2BD4DF1697639292828947F496FD6 )
+	rom ( name "Rody & Mastico (1988)(Lankhor)(fr)(Side A).dsk" size 201817 crc 29ACC063 md5 A08798F1DBB47FACB2E99CB74C417090 sha1 A9FFD65335A13A70359A97EFF5264B9583592D1A )
 )
 game (
 	name "Rollaround (Mastertronic)"
@@ -10409,8 +10409,8 @@ game (
 game (
 	name "Running Man, The (Grandslam)"
 	description "Running Man, The (Grandslam)"
-	rom ( name "Running Man, The (1989)(Grandslam)(Side A).dsk" size 195635 crc D66297B4 md5 AF470419A3358B348F8CE80811413B9D sha1 7B97891BD542FEE912B74B1937158BBA6E7F21A0 )
 	rom ( name "Running Man, The (1989)(Grandslam)(Side B).dsk" size 175075 crc 87F88B92 md5 87309A737B656A38F80D54B5EAC6A851 sha1 8934C254C8EA7EE5688C4FB1538F96D9F0E11649 )
+	rom ( name "Running Man, The (1989)(Grandslam)(Side A).dsk" size 195635 crc D66297B4 md5 AF470419A3358B348F8CE80811413B9D sha1 7B97891BD542FEE912B74B1937158BBA6E7F21A0 )
 )
 game (
 	name "Rogue (Mastertronic)"
@@ -10450,8 +10450,8 @@ game (
 game (
 	name "Rock 'n Roll (Rainbow Arts)"
 	description "Rock 'n Roll (Rainbow Arts)"
-	rom ( name "Rock 'n Roll (1989)(Rainbow Arts)(Side A).dsk" size 151699 crc 3F72C8BF md5 485EE5AFFFF56A4F6A9174353D18787B sha1 2EF7F82539E235DD6B3F39327E919A5F81A137AB )
 	rom ( name "Rock 'n Roll (1989)(Rainbow Arts)(Side B).dsk" size 195637 crc 6ACF4045 md5 1DC2930A6F4C433BBD2B3F77A59C2681 sha1 422E4AFEF2C0009B799348A85136B224A69389CD )
+	rom ( name "Rock 'n Roll (1989)(Rainbow Arts)(Side A).dsk" size 151699 crc 3F72C8BF md5 485EE5AFFFF56A4F6A9174353D18787B sha1 2EF7F82539E235DD6B3F39327E919A5F81A137AB )
 )
 game (
 	name "Renaud - Sidewalk (Infogrames) (Spain) (Hack)"
@@ -10521,8 +10521,8 @@ game (
 game (
 	name "Rastan (Ocean Software)"
 	description "Rastan (Ocean Software)"
-	rom ( name "Rastan (1987)(Ocean Software)(Side A).dsk" size 75008 crc 268FFF6A md5 EF77522536390B0EFA71A3E14AD52054 sha1 2FEA8594392047F348C717921CAB3ED319DD2547 )
 	rom ( name "Rastan (1987)(Ocean Software)(Side B).dsk" size 194816 crc F083DFE6 md5 67C216F8316149F3D70DFBF2D2308653 sha1 70A42E840C568D139595239E7DE07A42B3DF84F0 )
+	rom ( name "Rastan (1987)(Ocean Software)(Side A).dsk" size 75008 crc 268FFF6A md5 EF77522536390B0EFA71A3E14AD52054 sha1 2FEA8594392047F348C717921CAB3ED319DD2547 )
 )
 game (
 	name "Roland in Space (Amsoft) (Spain)"
@@ -10532,8 +10532,8 @@ game (
 game (
 	name "Reisende im Wind (Infogrames) (de)"
 	description "Reisende im Wind (Infogrames) (de)"
-	rom ( name "Reisende im Wind (1986)(Infogrames)(de)(Side A).dsk" size 201041 crc 2238A34F md5 97D39FBF007F857093BA25BAD42806F7 sha1 A9DDB5BD66EDBD189B4E24F0CB962F0F48E9CF27 )
 	rom ( name "Reisende im Wind (1986)(Infogrames)(de)(Side B).dsk" size 202053 crc 8FC2BBE2 md5 9D181CB645283DE0B35F007F8FA42327 sha1 5826591206F1E6856295369C2B51AFEE71CE85C2 )
+	rom ( name "Reisende im Wind (1986)(Infogrames)(de)(Side A).dsk" size 201041 crc 2238A34F md5 97D39FBF007F857093BA25BAD42806F7 sha1 A9DDB5BD66EDBD189B4E24F0CB962F0F48E9CF27 )
 )
 game (
 	name "Ring des Lichts, Der (Frank Senft) (de)"
@@ -10658,8 +10658,8 @@ game (
 game (
 	name "Rod-Land (Storm Software)"
 	description "Rod-Land (Storm Software)"
-	rom ( name "Rod-Land (1991)(Storm Software)(Side A).dsk" size 195635 crc 4A61C20C md5 3371D033BAA1A1D768CCFE7AD2F9465A sha1 A203584E240C4AFF6B12DB03127F5C9207066E15 )
 	rom ( name "Rod-Land (1991)(Storm Software)(Side B).dsk" size 195635 crc C37F2175 md5 456CB4072BDF3AFC9C4636E5E10E4622 sha1 EB92F9DD4F311C4A42AC52849FF73C0927471ACD )
+	rom ( name "Rod-Land (1991)(Storm Software)(Side A).dsk" size 195635 crc 4A61C20C md5 3371D033BAA1A1D768CCFE7AD2F9465A sha1 A203584E240C4AFF6B12DB03127F5C9207066E15 )
 )
 game (
 	name "Robocide (Asclepios Software)"
@@ -10709,8 +10709,8 @@ game (
 game (
 	name "Real Ghostbusters, The (Activision)"
 	description "Real Ghostbusters, The (Activision)"
-	rom ( name "Real Ghostbusters, The (1989)(Activision)(v2)(Side A).dsk" size 220049 crc 42FB20B8 md5 2EA35E432AF885BA0B6D3E02A1935CDE sha1 D5660EF987134897D35893F9EF9002831E306EC4 )
 	rom ( name "Real Ghostbusters, The (1989)(Activision)(v2)(Side B).dsk" size 220049 crc 68E69274 md5 6858EBFAE7CE46D05E2854F9EFA8A233 sha1 E7CEA83C1455CCADA808FC14D818BEDEA3724B90 )
+	rom ( name "Real Ghostbusters, The (1989)(Activision)(v2)(Side A).dsk" size 220049 crc 42FB20B8 md5 2EA35E432AF885BA0B6D3E02A1935CDE sha1 D5660EF987134897D35893F9EF9002831E306EC4 )
 )
 game (
 	name "Rescate en el Golfo (Opera Soft) (M2) (Codes)"
@@ -10765,8 +10765,8 @@ game (
 game (
 	name "Robbbot (ERE Informatique) (Spain)"
 	description "Robbbot (ERE Informatique) (Spain)"
-	rom ( name "Robbbot (1986)(ERE Informatique)(es)(Side A).dsk" size 84480 crc D6A9CD52 md5 485469473A105C31F93E8BF98F27C7F2 sha1 C6044431FE63D7B6A99DD44478ED92B25BA717AC )
 	rom ( name "Robbbot (1986)(ERE Informatique)(es)(Side B).dsk" size 84480 crc 62C50234 md5 CF595F219BEFB5C06FCB212C1F594191 sha1 D5D7DEC6183AC06D6DDAD6C3E48F729719B1828B )
+	rom ( name "Robbbot (1986)(ERE Informatique)(es)(Side A).dsk" size 84480 crc D6A9CD52 md5 485469473A105C31F93E8BF98F27C7F2 sha1 C6044431FE63D7B6A99DD44478ED92B25BA717AC )
 )
 game (
 	name "Run the Gauntlet (Ocean Software)"
@@ -10811,8 +10811,8 @@ game (
 game (
 	name "Robinson Crusoe (Coktel Vision) (France)"
 	description "Robinson Crusoe (Coktel Vision) (France)"
-	rom ( name "Robinson Crusoe (1987)(Coktel Vision)(fr)(Side A).dsk" size 195584 crc C3273263 md5 4ADDF8C8B2B788C1BD3BE01AE31AB2EC sha1 E9005FAAB6350D9A83EEADF574520C83EA961330 )
 	rom ( name "Robinson Crusoe (1987)(Coktel Vision)(fr)(Side B).dsk" size 194816 crc B5BB311E md5 6A4CC6C35CB5C95128C48DDF20969B67 sha1 38EC7349A4228423B142BE3862FE36EF1A147049 )
+	rom ( name "Robinson Crusoe (1987)(Coktel Vision)(fr)(Side A).dsk" size 195584 crc C3273263 md5 4ADDF8C8B2B788C1BD3BE01AE31AB2EC sha1 E9005FAAB6350D9A83EEADF574520C83EA961330 )
 )
 game (
 	name "Rally II (Loriciels) (France)"
@@ -10942,8 +10942,8 @@ game (
 game (
 	name "Summer Games II (Epyx)"
 	description "Summer Games II (Epyx)"
-	rom ( name "Summer Games II (1989)(Epyx)(Side A).dsk" size 195653 crc 41703C02 md5 D877C1BE93491ADAF58A3F94B852EA16 sha1 DC10FA6DE23D7770E1918B0EF590B48246834431 )
 	rom ( name "Summer Games II (1989)(Epyx)(Side B).dsk" size 195653 crc 3ED4F3CC md5 3CC85DD91386ACE8D8FDD26096A0069E sha1 1C8EFA65EB26590A02920A9B348DD7F0273A5725 )
+	rom ( name "Summer Games II (1989)(Epyx)(Side A).dsk" size 195653 crc 41703C02 md5 D877C1BE93491ADAF58A3F94B852EA16 sha1 DC10FA6DE23D7770E1918B0EF590B48246834431 )
 )
 game (
 	name "Stress (Cobra Soft) (France)"
@@ -10968,8 +10968,8 @@ game (
 game (
 	name "Skate or Die (Electronic Arts)"
 	description "Skate or Die (Electronic Arts)"
-	rom ( name "Skate or Die (1989)(Electronic Arts)(Side A).dsk" size 170496 crc 6E1D7AD5 md5 3E0CB6ADBB491ABF35B10C4EB544C786 sha1 C6EA53E7B8C7B3B1A47F3338FC6B0F5D5166CED5 )
 	rom ( name "Skate or Die (1989)(Electronic Arts)(Side B).dsk" size 180224 crc 6D19167A md5 785BF942452C0A471CA5789939E31E15 sha1 764BD51CACDD4D5E9FEC087AE1D349D7944F7DA9 )
+	rom ( name "Skate or Die (1989)(Electronic Arts)(Side A).dsk" size 170496 crc 6E1D7AD5 md5 3E0CB6ADBB491ABF35B10C4EB544C786 sha1 C6EA53E7B8C7B3B1A47F3338FC6B0F5D5166CED5 )
 )
 game (
 	name "Sir Lancelot (Melbourne House)"
@@ -10999,8 +10999,8 @@ game (
 game (
 	name "Secte Noire, La (Lankhor) (France)"
 	description "Secte Noire, La (Lankhor) (France)"
-	rom ( name "Secte Noire, La (1990)(Lankhor)(fr)(Side A).dsk" size 274009 crc 95B94081 md5 25515CE017A885C25A6A4F8F6961BBAB sha1 7E08FC207C73783D4B1CEC90CFE5D5ECD7125C0D )
 	rom ( name "Secte Noire, La (1990)(Lankhor)(fr)(Side B).dsk" size 195635 crc 438616E4 md5 EAD91DAA350F10B20BAE4D808378E73C sha1 D523046B6416F83F9FA564AE177EEA67E2682FE0 )
+	rom ( name "Secte Noire, La (1990)(Lankhor)(fr)(Side A).dsk" size 274009 crc 95B94081 md5 25515CE017A885C25A6A4F8F6961BBAB sha1 7E08FC207C73783D4B1CEC90CFE5D5ECD7125C0D )
 )
 game (
 	name "Split Personalities (Domark)"
@@ -11035,8 +11035,8 @@ game (
 game (
 	name "Simon (Amstrad Action)"
 	description "Simon (Amstrad Action)"
-	rom ( name "Simon (1986)(Amstrad Action)[cr].dsk" size 204544 crc 7ADAD7A0 md5 86AC4A260FDE57BB681E9ABEFB439407 sha1 7FDECE620B3508C1A8D2FEBE27F46EF5139147F6 )
 	rom ( name "Simon (1990)(Amstrad Action)[cr].dsk" size 194816 crc BDFBD2D0 md5 3F75682AF7C8F440A3D6985D0F4BAC84 sha1 585C75745D6357C5FA8A9DA99F92393780F53B1B )
+	rom ( name "Simon (1986)(Amstrad Action)[cr].dsk" size 204544 crc 7ADAD7A0 md5 86AC4A260FDE57BB681E9ABEFB439407 sha1 7FDECE620B3508C1A8D2FEBE27F46EF5139147F6 )
 )
 game (
 	name "Street Fighter (Us Gold)"
@@ -11176,8 +11176,8 @@ game (
 game (
 	name "SRAM (ERE Informatique) (M3)"
 	description "SRAM (ERE Informatique) (M3)"
-	rom ( name "SRAM (1986)(ERE Informatique)(M3)(Side A).dsk" size 233715 crc 3F4B2026 md5 E5B9C59808C0F8C49C86AA396CF1CC28 sha1 284D28E7A15A0D366F6593FC9EF130179A5A3CAE )
 	rom ( name "SRAM (1986)(ERE Informatique)(M3)(Side B).dsk" size 267315 crc BE597FAA md5 FB366ED114FFFA1D9B9D16A835B4B323 sha1 C1B5056A61D4977DBEC6400D5261B0E54B37CDA9 )
+	rom ( name "SRAM (1986)(ERE Informatique)(M3)(Side A).dsk" size 233715 crc 3F4B2026 md5 E5B9C59808C0F8C49C86AA396CF1CC28 sha1 284D28E7A15A0D366F6593FC9EF130179A5A3CAE )
 )
 game (
 	name "Sport (Amstar & Cpc)"
@@ -11227,8 +11227,8 @@ game (
 game (
 	name "Stifflip & Co (Palace Software) (de)"
 	description "Stifflip & Co (Palace Software) (de)"
-	rom ( name "Stifflip & Co (1987)(Palace Software)(de)(Side A).dsk" size 195635 crc 2314F143 md5 C76AF4383EB21810891AB58103E33660 sha1 8F27234A45F9879C9949A6E873453FD27356153E )
 	rom ( name "Stifflip & Co (1987)(Palace Software)(de)(Side B).dsk" size 195635 crc 93C69FCD md5 A792C7E228706A5E63C62B82024382FB sha1 5FEE64226DEA81FA2EB9848CD77DD746B98EBB6A )
+	rom ( name "Stifflip & Co (1987)(Palace Software)(de)(Side A).dsk" size 195635 crc 2314F143 md5 C76AF4383EB21810891AB58103E33660 sha1 8F27234A45F9879C9949A6E873453FD27356153E )
 )
 game (
 	name "Silicon Dreams (Level 9 Computing)"
@@ -11363,8 +11363,8 @@ game (
 game (
 	name "Star Trap (Loriciels) (France)"
 	description "Star Trap (Loriciels) (France)"
-	rom ( name "Star Trap (1989)(Loriciels)(fr)(Side A)[cr].dsk" size 194816 crc 7F758031 md5 E13D479C79805793B95EA0FB50252E00 sha1 58859EF2FF8F450DC6A7023E15F9318F09D71481 )
 	rom ( name "Star Trap (1989)(Loriciels)(fr)(Side B)[cr].dsk" size 194816 crc A32D702C md5 C0DFBB8A9556DCFB6D3642CD9FB48DFF sha1 080BF73F432DF2D974D2BFB809D49DB7C8105F2E )
+	rom ( name "Star Trap (1989)(Loriciels)(fr)(Side A)[cr].dsk" size 194816 crc 7F758031 md5 E13D479C79805793B95EA0FB50252E00 sha1 58859EF2FF8F450DC6A7023E15F9318F09D71481 )
 )
 game (
 	name "Super Skweek (Loriciels) (Bugs)"
@@ -11429,8 +11429,8 @@ game (
 game (
 	name "Samurai Trilogy (Gremlin Graphics Software) (M4)"
 	description "Samurai Trilogy (Gremlin Graphics Software) (M4)"
-	rom ( name "Samurai Trilogy (1987)(Gremlin Graphics Software)(M4)(Side A).dsk" size 176103 crc F773074B md5 15075501BF7E877536B5591AFD17A89E sha1 181B333D2A3D528751EA33A35219F327652BF63E )
 	rom ( name "Samurai Trilogy (1987)(Gremlin Graphics Software)(M4)(Side B).dsk" size 176103 crc 4E6E569E md5 A90086906D5080554DA634E5FE3917EB sha1 CD04E652559DB4FAD42D7DA08A4C29F2768E0694 )
+	rom ( name "Samurai Trilogy (1987)(Gremlin Graphics Software)(M4)(Side A).dsk" size 176103 crc F773074B md5 15075501BF7E877536B5591AFD17A89E sha1 181B333D2A3D528751EA33A35219F327652BF63E )
 )
 game (
 	name "Solo (Opera Soft) (Spain) (LightGun)"
@@ -11440,8 +11440,8 @@ game (
 game (
 	name "Saga (Lankhor) (France)"
 	description "Saga (Lankhor) (France)"
-	rom ( name "Saga (1990)(Lankhor)(fr)(Side A).dsk" size 200589 crc CE5C2785 md5 CBF8FD9E3AFE1A409D0B12DB31E835F1 sha1 DD2D303072CBF9287933E03B823D633430782E06 )
 	rom ( name "Saga (1990)(Lankhor)(fr)(Side B).dsk" size 202077 crc BA4C03DC md5 6D1FFAECCB51EA4D202AEFE1CDC2077B sha1 46BEB19615C5AE374A428099C460A97364CFCE98 )
+	rom ( name "Saga (1990)(Lankhor)(fr)(Side A).dsk" size 200589 crc CE5C2785 md5 CBF8FD9E3AFE1A409D0B12DB31E835F1 sha1 DD2D303072CBF9287933E03B823D633430782E06 )
 )
 game (
 	name "Space Shuttle Simulateur (Loriciels) (France)"
@@ -11456,8 +11456,8 @@ game (
 game (
 	name "Sdaw (Lankhor) (France)"
 	description "Sdaw (Lankhor) (France)"
-	rom ( name "Sdaw (1990)(Lankhor)(fr)(Side A).dsk" size 273753 crc C58820BF md5 51E25F9DD0ED090DBAED0A50552B01B9 sha1 6B86B9197764D23E0A8D368444D7E0D3C72A9B49 )
 	rom ( name "Sdaw (1990)(Lankhor)(fr)(Side B).dsk" size 195635 crc 498BC11A md5 C3B206DA28B85CA3BAF6F0CCD9881980 sha1 7934C6FAED61046D60CB887A2F1B6D78A15EAC48 )
+	rom ( name "Sdaw (1990)(Lankhor)(fr)(Side A).dsk" size 273753 crc C58820BF md5 51E25F9DD0ED090DBAED0A50552B01B9 sha1 6B86B9197764D23E0A8D368444D7E0D3C72A9B49 )
 )
 game (
 	name "Star-Bores (Neutrino Software)"
@@ -11507,8 +11507,8 @@ game (
 game (
 	name "Skaal (Softhawk) (France)"
 	description "Skaal (Softhawk) (France)"
-	rom ( name "Skaal (1987)(Softhawk)(fr)(Side A).dsk" size 196915 crc 4EC6FCF8 md5 1A462537878A3F01EDCBD884D5FA5D09 sha1 32BC00E3D8894A4A2DE4B39BDB7E2DAC4A708B9B )
 	rom ( name "Skaal (1987)(Softhawk)(fr)(Side B).dsk" size 196915 crc 13245BA1 md5 01C6D8CD260B87C125259316CA138295 sha1 08917278F07641BCB6C8715B9046601EBC62A860 )
+	rom ( name "Skaal (1987)(Softhawk)(fr)(Side A).dsk" size 196915 crc 4EC6FCF8 md5 1A462537878A3F01EDCBD884D5FA5D09 sha1 32BC00E3D8894A4A2DE4B39BDB7E2DAC4A708B9B )
 )
 game (
 	name "Stockmarket (Amsoft)"
@@ -11548,8 +11548,8 @@ game (
 game (
 	name "Super Wonderboy in Monster Land (Activision)"
 	description "Super Wonderboy in Monster Land (Activision)"
-	rom ( name "Super Wonderboy in Monster Land (1989)(Activision)(Side A).dsk" size 213395 crc 9364824B md5 1EDFB2792B3787CA7B41B08BCAED2D2A sha1 3E6A530E9F481AF365E08470E6463DDFCD4837C3 )
 	rom ( name "Super Wonderboy in Monster Land (1989)(Activision)(Side B).dsk" size 195635 crc C3D05794 md5 6856E5BDCB4C22427B68D59368730ED9 sha1 EB66C0ADC16B13FAC26D287705BDA8DB8EA32AB0 )
+	rom ( name "Super Wonderboy in Monster Land (1989)(Activision)(Side A).dsk" size 213395 crc 9364824B md5 1EDFB2792B3787CA7B41B08BCAED2D2A sha1 3E6A530E9F481AF365E08470E6463DDFCD4837C3 )
 )
 game (
 	name "Shanghai (-)"
@@ -11589,8 +11589,8 @@ game (
 game (
 	name "Spherical (Rainbow Arts)"
 	description "Spherical (Rainbow Arts)"
-	rom ( name "Spherical (1989)(Rainbow Arts)(Side A).dsk" size 194816 crc BA1E0DE md5 3455347EDD8F19FFBE8EFD84B08CFE3A sha1 A043651F9389436FBA2387D3E6F5D1122FA2F96D )
 	rom ( name "Spherical (1989)(Rainbow Arts)(Side B).dsk" size 194816 crc 196F47F0 md5 FEB3C0DBC04AA8EE3055682017AEA4BD sha1 5A4FDA0695372500E334AA8E1281BE64AF189C50 )
+	rom ( name "Spherical (1989)(Rainbow Arts)(Side A).dsk" size 194816 crc BA1E0DE md5 3455347EDD8F19FFBE8EFD84B08CFE3A sha1 A043651F9389436FBA2387D3E6F5D1122FA2F96D )
 )
 game (
 	name "Sai Combat (Mirrorsoft)"
@@ -11670,14 +11670,14 @@ game (
 game (
 	name "Space Harrier II (Grandslam)"
 	description "Space Harrier II (Grandslam)"
-	rom ( name "Space Harrier II (1990)(Grandslam)(Side A).dsk" size 175589 crc C8282B md5 B43FED35FE51961C95FD5F664954140A sha1 E6294EF232AD2C440FE705598902F17C7E972AF8 )
 	rom ( name "Space Harrier II (1990)(Grandslam)(Side B).dsk" size 195635 crc 2DF2D8C6 md5 E8BB9280843544758A26DE3E4ADC0EC4 sha1 53C78DA2EACFDDE44E52A69479CFF855309CFAE0 )
+	rom ( name "Space Harrier II (1990)(Grandslam)(Side A).dsk" size 175589 crc C8282B md5 B43FED35FE51961C95FD5F664954140A sha1 E6294EF232AD2C440FE705598902F17C7E972AF8 )
 )
 game (
 	name "Stifflip & Co (Palace Software) (France)"
 	description "Stifflip & Co (Palace Software) (France)"
-	rom ( name "Stifflip & Co (1987)(Palace Software)(fr)(Side A).dsk" size 195635 crc CE0180D5 md5 AB6F73A0D4CE59C629D6B7BD2D514B65 sha1 717FAC417D56A37E8C44AF2D65221A13A238A219 )
 	rom ( name "Stifflip & Co (1987)(Palace Software)(fr)(Side B).dsk" size 195635 crc C578D019 md5 3D138A825A3529BC5F77965115F06099 sha1 C7EF3435CF7E94DE3A692E619107F56485ECAE2D )
+	rom ( name "Stifflip & Co (1987)(Palace Software)(fr)(Side A).dsk" size 195635 crc CE0180D5 md5 AB6F73A0D4CE59C629D6B7BD2D514B65 sha1 717FAC417D56A37E8C44AF2D65221A13A238A219 )
 )
 game (
 	name "Simplex 3D (Micro Mag) (France)"
@@ -11697,8 +11697,8 @@ game (
 game (
 	name "Scoop Junior (Generation 5) (France)"
 	description "Scoop Junior (Generation 5) (France)"
-	rom ( name "Scoop Junior (1990)(Generation 5)(fr)(Side A).dsk" size 279641 crc 39D956C4 md5 B0AFD738476418716576F1DBFA21B154 sha1 119B819B24F171C1B466E2F8C3A5C335D1BDB807 )
 	rom ( name "Scoop Junior (1990)(Generation 5)(fr)(Side B).dsk" size 195635 crc BB974B81 md5 CF2C28B0AA88C1AAC558F91A97423234 sha1 BEF764E9B3608A89201A3968A096A556FF2FE4DF )
+	rom ( name "Scoop Junior (1990)(Generation 5)(fr)(Side A).dsk" size 279641 crc 39D956C4 md5 B0AFD738476418716576F1DBFA21B154 sha1 119B819B24F171C1B466E2F8C3A5C335D1BDB807 )
 )
 game (
 	name "Super Pac (PC Schneider International)"
@@ -11713,8 +11713,8 @@ game (
 game (
 	name "Septieme Continent, Le (L. Dplanque) (France)"
 	description "Septieme Continent, Le (L. Dplanque) (France)"
-	rom ( name "Septieme Continent, Le (1987)(L. Dplanque)(fr)(Side A).dsk" size 199680 crc 6E83FA1F md5 51656B9C9AA405F7A8C3D782FFE271AB sha1 7B9F1FA10BCF637EF1EB0B366CD840AED87865A2 )
 	rom ( name "Septieme Continent, Le (1987)(L. Dplanque)(fr)(Side B).dsk" size 194816 crc 9FC324F7 md5 E88D8BC2BC6D96C84B5FD28CF9EFEDEF sha1 ECD0723488BCDAA61FF890C1975CF181EF4A6965 )
+	rom ( name "Septieme Continent, Le (1987)(L. Dplanque)(fr)(Side A).dsk" size 199680 crc 6E83FA1F md5 51656B9C9AA405F7A8C3D782FFE271AB sha1 7B9F1FA10BCF637EF1EB0B366CD840AED87865A2 )
 )
 game (
 	name "Smiley Affair, The (M. Dowse)"
@@ -11739,8 +11739,8 @@ game (
 game (
 	name "Skate Crazy (Gremlin Graphics Software)"
 	description "Skate Crazy (Gremlin Graphics Software)"
-	rom ( name "Skate Crazy (1988)(Gremlin Graphics Software)(Side A).dsk" size 176103 crc EF7871DC md5 75CB7812DDA76771286D24767A172862 sha1 F5F94D8BE8FE13C0C72771CE0BF4CB043A3F0BFA )
 	rom ( name "Skate Crazy (1988)(Gremlin Graphics Software)(Side B).dsk" size 176103 crc 5AC9F3F4 md5 539BB3457F333396E9849A8EF9848633 sha1 41F1CBD78E69BD59AA6372CAC48FEBFC5AE15786 )
+	rom ( name "Skate Crazy (1988)(Gremlin Graphics Software)(Side A).dsk" size 176103 crc EF7871DC md5 75CB7812DDA76771286D24767A172862 sha1 F5F94D8BE8FE13C0C72771CE0BF4CB043A3F0BFA )
 )
 game (
 	name "Sigma 7 (Durell Software)"
@@ -11775,8 +11775,8 @@ game (
 game (
 	name "SRAM 2 (ERE Informatique) (France)"
 	description "SRAM 2 (ERE Informatique) (France)"
-	rom ( name "SRAM 2 (1986)(ERE Informatique)(fr)(Side A).dsk" size 100947 crc D611E454 md5 68256FE3DFD667248E7509B3FACC2EA4 sha1 F0FC13FB6139A313C5D725265AF35DAE56295F85 )
 	rom ( name "SRAM 2 (1986)(ERE Informatique)(fr)(Side B).dsk" size 195635 crc 2BFD2901 md5 279809A68D29F499BC8ABE111573369B sha1 054B61096A07C4B1D5515949BF46F365A4CC4A71 )
+	rom ( name "SRAM 2 (1986)(ERE Informatique)(fr)(Side A).dsk" size 100947 crc D611E454 md5 68256FE3DFD667248E7509B3FACC2EA4 sha1 F0FC13FB6139A313C5D725265AF35DAE56295F85 )
 )
 game (
 	name "Serpentino (AM-Mag) (France)"
@@ -11836,8 +11836,8 @@ game (
 game (
 	name "Scott Winder Reporter (ERE Informatique) (France)"
 	description "Scott Winder Reporter (ERE Informatique) (France)"
-	rom ( name "Scott Winder Reporter (1987)(ERE Informatique)(fr)(Side A).dsk" size 198211 crc B2C6C7CD md5 7357EC63F12BC773A601756CCEDA4BF1 sha1 4BECF20557C10423EEE010323393062CD006BFFF )
 	rom ( name "Scott Winder Reporter (1987)(ERE Informatique)(fr)(Side B).dsk" size 195635 crc 4CBE0619 md5 496D0DD69F996D9DCE9758BE150212E0 sha1 536E02976177A782D230269AE8A9316BE320FAE0 )
+	rom ( name "Scott Winder Reporter (1987)(ERE Informatique)(fr)(Side A).dsk" size 198211 crc B2C6C7CD md5 7357EC63F12BC773A601756CCEDA4BF1 sha1 4BECF20557C10423EEE010323393062CD006BFFF )
 )
 game (
 	name "Snowstrike (US Gold)"
@@ -11902,14 +11902,14 @@ game (
 game (
 	name "Skyx (Legend Software) (France)"
 	description "Skyx (Legend Software) (France)"
-	rom ( name "Skyx (1988)(Legend Software)(fr)(Side A).dsk" size 227327 crc 1733C833 md5 6C33934FB23303601CFE2E5B56FF1543 sha1 19D04BB6380C25DAEABF49A05B049B98D1063C31 )
 	rom ( name "Skyx (1988)(Legend Software)(fr)(Side B).dsk" size 226567 crc C1E745E8 md5 EFC5E0A5D1BC88FA132CAA7AD3CFCAD9 sha1 44552658DFC78D90CCF148AF2A92C4542901B859 )
+	rom ( name "Skyx (1988)(Legend Software)(fr)(Side A).dsk" size 227327 crc 1733C833 md5 6C33934FB23303601CFE2E5B56FF1543 sha1 19D04BB6380C25DAEABF49A05B049B98D1063C31 )
 )
 game (
 	name "Shadows Of Sergoth, The (PD) (M3)"
 	description "Shadows Of Sergoth, The (PD) (M3)"
-	rom ( name "Shadows Of Sergoth, The (2018)(PD)(M3)(v1.0)(Side A).dsk" size 194816 crc 6D63F48A md5 4D6C8E980A3B1A1343BA9353396ADA5E sha1 00729F5506B22BC524F1F316C8DE8EF244485693 )
 	rom ( name "Shadows Of Sergoth, The (2018)(PD)(M3)(v1.0)(Side B).dsk" size 194816 crc FDF9EBC0 md5 34C9E886D4E2E43860E36D61008DBB7E sha1 7426EFE9DCFE03F0645709817DA2F82737BE5300 )
+	rom ( name "Shadows Of Sergoth, The (2018)(PD)(M3)(v1.0)(Side A).dsk" size 194816 crc 6D63F48A md5 4D6C8E980A3B1A1343BA9353396ADA5E sha1 00729F5506B22BC524F1F316C8DE8EF244485693 )
 )
 game (
 	name "Santa's Christmas Capers (Zeppelin Games)"
@@ -11924,8 +11924,8 @@ game (
 game (
 	name "Summer Games (Epyx)"
 	description "Summer Games (Epyx)"
-	rom ( name "Summer Games (1988)(Epyx)(Side A).dsk" size 192569 crc 192A42FA md5 E13681DED1F003C0ABC6A53E679AA192 sha1 B233D9F7EB88AEEC7646072D6E35D1C7018FE299 )
 	rom ( name "Summer Games (1988)(Epyx)(Side B).dsk" size 177131 crc 63E0E255 md5 BA9B173450D4BA766308ACC35649D8B9 sha1 CD0C96C6FB1CF532A9F862EE509DBA7549CC0C21 )
+	rom ( name "Summer Games (1988)(Epyx)(Side A).dsk" size 192569 crc 192A42FA md5 E13681DED1F003C0ABC6A53E679AA192 sha1 B233D9F7EB88AEEC7646072D6E35D1C7018FE299 )
 )
 game (
 	name "Snoopy and Peanuts (The Edge)"
@@ -12090,8 +12090,8 @@ game (
 game (
 	name "Savage (Firebird)"
 	description "Savage (Firebird)"
-	rom ( name "Savage (1988)(Firebird)(Side A).dsk" size 137051 crc CA6FFD7A md5 35C4B4BEBC2CAF8BA95EB89D85A75FC5 sha1 8B7CC4648C698FDAE173D80D8AEEE9CBCF23BD7A )
 	rom ( name "Savage (1988)(Firebird)(Side B).dsk" size 146815 crc 9300CEFC md5 8F50A2C49DB5A60ECA2283D86240381F sha1 D985765BA7E617BC9C46F31C01AB3E157012740C )
+	rom ( name "Savage (1988)(Firebird)(Side A).dsk" size 137051 crc CA6FFD7A md5 35C4B4BEBC2CAF8BA95EB89D85A75FC5 sha1 8B7CC4648C698FDAE173D80D8AEEE9CBCF23BD7A )
 )
 game (
 	name "Spirits (Topo Soft) (Spain)"
@@ -12101,8 +12101,8 @@ game (
 game (
 	name "Scoop Senior (Generation 5) (France)"
 	description "Scoop Senior (Generation 5) (France)"
-	rom ( name "Scoop Senior (1990)(Generation 5)(fr)(Side A).dsk" size 200060 crc 25723968 md5 885CEEF09D6379ACFAF5AA72FD7B94EC sha1 6C9E64BF2DC395B46A1D0A87518110CFCDFAFEFA )
 	rom ( name "Scoop Senior (1990)(Generation 5)(fr)(Side B).dsk" size 195635 crc 91F263DE md5 A30E1EA67B559A5ABD617494B98CAF98 sha1 6AA8A4F5B4480BC48B951CD4EA512860CF7B3879 )
+	rom ( name "Scoop Senior (1990)(Generation 5)(fr)(Side A).dsk" size 200060 crc 25723968 md5 885CEEF09D6379ACFAF5AA72FD7B94EC sha1 6C9E64BF2DC395B46A1D0A87518110CFCDFAFEFA )
 )
 game (
 	name "Shufflepuck Cafe (Broderbund Software) (France)"
@@ -12192,8 +12192,8 @@ game (
 game (
 	name "Sly Spy - Secret Agent (Ocean Software)"
 	description "Sly Spy - Secret Agent (Ocean Software)"
-	rom ( name "Sly Spy - Secret Agent (1990)(Ocean Software)(Side A).dsk" size 194816 crc 62641A3B md5 C54BE43BAF127F33749764F0B76825D5 sha1 C59656B6A7E4A358DFE91DB982BFD530D3AD3948 )
 	rom ( name "Sly Spy - Secret Agent (1990)(Ocean Software)(Side B).dsk" size 194816 crc D0937642 md5 0377C9F83DA678EAF83EF5AEBD1EFFCA sha1 E03C63CC3F3391DF0FD5287F9AF194547F7357C8 )
+	rom ( name "Sly Spy - Secret Agent (1990)(Ocean Software)(Side A).dsk" size 194816 crc 62641A3B md5 C54BE43BAF127F33749764F0B76825D5 sha1 C59656B6A7E4A358DFE91DB982BFD530D3AD3948 )
 )
 game (
 	name "Strike Force S.A.S. (Mikrogen)"
@@ -12343,8 +12343,8 @@ game (
 game (
 	name "Super Sports - The Olympic Challenge (Gremlin Graphics Software)"
 	description "Super Sports - The Olympic Challenge (Gremlin Graphics Software)"
-	rom ( name "Super Sports - The Olympic Challenge (1988)(Gremlin Graphics Software)(Side A).dsk" size 174848 crc 1257F77 md5 D64B64996DDD399373DBB14AE9BDEFD1 sha1 24B36E1464F5F98CFCBC730356E9E197FAE38E1C )
 	rom ( name "Super Sports - The Olympic Challenge (1988)(Gremlin Graphics Software)(Side B).dsk" size 174848 crc 1BFC098E md5 9C5EC606C542ABC5E22F3FC9818D6B6D sha1 AEC421580FC6AE7766322123DEB6A25C1826973B )
+	rom ( name "Super Sports - The Olympic Challenge (1988)(Gremlin Graphics Software)(Side A).dsk" size 174848 crc 1257F77 md5 D64B64996DDD399373DBB14AE9BDEFD1 sha1 24B36E1464F5F98CFCBC730356E9E197FAE38E1C )
 )
 game (
 	name "Samurai (Amstar & Cpc)"
@@ -12374,8 +12374,8 @@ game (
 game (
 	name "Superman - The Man of Steel (Tynesoft)"
 	description "Superman - The Man of Steel (Tynesoft)"
-	rom ( name "Superman - The Man of Steel (1989)(Tynesoft)(Side A).dsk" size 194816 crc F0A67F40 md5 0762792DF725931F70E9B6C45B8BF1F3 sha1 B160BA439581424D356B3EE2D966A738B2DBFA9F )
 	rom ( name "Superman - The Man of Steel (1989)(Tynesoft)(Side B).dsk" size 194816 crc 6AE1BD8B md5 D33B9E6B2FF0D7DF0A5DB1F4FB80B64A sha1 9700432E1A56DCF8738D3CB42C4840764441DA3A )
+	rom ( name "Superman - The Man of Steel (1989)(Tynesoft)(Side A).dsk" size 194816 crc F0A67F40 md5 0762792DF725931F70E9B6C45B8BF1F3 sha1 B160BA439581424D356B3EE2D966A738B2DBFA9F )
 )
 game (
 	name "Swap (Microids) (M2)"
@@ -12395,10 +12395,10 @@ game (
 game (
 	name "Sandman, The (TGS) (de)"
 	description "Sandman, The (TGS) (de)"
-	rom ( name "Sandman, The (1995)(TGS)(PD)(de)(Disk 1 Side A).dsk" size 194816 crc E2B5B1F5 md5 0D570668CB28C47699D8F4A1639DEED3 sha1 0573EABBFA203A14E30D5CC5304A5D593AAE9566 )
 	rom ( name "Sandman, The (1995)(TGS)(PD)(de)(Disk 1 Side B).dsk" size 194816 crc 510B781B md5 84D183A580E4EDC7E2BE272ABAB22B8F sha1 63CA5B3AC4CE2DF48121D7E6160C455A439EC32C )
 	rom ( name "Sandman, The (1995)(TGS)(PD)(de)(Disk 2 Side A).dsk" size 194816 crc 3964FE9 md5 37BA2F7A8BA976C07A970BD9B48BD5DD sha1 B4389C2BE5D8258217C0AA2718C6914C5F0CF70C )
 	rom ( name "Sandman, The (1995)(TGS)(PD)(de)(Disk 2 Side B).dsk" size 194816 crc AB09170E md5 2693E86AEE89FF4C77EC494221CF256F sha1 01E3E83BE7C00FF817C3C519BC322CD2215A78D3 )
+	rom ( name "Sandman, The (1995)(TGS)(PD)(de)(Disk 1 Side A).dsk" size 194816 crc E2B5B1F5 md5 0D570668CB28C47699D8F4A1639DEED3 sha1 0573EABBFA203A14E30D5CC5304A5D593AAE9566 )
 )
 game (
 	name "Space Pod Rescue (Cascade Games)"
@@ -12418,8 +12418,8 @@ game (
 game (
 	name "Stir Crazy Featuring Bobo (Infogrames)"
 	description "Stir Crazy Featuring Bobo (Infogrames)"
-	rom ( name "Stir Crazy Featuring Bobo (1988)(Infogrames)(Side A).dsk" size 202563 crc 3D6720C md5 B24E7A2640E25F700383E30E1CDAA89C sha1 0314EF3FFF7EA7FD04EB90F8AF6A4C0358CD21F7 )
 	rom ( name "Stir Crazy Featuring Bobo (1988)(Infogrames)(Side B).dsk" size 202563 crc 7B81D352 md5 E496F0DE2B315B3A31E6C91820C5696F sha1 2792A6D399E66BDEABF5D0DFE0D720EACBBDC113 )
+	rom ( name "Stir Crazy Featuring Bobo (1988)(Infogrames)(Side A).dsk" size 202563 crc 3D6720C md5 B24E7A2640E25F700383E30E1CDAA89C sha1 0314EF3FFF7EA7FD04EB90F8AF6A4C0358CD21F7 )
 )
 game (
 	name "Starquake (Bubble Bus Software)"
@@ -12459,8 +12459,8 @@ game (
 game (
 	name "Super Space Invaders (Domark)"
 	description "Super Space Invaders (Domark)"
-	rom ( name "Super Space Invaders (1991)(Domark)(Side A).dsk" size 195635 crc F3163FF3 md5 0160E48FBC34DE6A8CD4FE6E26A694AD sha1 ED8BEA376600ABDD898FC01452FD5EEEA9010F76 )
 	rom ( name "Super Space Invaders (1991)(Domark)(Side B).dsk" size 195635 crc CFC0A807 md5 3016BE1645B75459B2B354DE4A1477B2 sha1 18ACDFFF717788642EBE67D90BFAB8462E9DA1ED )
+	rom ( name "Super Space Invaders (1991)(Domark)(Side A).dsk" size 195635 crc F3163FF3 md5 0160E48FBC34DE6A8CD4FE6E26A694AD sha1 ED8BEA376600ABDD898FC01452FD5EEEA9010F76 )
 )
 game (
 	name "Star-Wreck (Alternative Software)"
@@ -12510,10 +12510,10 @@ game (
 game (
 	name "Sandman, The (TGS)"
 	description "Sandman, The (TGS)"
-	rom ( name "Sandman, The (1995)(TGS)(PD)(Disk 1 Side A).dsk" size 194816 crc B49383C1 md5 74F4612336F0C5B07F3C5AF8E00F342A sha1 2654B7E10FA810DC496BEDA977F6B682216FA16A )
 	rom ( name "Sandman, The (1995)(TGS)(PD)(Disk 1 Side B).dsk" size 194816 crc 8189874C md5 A4436C8D5564D2C15F77210A027A85BE sha1 638C393339D13E2B6EA5B9299402E1F40A6CF292 )
 	rom ( name "Sandman, The (1995)(TGS)(PD)(Disk 2 Side A).dsk" size 194816 crc 2545F08E md5 174A7AA5CD3508AD8E96AB72956161C8 sha1 CE6FEA7E187F2E1B495FF9A8E8D7456A8969C513 )
 	rom ( name "Sandman, The (1995)(TGS)(PD)(Disk 2 Side B).dsk" size 194816 crc 167D042D md5 8C5D4D7921ED61061371CB1C1F3537DB sha1 EF7860D97CD82B9B0FBA80D57FC169201ED2A288 )
+	rom ( name "Sandman, The (1995)(TGS)(PD)(Disk 1 Side A).dsk" size 194816 crc B49383C1 md5 74F4612336F0C5B07F3C5AF8E00F342A sha1 2654B7E10FA810DC496BEDA977F6B682216FA16A )
 )
 game (
 	name "Strider II (US Gold)"
@@ -12533,14 +12533,14 @@ game (
 game (
 	name "Silva (Lankhor) (France)"
 	description "Silva (Lankhor) (France)"
-	rom ( name "Silva (1985)(Lankhor)(fr)(Side A).dsk" size 274009 crc 6307EB75 md5 1B0EB67E716818C4DC3B3C4B1A75AA07 sha1 D9EACECD1B04B507A2FF86B7E7717A95CF5FDE70 )
 	rom ( name "Silva (1985)(Lankhor)(fr)(Side B).dsk" size 195635 crc 5D275E95 md5 B75B4C81CE25C4A06E8F6575DF5BE59E sha1 262595EA7044FF62E9ECFFB4C43F868D3A37BDBC )
+	rom ( name "Silva (1985)(Lankhor)(fr)(Side A).dsk" size 274009 crc 6307EB75 md5 1B0EB67E716818C4DC3B3C4B1A75AA07 sha1 D9EACECD1B04B507A2FF86B7E7717A95CF5FDE70 )
 )
 game (
 	name "Steve Mc Queen Westphaser (Loriciels) (Phaser)"
 	description "Steve Mc Queen Westphaser (Loriciels) (Phaser)"
-	rom ( name "Steve Mc Queen Westphaser (1992)(Loriciels)(West Phaser)(Side A).dsk" size 202053 crc 133E8046 md5 86ADDAC8C7B3DDA3697B9AF67CBC09C3 sha1 52AF29D7D94A5560FE38C46DB2A88400CF980DA3 )
 	rom ( name "Steve Mc Queen Westphaser (1992)(Loriciels)(West Phaser)(Side B).dsk" size 195635 crc 75CF0CC7 md5 B404BD73CD2CAE8F5BB00797927C26E0 sha1 9FDC50AF61155C81D945601FEA68F418F456E749 )
+	rom ( name "Steve Mc Queen Westphaser (1992)(Loriciels)(West Phaser)(Side A).dsk" size 202053 crc 133E8046 md5 86ADDAC8C7B3DDA3697B9AF67CBC09C3 sha1 52AF29D7D94A5560FE38C46DB2A88400CF980DA3 )
 )
 game (
 	name "Street Hawk (Ocean Software)"
@@ -12560,8 +12560,8 @@ game (
 game (
 	name "Superpix (Crack'n'Rom)"
 	description "Superpix (Crack'n'Rom)"
-	rom ( name "Superpix (2014)(Crack'n'Rom)(Side A)[f].dsk" size 185856 crc 802695E9 md5 DF30AC218D719D6940440546B54A06BD sha1 E9C2855E732B3A90E90364460FD652DD3E7BC88B )
 	rom ( name "Superpix (2014)(Crack'n'Rom)(Side B)[f].dsk" size 198400 crc 16BBC3DA md5 55448FDF7A7C6F9FCDAA0168A195E8F8 sha1 40F5CE99CD6E0BCBF7EC3355BF36A270903B90EA )
+	rom ( name "Superpix (2014)(Crack'n'Rom)(Side A)[f].dsk" size 185856 crc 802695E9 md5 DF30AC218D719D6940440546B54A06BD sha1 E9C2855E732B3A90E90364460FD652DD3E7BC88B )
 )
 game (
 	name "Satan (Dinamic Software) (Spain)"
@@ -12641,8 +12641,8 @@ game (
 game (
 	name "Shadow of the Beast (Gremlin Graphics Software)"
 	description "Shadow of the Beast (Gremlin Graphics Software)"
-	rom ( name "Shadow of the Beast (1990)(Gremlin Graphics Software)(Side A).dsk" size 174848 crc FFF6B37B md5 C66E0612BA0B5C6846D21508B6F1CB69 sha1 4F6CF3DC952A5E8CC3385DD54EC73E79851152B8 )
 	rom ( name "Shadow of the Beast (1990)(Gremlin Graphics Software)(Side B).dsk" size 174848 crc 6AF22741 md5 24F7193625E4345246189D0F6D9D892C sha1 6EEF5BE3F5A20ACB736A91946687EA6FA96CDC47 )
+	rom ( name "Shadow of the Beast (1990)(Gremlin Graphics Software)(Side A).dsk" size 174848 crc FFF6B37B md5 C66E0612BA0B5C6846D21508B6F1CB69 sha1 4F6CF3DC952A5E8CC3385DD54EC73E79851152B8 )
 )
 game (
 	name "Spellbound (Mastertronic)"
@@ -12692,8 +12692,8 @@ game (
 game (
 	name "Survivre (Lankhor) (France)"
 	description "Survivre (Lankhor) (France)"
-	rom ( name "Survivre (1991)(Lankhor)(fr)(Side A).dsk" size 195635 crc 2CC66470 md5 365E07C60E46940301DA8C340BC0EFEF sha1 994E58D4DB9EBE892B861A27A4D4DDE95D346091 )
 	rom ( name "Survivre (1991)(Lankhor)(fr)(Side B).dsk" size 195635 crc CE70D508 md5 763FB3F6D05A9314AC0299D6159A2D7B sha1 E057E0C2489B6E020F186EF1053C2F9E26DC8CC1 )
+	rom ( name "Survivre (1991)(Lankhor)(fr)(Side A).dsk" size 195635 crc 2CC66470 md5 365E07C60E46940301DA8C340BC0EFEF sha1 994E58D4DB9EBE892B861A27A4D4DDE95D346091 )
 )
 game (
 	name "Solomon's Key (US Gold)"
@@ -12713,8 +12713,8 @@ game (
 game (
 	name "Scapeghost (Level 9 Computing)"
 	description "Scapeghost (Level 9 Computing)"
-	rom ( name "Scapeghost (1989)(Level 9 Computing)(Side A).dsk" size 194816 crc DDC50888 md5 EDC1D9182CE8CE4D120E39F29A1F9393 sha1 D296646A7B7A271911C6271F65A338DE9ADECD2E )
 	rom ( name "Scapeghost (1989)(Level 9 Computing)(Side B).dsk" size 194816 crc 4B155B5 md5 605C85EC131E2A215335D9A0E89C35E2 sha1 65C6E58D78AEE5315A643E9041584E3479F6A5B0 )
+	rom ( name "Scapeghost (1989)(Level 9 Computing)(Side A).dsk" size 194816 crc DDC50888 md5 EDC1D9182CE8CE4D120E39F29A1F9393 sha1 D296646A7B7A271911C6271F65A338DE9ADECD2E )
 )
 game (
 	name "Stairway to Hell (Software invasion)"
@@ -12724,8 +12724,8 @@ game (
 game (
 	name "Sphaira (Ubi Soft) (France)"
 	description "Sphaira (Ubi Soft) (France)"
-	rom ( name "Sphaira (1989)(Ubi Soft)(fr)(Side A).dsk" size 282287 crc A266C7D9 md5 7D18FA814BE74B1CEF4B4CB9E2413749 sha1 5D5B043A7FD5104F8DC63D533646FAD845401D58 )
 	rom ( name "Sphaira (1989)(Ubi Soft)(fr)(Side B).dsk" size 205913 crc 3A697A24 md5 BB94F8FBCB3B0DCD8B40BE52BA8A8A03 sha1 9C31FD0AB61C92FDD6D26B6F77B8C6B686DEE3EB )
+	rom ( name "Sphaira (1989)(Ubi Soft)(fr)(Side A).dsk" size 282287 crc A266C7D9 md5 7D18FA814BE74B1CEF4B4CB9E2413749 sha1 5D5B043A7FD5104F8DC63D533646FAD845401D58 )
 )
 game (
 	name "Space Moves (Retrobytes Productions)"
@@ -12740,8 +12740,8 @@ game (
 game (
 	name "Sim City (Infogrames)"
 	description "Sim City (Infogrames)"
-	rom ( name "Sim City (1989)(Infogrames)(Side A).dsk" size 87808 crc 1C2787F3 md5 7496E4EFC8207B10EB81F1CA7A015874 sha1 B46676BCCFA1A4F6B88094DCBBAECB634CD18057 )
 	rom ( name "Sim City (1989)(Infogrames)(Side B)[Cities].dsk" size 194816 crc B11F44C md5 0630FF75D86A51FB29F8B09A7A11F4E8 sha1 66A7CA1C84913E97840164E22D849AE652DD2874 )
+	rom ( name "Sim City (1989)(Infogrames)(Side A).dsk" size 87808 crc 1C2787F3 md5 7496E4EFC8207B10EB81F1CA7A015874 sha1 B46676BCCFA1A4F6B88094DCBBAECB634CD18057 )
 )
 game (
 	name "Space Mania (Amstrad Computer User)"
@@ -12836,8 +12836,8 @@ game (
 game (
 	name "Simpsons - Bart vs the Space Mutants (Ocean Software)"
 	description "Simpsons - Bart vs the Space Mutants (Ocean Software)"
-	rom ( name "Simpsons - Bart vs the Space Mutants (1991)(Ocean Software)(v2)(Side A).dsk" size 190733 crc CC5F46B2 md5 843D47B8560B62D8C4972A90409263C9 sha1 0DBF925D52E52BF0B6B82DEBEE570D3D1424623F )
 	rom ( name "Simpsons - Bart vs the Space Mutants (1991)(Ocean Software)(v2)(Side B).dsk" size 120585 crc 627F4ACF md5 2C70D33EE3D0EFFEFA434E311330B59A sha1 0B5E67AF5FD927A52A7078ED1847494FFF841CF9 )
+	rom ( name "Simpsons - Bart vs the Space Mutants (1991)(Ocean Software)(v2)(Side A).dsk" size 190733 crc CC5F46B2 md5 843D47B8560B62D8C4972A90409263C9 sha1 0DBF925D52E52BF0B6B82DEBEE570D3D1424623F )
 )
 game (
 	name "Snakes and Hazards (Gremlin Graphics Software)"
@@ -12927,8 +12927,8 @@ game (
 game (
 	name "Trivial Pursuit II - A New Beginning (Domark)"
 	description "Trivial Pursuit II - A New Beginning (Domark)"
-	rom ( name "Trivial Pursuit II - A New Beginning (1988)(Domark)(Side A).dsk" size 195635 crc C46C46DE md5 B6FD8AEC2C18CE303DF78CA8F405C03B sha1 6FB11A259409ED4FC4CC9126A847B984B6577FA6 )
 	rom ( name "Trivial Pursuit II - A New Beginning (1988)(Domark)(Side B).dsk" size 195635 crc 4F677A6A md5 0321B1370A45B95CCD8EB6AC6464AEA3 sha1 E00E84A728C2FAB015979BE782F345BA9E5F971A )
+	rom ( name "Trivial Pursuit II - A New Beginning (1988)(Domark)(Side A).dsk" size 195635 crc C46C46DE md5 B6FD8AEC2C18CE303DF78CA8F405C03B sha1 6FB11A259409ED4FC4CC9126A847B984B6577FA6 )
 )
 game (
 	name "Tomahawk (Digital Integration) (M3)"
@@ -13028,8 +13028,8 @@ game (
 game (
 	name "Terre et Conquerants (Ubi Soft) (France)"
 	description "Terre et Conquerants (Ubi Soft) (France)"
-	rom ( name "Terre et Conquerants (1989)(Ubi Soft)(fr)(Side A).dsk" size 228307 crc 1945B8C md5 7C114E0878CF96A6DC435375FA4FD330 sha1 BAE5BBFBFAC147ED587909AD48342001D95F9D8B )
 	rom ( name "Terre et Conquerants (1989)(Ubi Soft)(fr)(Side B).dsk" size 228307 crc C2FA28AE md5 C1B85DF39D234B8671AA2C56DCD343DF sha1 B86ABB35C18F6B0FFF074225DDE3CEB39E6CA40E )
+	rom ( name "Terre et Conquerants (1989)(Ubi Soft)(fr)(Side A).dsk" size 228307 crc 1945B8C md5 7C114E0878CF96A6DC435375FA4FD330 sha1 BAE5BBFBFAC147ED587909AD48342001D95F9D8B )
 )
 game (
 	name "Trollie Wallie (Players)"
@@ -13044,8 +13044,8 @@ game (
 game (
 	name "Tyrann (Norsoft) (France)"
 	description "Tyrann (Norsoft) (France)"
-	rom ( name "Tyrann (1985)(Norsoft)(fr)(Side A).dsk" size 195635 crc 1A6F0FFF md5 C8EF877C8CCDE5CBD723D82B190C96E9 sha1 8334E1FED47BCCDFECDBD48B681F5C9D5D284DE4 )
 	rom ( name "Tyrann (1985)(Norsoft)(fr)(Side B).dsk" size 195635 crc E577D88F md5 85A3E9B4EB1571064C09B915B8637D8A sha1 EB63A4FA9CEF7958C06CF40BBB5DFAC5C51D8193 )
+	rom ( name "Tyrann (1985)(Norsoft)(fr)(Side A).dsk" size 195635 crc 1A6F0FFF md5 C8EF877C8CCDE5CBD723D82B190C96E9 sha1 8334E1FED47BCCDFECDBD48B681F5C9D5D284DE4 )
 )
 game (
 	name "Top Cat in Beverly Hills Cats (Hi-Tec Software)"
@@ -13135,8 +13135,8 @@ game (
 game (
 	name "Trivial Pursuit - Edition Genius (Domark) (Spain)"
 	description "Trivial Pursuit - Edition Genius (Domark) (Spain)"
-	rom ( name "Trivial Pursuit - Edition Genius (1986)(Domark)(es)(Side A).dsk" size 111872 crc 7638271C md5 0D0C81567AADC1513BC0AD443E903950 sha1 2FB698D0A7EDAFAB89F9F1E58896B02138F72985 )
 	rom ( name "Trivial Pursuit - Edition Genius (1986)(Domark)(es)(Side B).dsk" size 194816 crc A55BB48D md5 4D1B4BE5E97094729FB6E9D596D280F7 sha1 F9B815C1C50B621C57B87E68091A37FA12C9C17D )
+	rom ( name "Trivial Pursuit - Edition Genius (1986)(Domark)(es)(Side A).dsk" size 111872 crc 7638271C md5 0D0C81567AADC1513BC0AD443E903950 sha1 2FB698D0A7EDAFAB89F9F1E58896B02138F72985 )
 )
 game (
 	name "Tetris (Mirrorsoft)"
@@ -13241,20 +13241,20 @@ game (
 game (
 	name "Tenebres (Rainbow Productions) (France)"
 	description "Tenebres (Rainbow Productions) (France)"
-	rom ( name "Tenebres (1987)(Rainbow Productions)(fr)(Side A)[cr].dsk" size 194816 crc 81D57297 md5 5E483DF4FBB01EFECD49F2DC078687DA sha1 D0FFAD2D4B6DA01E0260B3486ED98972975BDD6F )
 	rom ( name "Tenebres (1987)(Rainbow Productions)(fr)(Side B)[cr].dsk" size 194816 crc 7BA6E032 md5 E1C7A491804F94BAFFD1878FE286AB59 sha1 50BB618A8C6F1561776B834DFFF55418C995D79B )
+	rom ( name "Tenebres (1987)(Rainbow Productions)(fr)(Side A)[cr].dsk" size 194816 crc 81D57297 md5 5E483DF4FBB01EFECD49F2DC078687DA sha1 D0FFAD2D4B6DA01E0260B3486ED98972975BDD6F )
 )
 game (
 	name "Thunder Jaws (Domark)"
 	description "Thunder Jaws (Domark)"
-	rom ( name "Thunder Jaws (1991)(Domark)(Side A).dsk" size 195635 crc 5D6A048B md5 0BA879B858294AD6AE9C1F06591B8534 sha1 2D323B909E1F6604B14ECCAFDBD9EB1929B084B9 )
 	rom ( name "Thunder Jaws (1991)(Domark)(Side B).dsk" size 195635 crc 34785299 md5 C91C4A8C970D128CAD086884625BF30E sha1 0EACFBC0E8C9EC264ADA8C05060774670EC5DD5C )
+	rom ( name "Thunder Jaws (1991)(Domark)(Side A).dsk" size 195635 crc 5D6A048B md5 0BA879B858294AD6AE9C1F06591B8534 sha1 2D323B909E1F6604B14ECCAFDBD9EB1929B084B9 )
 )
 game (
 	name "Trivial Pursuit - Edition Genius (Domark) (France)"
 	description "Trivial Pursuit - Edition Genius (Domark) (France)"
-	rom ( name "Trivial Pursuit - Edition Genius (1986)(Domark)(fr)(Side A).dsk" size 88231 crc 87BA6D6D md5 67485C9DE67F745EE590AB5D84A772C5 sha1 017D53DA94A2C512B2E6A7100FE3F8D1DDC664BA )
 	rom ( name "Trivial Pursuit - Edition Genius (1986)(Domark)(fr)(Side B).dsk" size 195635 crc 850F88D1 md5 50DC2708FCFA3DB6438C08BDA456E768 sha1 9A3F05F9537C92032BB8E00D76F04584FEB68B13 )
+	rom ( name "Trivial Pursuit - Edition Genius (1986)(Domark)(fr)(Side A).dsk" size 88231 crc 87BA6D6D md5 67485C9DE67F745EE590AB5D84A772C5 sha1 017D53DA94A2C512B2E6A7100FE3F8D1DDC664BA )
 )
 game (
 	name "Tesoro Perdido De Cuauhtemoc (4Mhz) (Spain)"
@@ -13294,8 +13294,8 @@ game (
 game (
 	name "Time and Magik Trilogy (Level 9 Computing)"
 	description "Time and Magik Trilogy (Level 9 Computing)"
-	rom ( name "Time and Magik Trilogy (1988)(Level 9 Computing)(Side A).dsk" size 195635 crc 38DDE7C9 md5 7993A2C728789267EECCB591441A1F58 sha1 7D2661C77BA1594009AB9DC74F47035580EF4D62 )
 	rom ( name "Time and Magik Trilogy (1988)(Level 9 Computing)(Side B).dsk" size 195635 crc 7A969C1 md5 CE067F1BD1FC246A451CCBF4A74D3F72 sha1 94704AA1A0D7CE6050CB2DA2FD2E1DE7F7DF82FB )
+	rom ( name "Time and Magik Trilogy (1988)(Level 9 Computing)(Side A).dsk" size 195635 crc 38DDE7C9 md5 7993A2C728789267EECCB591441A1F58 sha1 7D2661C77BA1594009AB9DC74F47035580EF4D62 )
 )
 game (
 	name "Terra Cognita (Codemasters Software)"
@@ -13310,8 +13310,8 @@ game (
 game (
 	name "Trivial Pursuit - Edition Genius (Domark) (de)"
 	description "Trivial Pursuit - Edition Genius (Domark) (de)"
-	rom ( name "Trivial Pursuit - Edition Genius (1986)(Domark)(de)(Side A).dsk" size 194816 crc D1992306 md5 9BD8702C2EE30DC0A893C97777994430 sha1 FDF02CAB437C6A675A91FADE53B4D3A9D11DE874 )
 	rom ( name "Trivial Pursuit - Edition Genius (1986)(Domark)(de)(Side B).dsk" size 194816 crc C6BC1409 md5 4826EF4C69A21E27B102C664ED7773A9 sha1 F0DE7B32382C0EBB767F2EF649028E851ECEAB8F )
+	rom ( name "Trivial Pursuit - Edition Genius (1986)(Domark)(de)(Side A).dsk" size 194816 crc D1992306 md5 9BD8702C2EE30DC0A893C97777994430 sha1 FDF02CAB437C6A675A91FADE53B4D3A9D11DE874 )
 )
 game (
 	name "Train, The - Escape to Normandy (Electronic Arts)"
@@ -13331,8 +13331,8 @@ game (
 game (
 	name "Turrican (Rainbow Arts) (Retail)"
 	description "Turrican (Rainbow Arts) (Retail)"
-	rom ( name "Turrican (1990)(Rainbow Arts)(Retail)(Side A)[f].dsk" size 194816 crc 89D0562F md5 4FF8CF422615A8D0E93E8BDF3CD9DEDF sha1 33F58BD0143B400868D6401C4F3B22FBCD254A27 )
 	rom ( name "Turrican (1990)(Rainbow Arts)(Retail)(Side B).dsk" size 195635 crc A08FDD10 md5 831713BD700435B99F9A4F5C6B2DD565 sha1 BEC370E96921A3024430A27AB853F9D8DCA169E5 )
+	rom ( name "Turrican (1990)(Rainbow Arts)(Retail)(Side A)[f].dsk" size 194816 crc 89D0562F md5 4FF8CF422615A8D0E93E8BDF3CD9DEDF sha1 33F58BD0143B400868D6401C4F3B22FBCD254A27 )
 )
 game (
 	name "Twice Shy (Mosaic Publishing)"
@@ -13342,8 +13342,8 @@ game (
 game (
 	name "Top Level (MBC Informatique) (France)"
 	description "Top Level (MBC Informatique) (France)"
-	rom ( name "Top Level (1988)(MBC Informatique)(fr)(Side A).dsk" size 220839 crc C1DE5E93 md5 6840CB5870837A2F7C417C73022B35B1 sha1 18691166FF90DC12F7AD4C77791BD7833FCF6503 )
 	rom ( name "Top Level (1988)(MBC Informatique)(fr)(Side B).dsk" size 203613 crc 425B6165 md5 52F98C7D0156B1C03EDCB14BEE47FA19 sha1 EB905EC95892A3AF889BE4F66C1E3FDA0A609BF3 )
+	rom ( name "Top Level (1988)(MBC Informatique)(fr)(Side A).dsk" size 220839 crc C1DE5E93 md5 6840CB5870837A2F7C417C73022B35B1 sha1 18691166FF90DC12F7AD4C77791BD7833FCF6503 )
 )
 game (
 	name "Traveller, The (Recreation Re-Creation Software)"
@@ -13373,8 +13373,8 @@ game (
 game (
 	name "Times of Lore (Origin Systems)"
 	description "Times of Lore (Origin Systems)"
-	rom ( name "Times of Lore (1988)(Origin Systems)(Side A).dsk" size 170752 crc 361B6F38 md5 5442BA2D3FC6C0EB837ED43DA6D5586C sha1 688B24F9CFD0D11C7306F68171F2D6A2670D0E0E )
 	rom ( name "Times of Lore (1988)(Origin Systems)(Side B).dsk" size 170752 crc 6A652828 md5 07FB05021096870A263EC9CB72128FF7 sha1 F9DC508507990A2307F652CD2E1773540C417DD3 )
+	rom ( name "Times of Lore (1988)(Origin Systems)(Side A).dsk" size 170752 crc 361B6F38 md5 5442BA2D3FC6C0EB837ED43DA6D5586C sha1 688B24F9CFD0D11C7306F68171F2D6A2670D0E0E )
 )
 game (
 	name "Thundercats -The Lost Eye Of Thundera (Elite Systems)"
@@ -13449,8 +13449,8 @@ game (
 game (
 	name "Toi Acid Game (Iber Soft) (Spain)"
 	description "Toi Acid Game (Iber Soft) (Spain)"
-	rom ( name "Toi Acid Game (1990)(Iber Soft)(es)(Side A).dsk" size 194816 crc D0DC75A0 md5 5983B9757A15983F24E1B031DCBA3DDC sha1 6C17225060CD44C791EDEF07F3E1C1F0CF6EF898 )
 	rom ( name "Toi Acid Game (1990)(Iber Soft)(es)(Side B).dsk" size 194816 crc 5E5EAC17 md5 75B81FCF43E4FD1D73B06115493103D3 sha1 1699A0B085CF5B32FCBF0555ED4A8EB912467679 )
+	rom ( name "Toi Acid Game (1990)(Iber Soft)(es)(Side A).dsk" size 194816 crc D0DC75A0 md5 5983B9757A15983F24E1B031DCBA3DDC sha1 6C17225060CD44C791EDEF07F3E1C1F0CF6EF898 )
 )
 game (
 	name "Trakers (Kennedy)"
@@ -13480,8 +13480,8 @@ game (
 game (
 	name "Trivial Pursuit - Edition Revolution (Domark) (France)"
 	description "Trivial Pursuit - Edition Revolution (Domark) (France)"
-	rom ( name "Trivial Pursuit - Edition Revolution (1986)(Domark)(fr)(Side A).dsk" size 195635 crc 668247D3 md5 536FBD058D2BA8F158A5D9B552E9A1A6 sha1 68E458686E7661EDF33A72533A2BD4CACDE0F330 )
 	rom ( name "Trivial Pursuit - Edition Revolution (1986)(Domark)(fr)(Side B).dsk" size 195635 crc 2E134ED8 md5 8BC4FAD1DE19FF26D05B86320DDD93D6 sha1 E7E43F55D08B325F47666876FDC42AF4F2CB0793 )
+	rom ( name "Trivial Pursuit - Edition Revolution (1986)(Domark)(fr)(Side A).dsk" size 195635 crc 668247D3 md5 536FBD058D2BA8F158A5D9B552E9A1A6 sha1 68E458686E7661EDF33A72533A2BD4CACDE0F330 )
 )
 game (
 	name "Tiny Skweeks, The (Loriciels) (France)"
@@ -13531,8 +13531,8 @@ game (
 game (
 	name "Top Secret (Loriciels) (France)"
 	description "Top Secret (Loriciels) (France)"
-	rom ( name "Top Secret (1986)(Loriciels)(fr)(Side A).dsk" size 196915 crc 97E0E484 md5 484B1520913BFE3A5F3E976EECC4B476 sha1 C0AD47A19261DC6544FF65BA4FBE0E153B5E05B5 )
 	rom ( name "Top Secret (1986)(Loriciels)(fr)(Side B).dsk" size 197171 crc 6A1287C3 md5 DB5F02D355ECBA25944D5E33C749A91E sha1 4E370D1D3C83A8DA0A69CD8D6DDB7E67AFED9E9A )
+	rom ( name "Top Secret (1986)(Loriciels)(fr)(Side A).dsk" size 196915 crc 97E0E484 md5 484B1520913BFE3A5F3E976EECC4B476 sha1 C0AD47A19261DC6544FF65BA4FBE0E153B5E05B5 )
 )
 game (
 	name "Target Plus (Dinamic Software) (Spain) (LightGun)"
@@ -13552,8 +13552,8 @@ game (
 game (
 	name "Teenage Mutant Hero Turtles 2 - Coin Op (Image Works) (Codes)"
 	description "Teenage Mutant Hero Turtles 2 - Coin Op (Image Works) (Codes)"
-	rom ( name "Teenage Mutant Hero Turtles 2 - Coin Op (1991)(Image Works)(Side A)[codes].dsk" size 194816 crc 1524C73A md5 48FF57D8A7730C6E6E122A9C6170C5BB sha1 85C4EB20F2E8AE0CF4D82650ABFD719DFE7411EC )
 	rom ( name "Teenage Mutant Hero Turtles 2 - Coin Op (1991)(Image Works)(Side B)[codes].dsk" size 194816 crc 6EBECE8B md5 2001F1CFC0B240012FF7E9A44A2787E9 sha1 8AE22C496149E4648BFA6FA9A25886B3DA911405 )
+	rom ( name "Teenage Mutant Hero Turtles 2 - Coin Op (1991)(Image Works)(Side A)[codes].dsk" size 194816 crc 1524C73A md5 48FF57D8A7730C6E6E122A9C6170C5BB sha1 85C4EB20F2E8AE0CF4D82650ABFD719DFE7411EC )
 )
 game (
 	name "Turbo-Pacman (PD) (de)"
@@ -13588,8 +13588,8 @@ game (
 game (
 	name "Turlogh le Rodeur (Cobra Soft) (France)"
 	description "Turlogh le Rodeur (Cobra Soft) (France)"
-	rom ( name "Turlogh le Rodeur (1988)(Cobra Soft)(fr)(Side A).dsk" size 197427 crc FA823501 md5 6A686DC5D61C5028760FA418B9F43E72 sha1 367B52F522AA55758D8CCA8A877330C98F2A6D51 )
 	rom ( name "Turlogh le Rodeur (1988)(Cobra Soft)(fr)(Side B).dsk" size 195635 crc E2B7909E md5 89FA7D63DE72793775493A5197AAA0D3 sha1 F60602B8E3B50FD991B976BC8E2F8BC502D9F58F )
+	rom ( name "Turlogh le Rodeur (1988)(Cobra Soft)(fr)(Side A).dsk" size 197427 crc FA823501 md5 6A686DC5D61C5028760FA418B9F43E72 sha1 367B52F522AA55758D8CCA8A877330C98F2A6D51 )
 )
 game (
 	name "Techno Cop (Gremlin Graphics Software)"
@@ -13619,8 +13619,8 @@ game (
 game (
 	name "Trivial Pursuit II - A New Beginning (Domark) (France)"
 	description "Trivial Pursuit II - A New Beginning (Domark) (France)"
-	rom ( name "Trivial Pursuit II - A New Beginning (1988)(Domark)(fr)(Side A).dsk" size 195635 crc 23C7634E md5 C8B06D7F8C82809AE77010EDC36E08D7 sha1 9176516E29E2FE03B51D8A596AF5FFCEED87DC86 )
 	rom ( name "Trivial Pursuit II - A New Beginning (1988)(Domark)(fr)(Side B).dsk" size 195635 crc 916B88A md5 BA088C0701FE5EE63F7FDFF461F714F7 sha1 6FD3945DAC1D7511D28FEF712E462183FCC7243C )
+	rom ( name "Trivial Pursuit II - A New Beginning (1988)(Domark)(fr)(Side A).dsk" size 195635 crc 23C7634E md5 C8B06D7F8C82809AE77010EDC36E08D7 sha1 9176516E29E2FE03B51D8A596AF5FFCEED87DC86 )
 )
 game (
 	name "Titus the Fox (Titus)"
@@ -13630,8 +13630,8 @@ game (
 game (
 	name "Teenage Queen (ERE Informatique)"
 	description "Teenage Queen (ERE Informatique)"
-	rom ( name "Teenage Queen (1988)(ERE Informatique)(Side A).dsk" size 199475 crc A9BE8CB2 md5 BDA5564692C0DDC9FBEF7FF79139EBD9 sha1 D6FCA81FA1E92D258DFF65BC265DBFFD581E6FEC )
 	rom ( name "Teenage Queen (1988)(ERE Informatique)(Side B).dsk" size 190753 crc 9944AAF3 md5 FB2A2224F9CC9E77F31412CA55285E2A sha1 AD77E4EDE96C6936D8BA9AA6E3317E4DD3BF04AE )
+	rom ( name "Teenage Queen (1988)(ERE Informatique)(Side A).dsk" size 199475 crc A9BE8CB2 md5 BDA5564692C0DDC9FBEF7FF79139EBD9 sha1 D6FCA81FA1E92D258DFF65BC265DBFFD581E6FEC )
 )
 game (
 	name "Trans-Atlantic Balloon Challenge, The (Virgin Games)"
@@ -13656,8 +13656,8 @@ game (
 game (
 	name "Targhan (Silmarils) (France)"
 	description "Targhan (Silmarils) (France)"
-	rom ( name "Targhan (1990)(Silmarils)(fr)(Side A).dsk" size 206339 crc A5E0AB2B md5 036543336EEB73EF35ACDBA85CDB37E6 sha1 8B87A5BCF8724ECDD178E9AFB1B3631D6E5E1A69 )
 	rom ( name "Targhan (1990)(Silmarils)(fr)(Side B).dsk" size 226987 crc 418D4134 md5 0DCA3E5F6A017F89FCCAD4A061F0BDBE sha1 2D932743BDC4FFDA8F748289BAD67D6433B4F3D4 )
+	rom ( name "Targhan (1990)(Silmarils)(fr)(Side A).dsk" size 206339 crc A5E0AB2B md5 036543336EEB73EF35ACDBA85CDB37E6 sha1 8B87A5BCF8724ECDD178E9AFB1B3631D6E5E1A69 )
 )
 game (
 	name "Total Recall (Ocean Software)"
@@ -13727,8 +13727,8 @@ game (
 game (
 	name "Turrican (Rainbow Arts)"
 	description "Turrican (Rainbow Arts)"
-	rom ( name "Turrican (1990)(Rainbow Arts)(Side A).dsk" size 231936 crc A43E38D6 md5 9E0E610E8BA5BD583CDE4483A0ACE057 sha1 707986615C4253938A22559CBC89FFE702273C8F )
 	rom ( name "Turrican (1990)(Rainbow Arts)(Side B).dsk" size 216195 crc 44E9FFDF md5 E1C4DA339785D73F794485C2DD0041D4 sha1 10526D8ADC0D87E6A3031FFFFEBC5A6A8EFEB08C )
+	rom ( name "Turrican (1990)(Rainbow Arts)(Side A).dsk" size 231936 crc A43E38D6 md5 9E0E610E8BA5BD583CDE4483A0ACE057 sha1 707986615C4253938A22559CBC89FFE702273C8F )
 )
 game (
 	name "Tomy en el Slalom (G.T.S. Editorial) (Spain)"
@@ -13753,8 +13753,8 @@ game (
 game (
 	name "Turrican II - The Final Fight (Rainbow Arts)"
 	description "Turrican II - The Final Fight (Rainbow Arts)"
-	rom ( name "Turrican II - The Final Fight (1991)(Rainbow Arts)(Side A).dsk" size 228249 crc BD4AB417 md5 D9E0855C3E002DAC14A36478ED505231 sha1 652160B55E093D9F2DA6B28C3714BEDAEF9C6F38 )
 	rom ( name "Turrican II - The Final Fight (1991)(Rainbow Arts)(Side B).dsk" size 228249 crc 2C084343 md5 2DEAD5E688A90D24AA7513B050F60992 sha1 CC18DCE49C99E00BD26701430FCAF9BF04E78D29 )
+	rom ( name "Turrican II - The Final Fight (1991)(Rainbow Arts)(Side A).dsk" size 228249 crc BD4AB417 md5 D9E0855C3E002DAC14A36478ED505231 sha1 652160B55E093D9F2DA6B28C3714BEDAEF9C6F38 )
 )
 game (
 	name "Tony Truand (Loriciels) (France)"
@@ -13799,14 +13799,14 @@ game (
 game (
 	name "Turbo Out Run (US Gold)"
 	description "Turbo Out Run (US Gold)"
-	rom ( name "Turbo Out Run (1990)(US Gold)(Side A).dsk" size 265413 crc F0EC6A9D md5 8D62E235C72895899AB0DE0DD743EEAC sha1 5ECC7E14DFFAA19E7BEF21CF243DA7BBA0E01281 )
 	rom ( name "Turbo Out Run (1990)(US Gold)(Side B).dsk" size 266675 crc 673571DC md5 13C570A5413D807C7B78607D410EFD95 sha1 179B1B9008145F55C61D7BA20D7546DCBD8A70B1 )
+	rom ( name "Turbo Out Run (1990)(US Gold)(Side A).dsk" size 265413 crc F0EC6A9D md5 8D62E235C72895899AB0DE0DD743EEAC sha1 5ECC7E14DFFAA19E7BEF21CF243DA7BBA0E01281 )
 )
 game (
 	name "Trivial Pursuit - Edition Genius (Domark)"
 	description "Trivial Pursuit - Edition Genius (Domark)"
-	rom ( name "Trivial Pursuit - Edition Genius (1986)(Domark)(v2)(Side A).dsk" size 195635 crc BDD66BF3 md5 9233739ED65A1FFE0427F03A88CCC535 sha1 4322B29804D9E7216FCA134E6A38FAB4A89F2B0E )
 	rom ( name "Trivial Pursuit - Edition Genius (1986)(Domark)(v2)(Side B).dsk" size 195635 crc 2AE181E1 md5 9F8F485FA772A5A13BFB6BDFF3107FB5 sha1 928D8DA019ADF6B2632F5B14550243820E7DA24F )
+	rom ( name "Trivial Pursuit - Edition Genius (1986)(Domark)(v2)(Side A).dsk" size 195635 crc BDD66BF3 md5 9233739ED65A1FFE0427F03A88CCC535 sha1 4322B29804D9E7216FCA134E6A38FAB4A89F2B0E )
 )
 game (
 	name "Tetris (Amstrad Action)"
@@ -13826,15 +13826,15 @@ game (
 game (
 	name "Times of Lore (Origin Systems) (France)"
 	description "Times of Lore (Origin Systems) (France)"
-	rom ( name "Times of Lore (1988)(Origin Systems)(fr)(v2)(Disk 1 Side A).dsk" size 191833 crc 8878F148 md5 5E29A14147EB669C6D117F1EFD60D1B8 sha1 320F4F43B3E0239949CF5A01E1CF8394C180B22C )
 	rom ( name "Times of Lore (1988)(Origin Systems)(fr)(v2)(Disk 1 Side B).dsk" size 193089 crc 57D5919B md5 1CD254A1469D31BEB1FD8077F3680348 sha1 258DD33493C079506D032C2E78946495E96B53BE )
 	rom ( name "Times of Lore (1988)(Origin Systems)(fr)(v2)(Disk 2 Side A).dsk" size 194816 crc AADD9AE3 md5 70BCAF9110D1B3F3E9DBB4D3CFA6FE3A sha1 DE098AA393D435CD2417209B2E7F4A5AF79CCA78 )
+	rom ( name "Times of Lore (1988)(Origin Systems)(fr)(v2)(Disk 1 Side A).dsk" size 191833 crc 8878F148 md5 5E29A14147EB669C6D117F1EFD60D1B8 sha1 320F4F43B3E0239949CF5A01E1CF8394C180B22C )
 )
 game (
 	name "Targhan (Silmarils) (Spain)"
 	description "Targhan (Silmarils) (Spain)"
-	rom ( name "Targhan (1990)(Silmarils)(es)(Side A).dsk" size 189696 crc 94E4554B md5 E73F7D350D7F2B5D1CCEA3994600E512 sha1 AE22F72D15EA27D71C361732F086E247BE3C1187 )
 	rom ( name "Targhan (1990)(Silmarils)(es)(Side B).dsk" size 226048 crc 712FD650 md5 3F810D2BA8CFFA72238BE0DF4755608C sha1 D7EAD2108EC798970389CDED4E80D8FC740029F6 )
+	rom ( name "Targhan (1990)(Silmarils)(es)(Side A).dsk" size 189696 crc 94E4554B md5 E73F7D350D7F2B5D1CCEA3994600E512 sha1 AE22F72D15EA27D71C361732F086E247BE3C1187 )
 )
 game (
 	name "Teenage Mutant Hero Turtles (Image Works)"
@@ -13884,8 +13884,8 @@ game (
 game (
 	name "Thunderbirds (Grandslam)"
 	description "Thunderbirds (Grandslam)"
-	rom ( name "Thunderbirds (1989)(Grandslam)(Side A).dsk" size 174336 crc 2E05E857 md5 865C1E8B9F4C21D65DCBC8F4E2CCDAA2 sha1 8DAD9999AE820F3B317E291387C8F553F195983A )
 	rom ( name "Thunderbirds (1989)(Grandslam)(Side B).dsk" size 174336 crc F585193A md5 515E6DD93E24414CE5A75404729683DC sha1 09CB738D2BF793181E7BA80F7FA4D8C214F1FE5F )
+	rom ( name "Thunderbirds (1989)(Grandslam)(Side A).dsk" size 174336 crc 2E05E857 md5 865C1E8B9F4C21D65DCBC8F4E2CCDAA2 sha1 8DAD9999AE820F3B317E291387C8F553F195983A )
 )
 game (
 	name "Typhoon (Ocean Software)"
@@ -13925,8 +13925,8 @@ game (
 game (
 	name "Trivial Pursuit - Baby Boomer Edition (Domark)"
 	description "Trivial Pursuit - Baby Boomer Edition (Domark)"
-	rom ( name "Trivial Pursuit - Baby Boomer Edition (1986)(Domark)(Side A)[cr].dsk" size 194816 crc 59348EC7 md5 8CD2F2B6BD34DF1806948653F644CB69 sha1 18C52AC7C4C29807CBACF68EB4530BA5C77C9223 )
 	rom ( name "Trivial Pursuit - Baby Boomer Edition (1986)(Domark)(Side B)[cr].dsk" size 194816 crc 5600AA6F md5 1C93DEF76CF5B35BA1198EB0F683D502 sha1 4C6D8343EC21C15213A9280FC4559701014CA655 )
+	rom ( name "Trivial Pursuit - Baby Boomer Edition (1986)(Domark)(Side A)[cr].dsk" size 194816 crc 59348EC7 md5 8CD2F2B6BD34DF1806948653F644CB69 sha1 18C52AC7C4C29807CBACF68EB4530BA5C77C9223 )
 )
 game (
 	name "Tolki (CPC Infos) (France)"
@@ -13976,14 +13976,14 @@ game (
 game (
 	name "UN Squadron (US Gold) (Bugs)"
 	description "UN Squadron (US Gold) (Bugs)"
-	rom ( name "UN Squadron (1990)(US Gold)(Side A)[b].dsk" size 265413 crc 5D683DF1 md5 846412864B03D7FFF47EEE0CFDDE7BE6 sha1 3F95E42C0CCA7D1779318A6914B1A36B6D43D4A9 )
 	rom ( name "UN Squadron (1990)(US Gold)(Side B)[b].dsk" size 273333 crc E0149DE md5 8017A9B04C4B46B32A376AD18AE11D7D sha1 5BEE1DD9080B2E9299E59073EEC5485EA58BB2E2 )
+	rom ( name "UN Squadron (1990)(US Gold)(Side A)[b].dsk" size 265413 crc 5D683DF1 md5 846412864B03D7FFF47EEE0CFDDE7BE6 sha1 3F95E42C0CCA7D1779318A6914B1A36B6D43D4A9 )
 )
 game (
 	name "Untouchables, The (Ocean Software)"
 	description "Untouchables, The (Ocean Software)"
-	rom ( name "Untouchables, The (1989)(Ocean Software)(Side A).dsk" size 65159 crc A5CA2404 md5 C11C8B21FDA01466F3375ABE118DFFE0 sha1 95316D72E6D28BB3E43B2F3D1C66CB2615ECD7B1 )
 	rom ( name "Untouchables, The (1989)(Ocean Software)(Side B).dsk" size 195635 crc 57E89E3 md5 6EDC25EA801572F7894B5EAAABFFAC2C sha1 8969E7DB10AD926AAF0D229BDE8E163F11BCA73F )
+	rom ( name "Untouchables, The (1989)(Ocean Software)(Side A).dsk" size 65159 crc A5CA2404 md5 C11C8B21FDA01466F3375ABE118DFFE0 sha1 95316D72E6D28BB3E43B2F3D1C66CB2615ECD7B1 )
 )
 game (
 	name "Uchi Mata (Martech)"
@@ -14118,8 +14118,8 @@ game (
 game (
 	name "Voyage au Centre de la Terre (Chip) (France)"
 	description "Voyage au Centre de la Terre (Chip) (France)"
-	rom ( name "Voyage au Centre de la Terre (1988)(Chip)(fr)(Side A).dsk" size 195637 crc B6753A1A md5 26A1E4867683A56C7D0040DBE682EC38 sha1 9B7E1B847AECA7F402176C5F47BAEEFB2AE2E75F )
 	rom ( name "Voyage au Centre de la Terre (1988)(Chip)(fr)(Side B).dsk" size 195637 crc ED9DF91D md5 0C35095EF9FE0EF8C8EDB5AF9B2149A0 sha1 C3D0A41BD93F4DFCCDC49CA833FE73B68B657927 )
+	rom ( name "Voyage au Centre de la Terre (1988)(Chip)(fr)(Side A).dsk" size 195637 crc B6753A1A md5 26A1E4867683A56C7D0040DBE682EC38 sha1 9B7E1B847AECA7F402176C5F47BAEEFB2AE2E75F )
 )
 game (
 	name "Video Card Arcade (CDS Software LTD)"
@@ -14154,14 +14154,14 @@ game (
 game (
 	name "Viz - The Computer Game (Virgin Games)"
 	description "Viz - The Computer Game (Virgin Games)"
-	rom ( name "Viz - The Computer Game (1991)(Virgin Games)(Side A).dsk" size 195635 crc DEF897B5 md5 828F4E397E52647A08F43375E0497C11 sha1 84A24701444259526B7BE9BF636C84B5032C09B9 )
 	rom ( name "Viz - The Computer Game (1991)(Virgin Games)(Side B).dsk" size 195635 crc 23FDDAF0 md5 7F2F639346182032E4083864CBD6B214 sha1 0221243D29D1C4A49CD8761A5159CFDBE6497B6D )
+	rom ( name "Viz - The Computer Game (1991)(Virgin Games)(Side A).dsk" size 195635 crc DEF897B5 md5 828F4E397E52647A08F43375E0497C11 sha1 84A24701444259526B7BE9BF636C84B5032C09B9 )
 )
 game (
 	name "V2 (Ubi Soft) (France)"
 	description "V2 (Ubi Soft) (France)"
-	rom ( name "V2 (1988)(Ubi Soft)(fr)(Prototype)(Side A)[cr].dsk" size 194816 crc 5FE4AE5F md5 E324A355DDACD2C51897D2828CAB5169 sha1 BF4A517995D07F7CC70A5C3B9A2AA788700348D6 )
 	rom ( name "V2 (1988)(Ubi Soft)(fr)(Prototype)(Side B)[cr].dsk" size 194816 crc E01ABC52 md5 AD9603267B1C1EE0687AFE60518BD39B sha1 EB8F7386F5E2A3F7AE5CDE92ED48F7AF2AD39950 )
+	rom ( name "V2 (1988)(Ubi Soft)(fr)(Prototype)(Side A)[cr].dsk" size 194816 crc 5FE4AE5F md5 E324A355DDACD2C51897D2828CAB5169 sha1 BF4A517995D07F7CC70A5C3B9A2AA788700348D6 )
 )
 game (
 	name "Vixen (Martech)"
@@ -14211,8 +14211,8 @@ game (
 game (
 	name "World Games (US Gold)"
 	description "World Games (US Gold)"
-	rom ( name "World Games (1987)(US Gold)(v2)(Side A).dsk" size 195379 crc 42F0FA2B md5 D489BB950C7910F43DFF42EC4A593D86 sha1 7760363FD7E7C1DED0E69FFB9E7ED8C3D9720594 )
 	rom ( name "World Games (1987)(US Gold)(v2)(Side B).dsk" size 195635 crc D1427667 md5 A936CD4677299944AE12ECA5F831259C sha1 864BEBB00C9340A7BB00C7B52D8013CC84C0D1CD )
+	rom ( name "World Games (1987)(US Gold)(v2)(Side A).dsk" size 195379 crc 42F0FA2B md5 D489BB950C7910F43DFF42EC4A593D86 sha1 7760363FD7E7C1DED0E69FFB9E7ED8C3D9720594 )
 )
 game (
 	name "Who's Afraid of the Balrog (Amstrad Action Magazine)"
@@ -14297,8 +14297,8 @@ game (
 game (
 	name "Western Games (Magic Bytes)"
 	description "Western Games (Magic Bytes)"
-	rom ( name "Western Games (1988)(Magic Bytes)(Side A).dsk" size 185871 crc 637D1C58 md5 FEB27170D8A1E70F174DA8E2A1325010 sha1 21553372E76003D5ED66AD82C435587B0869450D )
 	rom ( name "Western Games (1988)(Magic Bytes)(Side B).dsk" size 185871 crc 52A5A13 md5 9A6219B39B4FE56E88D0847F7D710201 sha1 A828BB1B00E4702CB14534713C7D1286E1D997CD )
+	rom ( name "Western Games (1988)(Magic Bytes)(Side A).dsk" size 185871 crc 637D1C58 md5 FEB27170D8A1E70F174DA8E2A1325010 sha1 21553372E76003D5ED66AD82C435587B0869450D )
 )
 game (
 	name "Wriggler (Romantic Robot) (Codes)"
@@ -14348,8 +14348,8 @@ game (
 game (
 	name "Warrior Plus (Rainbow Productions) (France)"
 	description "Warrior Plus (Rainbow Productions) (France)"
-	rom ( name "Warrior Plus (1986)(Rainbow Productions)(fr)(Side A).dsk" size 195635 crc 5B80457C md5 99DD3900D6A93A5089307181BF1F0D46 sha1 CBBDC8386A14BB92C24D9661EDB254507FB511BF )
 	rom ( name "Warrior Plus (1986)(Rainbow Productions)(fr)(Side B).dsk" size 195635 crc 6CE693B1 md5 49C24D1B66A343F00B28D01983BD9C57 sha1 03662A59D541F1D25A82106C56AA39AE9BB6A9C4 )
+	rom ( name "Warrior Plus (1986)(Rainbow Productions)(fr)(Side A).dsk" size 195635 crc 5B80457C md5 99DD3900D6A93A5089307181BF1F0D46 sha1 CBBDC8386A14BB92C24D9661EDB254507FB511BF )
 )
 game (
 	name "Wulfpack (CDS Software LTD)"
@@ -14459,8 +14459,8 @@ game (
 game (
 	name "Winter Sports (Activision)"
 	description "Winter Sports (Activision)"
-	rom ( name "Winter Sports (1985)(Activision)(Side A).dsk" size 195635 crc E814906D md5 13DF2E0946C6A0A95052FF41B24ABE8F sha1 946BDCD896E00967CC2FE58E5E8C2E2C1B349B95 )
 	rom ( name "Winter Sports (1985)(Activision)(Side B).dsk" size 195635 crc B2BD3040 md5 A3630888FD39AB41D7995F44A92BD091 sha1 F20CEB1222DA423C44575B51E668CBB5F1778593 )
+	rom ( name "Winter Sports (1985)(Activision)(Side A).dsk" size 195635 crc E814906D md5 13DF2E0946C6A0A95052FF41B24ABE8F sha1 946BDCD896E00967CC2FE58E5E8C2E2C1B349B95 )
 )
 game (
 	name "World Championship Boxing Manager (Goliath Games)"
@@ -14520,8 +14520,8 @@ game (
 game (
 	name "Winter Games (Epyx)"
 	description "Winter Games (Epyx)"
-	rom ( name "Winter Games (1986)(Epyx)(v2)(Side A).dsk" size 194816 crc BA91AF38 md5 0045537CE3319DB04372E37E99CC0972 sha1 9E10CEE99B705F2F6274660E12D70D04AE68C201 )
 	rom ( name "Winter Games (1986)(Epyx)(v2)(Side B).dsk" size 194816 crc 4794CFB0 md5 92E0FE6F1AA7C32E21F5DF7064A2B509 sha1 824D30E97533C3BD3F77CDC48FE10E1B1F02C583 )
+	rom ( name "Winter Games (1986)(Epyx)(v2)(Side A).dsk" size 194816 crc BA91AF38 md5 0045537CE3319DB04372E37E99CC0972 sha1 9E10CEE99B705F2F6274660E12D70D04AE68C201 )
 )
 game (
 	name "Warlord (Interceptor Software)"
@@ -14536,8 +14536,8 @@ game (
 game (
 	name "World Class Leadboard (US Gold)"
 	description "World Class Leadboard (US Gold)"
-	rom ( name "World Class Leadboard (1987)(US Gold)(Side A).dsk" size 195379 crc 8D9EC690 md5 D84DA226754D3057407368592E64C3F7 sha1 6CB45434F73A43CF920EF440D5D44FC9B415B5D5 )
 	rom ( name "World Class Leadboard (1987)(US Gold)(Side B).dsk" size 195635 crc E069C64A md5 42454AC411C41ADEDB782F657E2D4EDA sha1 C8C128092A75A7C52A2BC3DF4FF15F3D5CE972CA )
+	rom ( name "World Class Leadboard (1987)(US Gold)(Side A).dsk" size 195379 crc 8D9EC690 md5 D84DA226754D3057407368592E64C3F7 sha1 6CB45434F73A43CF920EF440D5D44FC9B415B5D5 )
 )
 game (
 	name "Winter Olympics (Tynesoft)"
@@ -14627,8 +14627,8 @@ game (
 game (
 	name "Xyphoes Fantasy (Silmarils) (France)"
 	description "Xyphoes Fantasy (Silmarils) (France)"
-	rom ( name "Xyphoes Fantasy (1991)(Silmarils)(Side A)(fr).dsk" size 248239 crc DB70571B md5 7389FEFAEA699DDC94957797D39F3CE8 sha1 6A41B499487C0E716E2DB7530F2BC2042B614824 )
 	rom ( name "Xyphoes Fantasy (1991)(Silmarils)(Side B)(fr).dsk" size 248239 crc A4E02780 md5 30244CC28BCA9209C776FC486264E088 sha1 338C21D73CAA257C525578C3C00D7E1BE8411754 )
+	rom ( name "Xyphoes Fantasy (1991)(Silmarils)(Side A)(fr).dsk" size 248239 crc DB70571B md5 7389FEFAEA699DDC94957797D39F3CE8 sha1 6A41B499487C0E716E2DB7530F2BC2042B614824 )
 )
 game (
 	name "Xanadu (-) (Spain) (Hack)"
@@ -14643,8 +14643,8 @@ game (
 game (
 	name "Xyphoes Fantasy (Silmarils) (Spain)"
 	description "Xyphoes Fantasy (Silmarils) (Spain)"
-	rom ( name "Xyphoes Fantasy (1991)(Silmarils)(Side A)(es).dsk" size 247552 crc F0A1468E md5 B19D6B1034851EBEF73DEDED9E232703 sha1 09F5706111CC491EDD482252241933FB311B3D0E )
 	rom ( name "Xyphoes Fantasy (1991)(Silmarils)(Side B)(es).dsk" size 247552 crc 42C675DE md5 385ADDE4FC022E8EDD13C921EBB86F14 sha1 E0947368383090D38DD106D320A76E9213E28D14 )
+	rom ( name "Xyphoes Fantasy (1991)(Silmarils)(Side A)(es).dsk" size 247552 crc F0A1468E md5 B19D6B1034851EBEF73DEDED9E232703 sha1 09F5706111CC491EDD482252241933FB311B3D0E )
 )
 game (
 	name "Xenon (Melbourne House)"
@@ -14694,8 +14694,8 @@ game (
 game (
 	name "Yes Prime Minister (Mosaic Publishing)"
 	description "Yes Prime Minister (Mosaic Publishing)"
-	rom ( name "Yes Prime Minister (1985)(Mosaic Publishing)(Side A).dsk" size 195635 crc B010705D md5 87160DC3F37954EBD0982D4E20360289 sha1 EB9623B2E8E1AB2B9E980B763E7A99DEE7977D67 )
 	rom ( name "Yes Prime Minister (1985)(Mosaic Publishing)(Side B).dsk" size 195635 crc DDDE36C9 md5 9D95B7A40E891DBCB4AF7B7E23967179 sha1 AE5BD8604AE1937BCE825A822A928DC3EC211B04 )
+	rom ( name "Yes Prime Minister (1985)(Mosaic Publishing)(Side A).dsk" size 195635 crc B010705D md5 87160DC3F37954EBD0982D4E20360289 sha1 EB9623B2E8E1AB2B9E980B763E7A99DEE7977D67 )
 )
 game (
 	name "Yabba Dabba Doo! - Flintstones (Quicksilva)"
@@ -14720,8 +14720,8 @@ game (
 game (
 	name "Zombi (Ubi Soft)"
 	description "Zombi (Ubi Soft)"
-	rom ( name "Zombi (1986)(Ubi Soft)(Side A).dsk" size 267315 crc 38696747 md5 394A392AC56480480177EFCD0D43E85D sha1 2597819CACF8851A5FADFDD36F5E7475E814723A )
 	rom ( name "Zombi (1986)(Ubi Soft)(Side B).dsk" size 267317 crc BDC6CB01 md5 198418206B90351F5C0201CB50EAC5CC sha1 B193D8F96BEF1199718EA89E79A91C33DDF85451 )
+	rom ( name "Zombi (1986)(Ubi Soft)(Side A).dsk" size 267315 crc 38696747 md5 394A392AC56480480177EFCD0D43E85D sha1 2597819CACF8851A5FADFDD36F5E7475E814723A )
 )
 game (
 	name "Z (Rino Marketing)"
@@ -14746,8 +14746,8 @@ game (
 game (
 	name "Zombi (Ubi Soft) (Spain)"
 	description "Zombi (Ubi Soft) (Spain)"
-	rom ( name "Zombi (1986)(Ubi Soft)(es)(Side A).dsk" size 194816 crc C13903E5 md5 6FAE42339A8A16DD4CD82DC8A649ADBA sha1 80F5BD2616FCF34A9EFCCD932BE02FFC4A3CA59F )
 	rom ( name "Zombi (1986)(Ubi Soft)(es)(Side B).dsk" size 195072 crc 7526075F md5 D9871173C6A7A67FEE90EDAE66C80E0C sha1 A986E35F221B867D75465AA957488E0366F452DB )
+	rom ( name "Zombi (1986)(Ubi Soft)(es)(Side A).dsk" size 194816 crc C13903E5 md5 6FAE42339A8A16DD4CD82DC8A649ADBA sha1 80F5BD2616FCF34A9EFCCD932BE02FFC4A3CA59F )
 )
 game (
 	name "Zelda (Le Chat Cyril) (France)"
@@ -14767,10 +14767,10 @@ game (
 game (
 	name "Zap 't' Balls (NoName EDV-Service)"
 	description "Zap 't' Balls (NoName EDV-Service)"
-	rom ( name "Zap 't' Balls (1992)(NoName EDV-Service)(Side A)[QWERTY].dsk" size 207360 crc E434E0DB md5 610D62A3FC2D067967321A09AC673FFA sha1 38190DDE633AFD09FBA3810772E13A7A9D0CF75C )
 	rom ( name "Zap 't' Balls (1992)(NoName EDV-Service)(Side A)[AZERTY].dsk" size 203264 crc 8559909A md5 101809789150E04DD9F84295ED20B6C6 sha1 A12F8565650AD85B5AD1085EA5C77104EEA537F8 )
 	rom ( name "Zap 't' Balls (1992)(NoName EDV-Service)(Side B)[AZERTY].dsk" size 196608 crc 318284F3 md5 A515EE1B728367A75634F0A33B46EA9A sha1 D81B143E40347F20BC53419CDBAD5965B80867E1 )
 	rom ( name "Zap 't' Balls (1992)(NoName EDV-Service)(Side B)[QWERTY].dsk" size 196608 crc 1976725 md5 460D1EA708F44BF1A53E8B9F0944C487 sha1 C526143634415757935E8EC794EBC0EAB9B6416D )
+	rom ( name "Zap 't' Balls (1992)(NoName EDV-Service)(Side A)[QWERTY].dsk" size 207360 crc E434E0DB md5 610D62A3FC2D067967321A09AC673FFA sha1 38190DDE633AFD09FBA3810772E13A7A9D0CF75C )
 )
 game (
 	name "Zox 2099 (Loriciels) (France)"
@@ -14780,8 +14780,8 @@ game (
 game (
 	name "Zombi (Ubi Soft) (France)"
 	description "Zombi (Ubi Soft) (France)"
-	rom ( name "Zombi (1986)(Ubi Soft)(fr)(Side A).dsk" size 257331 crc 6B941913 md5 948179CF6E6E4A41D4C5E1E40BB81190 sha1 004C2046CB4447A6EDE8601610D6E77615ACF785 )
 	rom ( name "Zombi (1986)(Ubi Soft)(fr)(Side B).dsk" size 257077 crc E4F758D3 md5 261F4671BFF8073A487F7A35A669334D sha1 D415A6C1E0459E0C9ED1F0576EF4D60DB67FBC64 )
+	rom ( name "Zombi (1986)(Ubi Soft)(fr)(Side A).dsk" size 257331 crc 6B941913 md5 948179CF6E6E4A41D4C5E1E40BB81190 sha1 004C2046CB4447A6EDE8601610D6E77615ACF785 )
 )
 game (
 	name "Zania (Myrddin Software)"
@@ -14846,8 +14846,8 @@ game (
 game (
 	name "Zombi (Ubi Soft) (de)"
 	description "Zombi (Ubi Soft) (de)"
-	rom ( name "Zombi (1986)(Ubi Soft)(de)(Side A).dsk" size 267315 crc 777BCE70 md5 06CD38931476C1CC46DA80612C3648AC sha1 6D9947317FEEACB4A68ECB5D7E86BD6C0AF4326B )
 	rom ( name "Zombi (1986)(Ubi Soft)(de)(Side B).dsk" size 280665 crc F4FE2BBA md5 977E59227BD18EF4FE22514145C57CD2 sha1 AF9803465124C9B9E564F3E0D544A65C2F4233FD )
+	rom ( name "Zombi (1986)(Ubi Soft)(de)(Side A).dsk" size 267315 crc 777BCE70 md5 06CD38931476C1CC46DA80612C3648AC sha1 6D9947317FEEACB4A68ECB5D7E86BD6C0AF4326B )
 )
 game (
 	name "Zork I - The Great Underground Empire (Infocom)"


### PR DESCRIPTION
Slight update of content based on clean-cpc-db v1.1.

Multi-disk images are now ordered in a way that last entry is the first disk (Side A), so that database will recognize that one.