### PR TITLE
Create PokemonCrystalMM+OG

### DIFF
--- a/cht/Nintendo - Game Boy Color/PokemonCrystalMM+OG
+++ b/cht/Nintendo - Game Boy Color/PokemonCrystalMM+OG
@@ -1,0 +1,5 @@
+252 Working Cheat Codes for Pokemon Crystal for Miyoo Mini Plus users
+Access to all 250 Pokemon in the wild to complete Pokedex
+2 Codes for Master Ball availability in PokeMart for $0
+Will add more codes compatible to Miyoo Mini Plus users
+Download file and add to your cheats folder in retroarch


### PR DESCRIPTION
252 Working Cheat Codes for Pokemon Crystal for Miyoo Mini Plus users Access to all 250 Pokemon in the wild to complete Pokedex 2 Codes for Master Ball availability in PokeMart for $0 Will add more codes compatible to Miyoo Mini Plus users Download file and add to your cheats folder in retroarch 

[Pokemon - Crystal MM+OG(USA, Europe).txt](https://github.com/libretro/libretro-database/files/14577944/Pokemon.-.Crystal.MM%2BOG.USA.Europe.txt)
