### PR TITLE
Level select code for SMS Black Belt / MKIII Hokuto no Ken

### DIFF
--- a/cht/Sega - Master System - Mark III/Black Belt (USA, Europe) (Action Replay) (diff).cht
+++ b/cht/Sega - Master System - Mark III/Black Belt (USA, Europe) (Action Replay) (diff).cht
@@ -1,4 +1,4 @@
-cheats = 3 
+cheats = 4
 
 cheat0_desc = "Infinite Lives"
 cheat0_code = "00D9-AA09"
@@ -12,3 +12,6 @@ cheat2_desc = "Infinite Time"
 cheat2_code = "00D9-A764"
 cheat2_enable = false 
 
+cheat3_desc = "Level Select (title: up on gamepad 2)"
+cheat3_code = "00DB-6B12"
+cheat3_enanble = false

--- a/cht/Sega - Master System - Mark III/Black Belt (USA, Europe) (Action Replay).cht
+++ b/cht/Sega - Master System - Mark III/Black Belt (USA, Europe) (Action Replay).cht
@@ -1,4 +1,4 @@
-cheats = 3 
+cheats = 4
 
 cheat0_desc = "Infinite Lives"
 cheat0_code = "00D9-AC09"
@@ -12,3 +12,6 @@ cheat2_desc = "Infinite Time"
 cheat2_code = "00D9-A964"
 cheat2_enable = false 
 
+cheat3_desc = "Level Select (title: up on gamepad 2)"
+cheat3_code = "00DB-6B12"
+cheat3_enanble = false

--- a/cht/Sega - Master System - Mark III/Black Belt (USA, Europe, Brazil).cht
+++ b/cht/Sega - Master System - Mark III/Black Belt (USA, Europe, Brazil).cht
@@ -1,4 +1,4 @@
-cheats = 11
+cheats = 12
 
 cheat0_desc = "Start with 0? Lives"
 cheat0_code = "00E-05F-E66"
@@ -43,3 +43,7 @@ cheat9_enable = false
 cheat10_desc = "Infinite Lives"
 cheat10_code = "B6B-BCE-3BE"
 cheat10_enable = false
+
+cheat11_desc = "Level Select (title: up on gamepad 2)"
+cheat11_code = "00DB-6B12"
+cheat11_enanble = false

--- a/cht/Sega - Master System - Mark III/Hokuto no Ken (Japan).cht
+++ b/cht/Sega - Master System - Mark III/Hokuto no Ken (Japan).cht
@@ -1,4 +1,4 @@
-cheats = 3
+cheats = 4
 
 cheat0_desc = "Infinite Lives"
 cheat0_code = "00D9-AA09"
@@ -11,3 +11,7 @@ cheat1_enable = false
 cheat2_desc = "Infinite Time"
 cheat2_code = "00D9-A764"
 cheat2_enable = false
+
+cheat3_desc = "Level Select (title: up on gamepad 2)"
+cheat3_code = "00DB-6B12"
+cheat3_enanble = false


### PR DESCRIPTION
Added a level select cheat code for Black Belt (SMS) and Hokuto no Ken (Sega Mark III). It works the same on all versions.