### PR TITLE
cheats: Update PlayStation Ray Tracers (USA)

### DIFF
--- a/cht/Sony - PlayStation/Ray Tracers (World) (Game Buster).cht
+++ b/cht/Sony - PlayStation/Ray Tracers (World) (Game Buster).cht
@@ -1,4 +1,4 @@
-cheats = 2 
+cheats = 4
 
 cheat0_desc = "Infinite Time"
 cheat0_code = "80058378+05DC"
@@ -8,3 +8,10 @@ cheat1_desc = "Infinite Nitro"
 cheat1_code = "80057F3C+03B6"
 cheat1_enable = false 
 
+cheat2_desc = "Infinite Time (Alternative)"
+cheat2_code = "80058E88+06D6"
+cheat2_enable = false
+
+cheat3_desc = "Infinite Nitro (Alternative)"
+cheat3_code = "80058A40+03B6"
+cheat3_enable = false


### PR DESCRIPTION
Added WORKING & TESTED cheat code versions, marked as “Alternative”, that successfully work for my version of the game whereas the existing cheats don’t work.   I left the supposedly (World) version codes because currently the libretro search isn’t working to find Ray Tracers, strangely, so I can’t confirm if it’s a versioning issue that stops the previous cheat codes from working.  

Oops wait a minute, this should be a separate Ray Tracers (USA) cht file based on the other one, not a replace of that file and name.  But I don’t see how to do that.