### PR TITLE
Create Final Fantasy I & II - Dawn of Souls (USA, Australia).cht

### DIFF
--- a/cht/Nintendo - Game Boy Advance/Final Fantasy I & II - Dawn of Souls (USA, Australia).cht
+++ b/cht/Nintendo - Game Boy Advance/Final Fantasy I & II - Dawn of Souls (USA, Australia).cht
@@ -1,0 +1,85 @@
+cheats = 21
+
+cheat0_desc = "[FFI] No Random Encounters"
+cheat0_code = "42001A18+0000+00000002+0002"	       
+cheat0_enable = false
+
+cheat1_desc = "[FFI] Maximum Gil"
+cheat1_code = "82002AB4+423F+82002AB6+000F"
+cheat1_enable = false
+
+cheat2_desc = "[FFI] All Weapons"
+cheat2_code = "42002898+0102+01000040+0004+4200289A+0063+00000040+0004"
+cheat2_enable = false
+
+cheat3_desc = "[FFI] All Armor"
+cheat3_code = "42002998+0103+01000046+0004+4200299A+0063+00000046+0004"
+cheat3_enable = false
+
+cheat4_desc = "[FFI] All Items"
+cheat4_code = "420027EC+0101+0100002B+0004+420027EE+0063+0000002B+0004"
+cheat4_enable = false
+
+cheat5_desc = "[FFI] Complete Bestiary"
+cheat5_code = "42002AD4+80FF+000000C3+0002"
+cheat5_enable = false
+
+cheat6_desc = "[FFI] Max HP" 
+cheat6_code = "420026E0+03E7+00000004+0048+420026E2+03E7+00000004+0048"
+cheat6_enable = false
+
+cheat7_desc = "[FFI] Max MP"
+cheat7_code = "420026E4+03E7+00000004+0048+420026E6+03E7+00000004+0048"
+cheat7_enable = false
+
+cheat8_desc = "[FFI] Max AGI"
+cheat8_code = "320026EA+0063+32002732+0063+3200277A+0063+320027C2+0063"
+cheat8_enable = false
+
+cheat9_desc = "[FFI] Max INT"
+cheat9_code = "320026EB+0063+32002733+0063+3200277B+0063+320027C3+0063"
+cheat9_enable = false
+
+cheat10_desc = "[FFI] Max STA"
+cheat10_code = "320026EC+0063+32002734+0063+3200277C+0063+320027C4+0063"
+cheat10_enable = false
+
+cheat11_desc = "[FFI] Max LCK"
+cheat11_code = "320026ED+0063+32002735+0063+3200277D+0063+320027C5+0063"
+cheat11_enable = false
+
+cheat12_desc = "[FFII] No Random Encounters"
+cheat12_code = "320029C3+0000"
+cheat12_enable = false
+
+cheat13_desc = "[FFII] Maximum Gil"
+cheat13_code = "82002134+E0FF+82002136+05F5"
+cheat13_enable = false
+
+cheat14_desc = "[FFII] All Weapons, Armor and Items"
+cheat14_code = "42002140+0201+020200C0+0002+42002202+6363+000000C0+0002"
+cheat14_enable = false
+
+cheat15_desc = "[FFII] Complete Bestiary"
+cheat15_code = "42002418+80FF+000000A9+0002"
+cheat15_enable = false
+
+cheat16_desc = "[FFII] Max HP"
+cheat16_code = "42001F42+270F+00000004+0080+42001F44+270F+00000004+0080"
+cheat16_enable = false
+
+cheat17_desc = "[FFII] Max MP"
+cheat17_code = "42001F46+03E7+00000004+0080+42001F48+03E7+00000004+0080"
+cheat17_enable = false
+
+cheat18_desc = "[FFII] All Weapons Mastered"
+cheat18_code = "42001F7B+6300+00000008+0002+42001FFB+6300+00000008+0002+4200207B+6300+00000010+0002+420020FB+6300+00000008+0002"
+cheat18_enable = false
+
+cheat19_desc = "[FFII] Max Magic Levels"
+cheat19_code = "42001F8A+9963+00000010+0002+4200200A+9963+00000010+0002+4200208A+9963+00000010+0002+4200210A+9963+00000010+0002"
+cheat19_enable = false
+
+cheat20_desc = "[FFII] Max Stats"
+cheat20_code = "42001F4A+FFFF+00000004+0080+42001F4C+FFFF+00000004+0080+42001F4E+FFFF+00000004+0080+32001F51+0063+32001F54+0084+32001F56+0084+32001FD1+0063+32001FD4+0084+32001FD6+0084+32002051+0063+32002054+0084+32002056+0084"
+cheat20_enable = false


### PR DESCRIPTION
Added a .cht file for Final Fantasy I & II - Dawn of Souls. 

Have prefaced each cheat with [FFI] or [FFII] to indicate which of the two games the cheat is for.