### PR TITLE
Remove BIOS and program entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /libretro-super
+.DS_Store

--- a/metadat/developer/Magnavox - Odyssey 2.dat
+++ b/metadat/developer/Magnavox - Odyssey 2.dat
@@ -34,18 +34,6 @@ game (
 )
 
 game (
-	comment "[BIOS] Magnavox Odyssey2 (USA, Europe)"
-	developer "Magnavox"
-	rom ( crc 8016A315 )
-)
-
-game (
-	comment "[BIOS] Philips C52 (France)"
-	developer "Philips Interactive Media"
-	rom ( crc A318E8D6 )
-)
-
-game (
 	comment "Attack of the Timelord (USA)"
 	developer "Philips Interactive Media"
 	rom ( crc FC5A7F08 )

--- a/metadat/developer/Microsoft - MSX.dat
+++ b/metadat/developer/Microsoft - MSX.dat
@@ -814,12 +814,6 @@ game (
 )
 
 game (
-	comment "Cheese (Japan) (Program)"
-	developer "Nippon Electronics (NEOS)"
-	rom ( crc 325BB241 )
-)
-
-game (
 	comment "Chess (Japan)"
 	developer "B.U.G. Inc."
 	rom ( crc 11EED1C7 )
@@ -1066,12 +1060,6 @@ game (
 )
 
 game (
-	comment "Designer's Pencil, The (Europe) (Program)"
-	developer "Activision"
-	rom ( crc CE588C20 )
-)
-
-game (
 	comment "Dig Dug (Japan)"
 	developer "Namco"
 	rom ( crc 3C749758 )
@@ -1204,18 +1192,6 @@ game (
 )
 
 game (
-	comment "Eddy 2 (Japan) (Program) (Alt)"
-	developer "HAL Laboratory"
-	rom ( crc 141A6300 )
-)
-
-game (
-	comment "Eddy 2 (Japan) (Program)"
-	developer "HAL Laboratory"
-	rom ( crc 2DE03477 )
-)
-
-game (
 	comment "Elevator Action (Japan)"
 	developer "Taito"
 	rom ( crc 39886593 )
@@ -1300,21 +1276,9 @@ game (
 )
 
 game (
-	comment "Family Automation Language Community (Japan) (Program)"
-	developer "Nexa Corporation"
-	rom ( crc FD8A5C1D )
-)
-
-game (
 	comment "Fantasy Zone (Japan)"
 	developer "SEGA"
 	rom ( crc 3E96D005 )
-)
-
-game (
-	comment "Farm Kit (Europe) (Program)"
-	developer "Joyce Hakansson Associates"
-	rom ( crc 83E1AA1A )
 )
 
 game (
@@ -2332,12 +2296,6 @@ game (
 )
 
 game (
-	comment "Konami's Synthesizer (Japan) (Program)"
-	developer "Konami"
-	rom ( crc B9B0999A )
-)
-
-game (
 	comment "Konami's Soccer (Japan)"
 	developer "Konami"
 	rom ( crc 74BC8295 )
@@ -2746,18 +2704,6 @@ game (
 )
 
 game (
-	comment "MSX Basic-kun (Japan) (Program)"
-	developer "ASCII Corporation"
-	rom ( crc 0EA62A4D )
-)
-
-game (
-	comment "MSX Bunsetsu Henkan Jisyo (Japan) (Program)"
-	developer "Panasonic"
-	rom ( crc 381B3431 )
-)
-
-game (
 	comment "MSX Rugby (Japan)"
 	developer "Panasoft"
 	rom ( crc 61B33748 )
@@ -2779,18 +2725,6 @@ game (
 	comment "MSX Soccer (Japan)"
 	developer "Panasoft"
 	rom ( crc 6824E45D )
-)
-
-game (
-	comment "MSX-Aid (Japan) (Program)"
-	developer "ASCII Corporation"
-	rom ( crc A7C4AC70 )
-)
-
-game (
-	comment "MSX-Logo (Netherlands) (Program)"
-	developer "LCSI"
-	rom ( crc 7AF0AA39 )
 )
 
 game (
@@ -2839,12 +2773,6 @@ game (
 	comment "Nemesis 3 - The Eve of Destruction (Japan, Europe) (En)"
 	developer "Konami"
 	rom ( crc 4B61AE91 )
-)
-
-game (
-	comment "New Horizon - English Course 1 (Japan) (Program)"
-	developer "Tokyo Shoseki"
-	rom ( crc 85D47F39 )
 )
 
 game (
@@ -2965,12 +2893,6 @@ game (
 	comment "Parodius (Japan) (Wii U Virtual Console)"
 	developer "Konami"
 	rom ( crc 9BB308F5 )
-)
-
-game (
-	comment "Pasokon Sakkyokuka (Japan) (Program)"
-	developer "Rittor Music - MCS"
-	rom ( crc E74B7943 )
 )
 
 game (
@@ -3151,12 +3073,6 @@ game (
 	comment "Professional Baseball (Japan)"
 	developer "Technopolis Soft"
 	rom ( crc 8CA4CD58 )
-)
-
-game (
-	comment "Psychedelia (Europe) (Program)"
-	developer "Llamasoft"
-	rom ( crc 9D89337A )
 )
 
 game (
@@ -3790,12 +3706,6 @@ game (
 )
 
 game (
-	comment "Super Synth (Japan) (Program) (Alt)"
-	developer "Cross Media Soft"
-	rom ( crc 31729CD0 )
-)
-
-game (
 	comment "Super Tennis (Japan)"
 	developer "Takara"
 	rom ( crc D560D9C0 )
@@ -3805,12 +3715,6 @@ game (
 	comment "Super Tripper (Spain)"
 	developer "Indescomp"
 	rom ( crc 0C36F5BD )
-)
-
-game (
-	comment "Super Synth (Japan) (Program)"
-	developer "Cross Media Soft"
-	rom ( crc 168832A2 )
 )
 
 game (
@@ -4225,12 +4129,6 @@ game (
 	comment "Zenji (Japan)"
 	developer "Activision"
 	rom ( crc 77B3B0B9 )
-)
-
-game (
-	comment "Zen (Europe) (Program)"
-	developer "Avalon Software"
-	rom ( crc 95E3C098 )
 )
 
 game (

--- a/metadat/developer/Sega - Master System - Mark III.dat
+++ b/metadat/developer/Sega - Master System - Mark III.dat
@@ -4,54 +4,6 @@ clrmamepro (
 )
 
 game (
-	comment "[BIOS] Sega Master System (Japan) (v2.1)"
-	developer "SEGA"
-	rom ( crc 48D44A13 )
-)
-
-game (
-	comment "[BIOS] Hang On & Safari Hunt (USA, Europe, Brazil) (En) (v2.4)"
-	developer "SEGA"
-	rom ( crc 91E93385 )
-)
-
-game (
-	comment "[BIOS] Missile Defense 3-D (USA, Europe) (v4.4)"
-	developer "SEGA"
-	rom ( crc E79BB689 )
-)
-
-game (
-	comment "[BIOS] Hang On (USA, Europe) (v3.4)"
-	developer "SEGA"
-	rom ( crc 8EDF7AC6 )
-)
-
-game (
-	comment "[BIOS] Sega Master System (USA) (M404) (Proto)"
-	developer "SEGA"
-	rom ( crc 1A15DFCC )
-)
-
-game (
-	comment "[BIOS] Sega Master System (USA) (v1.0) (Proto)"
-	developer "SEGA"
-	rom ( crc 72BEC693 )
-)
-
-game (
-	comment "[BIOS] Sega Master System (USA, Europe) (v1.3)"
-	developer "SEGA"
-	rom ( crc 0072ED54 )
-)
-
-game (
-	comment "[BIOS] Sega Master System (USA) (Store Display Unit)"
-	developer "SEGA"
-	rom ( crc EE2C29BA )
-)
-
-game (
 	comment "20 em 1 (Brazil)"
 	developer "Tec Toy"
 	rom ( crc F0F35C22 )

--- a/metadat/developer/Sega - Mega Drive - Genesis.dat
+++ b/metadat/developer/Sega - Mega Drive - Genesis.dat
@@ -4,168 +4,6 @@ clrmamepro (
 )
 
 game (
-	comment "[BIOS] LaserActive (Japan) (v1.05)"
-	developer "SEGA"
-	rom ( crc 474AAA44 )
-)
-
-game (
-	comment "[BIOS] Mega-CD (Japan) (Rev E)"
-	developer "SEGA"
-	rom ( crc 9D2DA8F2 )
-)
-
-game (
-	comment "[BIOS] LaserActive (USA) (v1.04)"
-	developer "SEGA"
-	rom ( crc 50CD3D23 )
-)
-
-game (
-	comment "[BIOS] Mega-CD (Europe) (v1.00)"
-	developer "SEGA"
-	rom ( crc 529AC15A )
-)
-
-game (
-	comment "[BIOS] LaserActive (USA) (v1.02)"
-	developer "SEGA"
-	rom ( crc 3B10CF41 )
-)
-
-game (
-	comment "[BIOS] Aiwa CSD-GM1 (Japan)"
-	developer "SEGA"
-	rom ( crc 8052C7A0 )
-)
-
-game (
-	comment "[BIOS] LaserActive (Japan) (v1.02)"
-	developer "SEGA"
-	rom ( crc 00EEDB3A )
-)
-
-game (
-	comment "[BIOS] Mega-CD (Asia) (Ja) (Rev H)"
-	developer "SEGA"
-	rom ( crc 550F30BB )
-)
-
-game (
-	comment "[BIOS] Mega-CD (Japan) (Rev C)"
-	developer "SEGA"
-	rom ( crc F18DDE5B )
-)
-
-game (
-	comment "[BIOS] Mega-CD (Japan) (Rev D)"
-	developer "SEGA"
-	rom ( crc 2EA250C0 )
-)
-
-game (
-	comment "[BIOS] Mega-CD (Japan) (v1.11B)"
-	developer "SEGA"
-	rom ( crc 4BE18FF6 )
-)
-
-game (
-	comment "[BIOS] Mega-CD (Japan) (Rev A)"
-	developer "SEGA"
-	rom ( crc C49D3663 )
-)
-
-game (
-	comment "[BIOS] Mega-CD (Japan) (Rev B)"
-	developer "SEGA"
-	rom ( crc 9BCE40B2 )
-)
-
-game (
-	comment "[BIOS] Mega-CD (Japan) (Rev H)"
-	developer "SEGA"
-	rom ( crc 79F85384 )
-)
-
-game (
-	comment "[BIOS] Mega-CD 2 (Europe) (v2.11)"
-	developer "SEGA"
-	rom ( crc C1AA217F )
-)
-
-game (
-	comment "[BIOS] Mega-CD 2 (Europe)"
-	developer "SEGA"
-	rom ( crc 0507B590 )
-)
-
-game (
-	comment "[BIOS] Multi-Mega (Europe)"
-	developer "SEGA"
-	rom ( crc AACB851E )
-)
-
-game (
-	comment "[BIOS] Mega-CD (Japan) (Beta)"
-	developer "SEGA"
-	rom ( crc 41AF44C4 )
-)
-
-game (
-	comment "[BIOS] Mega-CD 2 (Japan)"
-	developer "SEGA"
-	rom ( crc DD6CC972 )
-)
-
-game (
-	comment "[BIOS] Sega CD (USA) (v1.00)"
-	developer "SEGA"
-	rom ( crc E7E3AFE2 )
-)
-
-game (
-	comment "[BIOS] Mega-CD 2 (Europe) (Rev A)"
-	developer "SEGA"
-	rom ( crc 4D5CB8DA )
-)
-
-game (
-	comment "[BIOS] Sega CD (USA) (Rev B)"
-	developer "SEGA"
-	rom ( crc C6D10268 )
-)
-
-game (
-	comment "[BIOS] Sega CD 2A (USA)"
-	developer "SEGA"
-	rom ( crc 2E49D72C )
-)
-
-game (
-	comment "[BIOS] Sega CD 2 (USA) (Rev A)"
-	developer "SEGA"
-	rom ( crc 9F6F6276 )
-)
-
-game (
-	comment "[BIOS] Sega CD 2 (USA)"
-	developer "SEGA"
-	rom ( crc 8AF65F58 )
-)
-
-game (
-	comment "[BIOS] Sega CDX (USA)"
-	developer "SEGA"
-	rom ( crc D48C44B5 )
-)
-
-game (
-	comment "[BIOS] Sega Mega Drive - Genesis Boot ROM (World)"
-	developer "SEGA"
-	rom ( crc 3F888CF4 )
-)
-
-game (
 	comment "007 Shitou - The Duel (Japan)"
 	developer "Domark"
 	rom ( crc AEB4B262 )
@@ -2107,18 +1945,6 @@ game (
 	comment "Castlevania - The New Generation (Europe) (Mega Drive Mini)"
 	developer "Konami"
 	rom ( crc 6A5E58CD )
-)
-
-game (
-	comment "CDX Pro (World) (v1.70) (Program) (Unl) [b]"
-	developer "SEGA"
-	rom ( crc E7F3A492 )
-)
-
-game (
-	comment "CDX Pro (World) (v1.8I) (Program) (Unl)"
-	developer "SEGA"
-	rom ( crc 170CA9DA )
 )
 
 game (
@@ -4762,18 +4588,6 @@ game (
 )
 
 game (
-	comment "Flux (Europe) (Program)"
-	developer "EXP"
-	rom ( crc 2A1DA08C )
-)
-
-game (
-	comment "Flux (Europe) (Beta) (Program)"
-	developer "EXP"
-	rom ( crc 0BA20EE0 )
-)
-
-game (
 	comment "Foreman for Real (World)"
 	developer "Software Creations"
 	rom ( crc BA6EAECA )
@@ -4981,12 +4795,6 @@ game (
 	comment "Garfield - Caught in the Act (USA, Europe)"
 	developer "SEGA"
 	rom ( crc F0FF078E )
-)
-
-game (
-	comment "Game Toshokan (Japan) (Rev A) (Program)"
-	developer "SEGA"
-	rom ( crc C185C819 )
 )
 
 game (
@@ -7237,12 +7045,6 @@ game (
 	comment "Medal City (Japan) (SegaNet)"
 	developer "SEGA"
 	rom ( crc 3EF4135D )
-)
-
-game (
-	comment "Mega Anser (Japan) (Program)"
-	developer "SEGA"
-	rom ( crc 08ECE367 )
 )
 
 game (
@@ -14521,12 +14323,6 @@ game (
 	comment "Wonder Boy V - Monster World III (Japan, Korea) (Ja)"
 	developer "Westone"
 	rom ( crc 45A50F96 )
-)
-
-game (
-	comment "Wonder Library (Japan) (Program)"
-	developer "Victor Entertainment"
-	rom ( crc 9350E754 )
 )
 
 game (

--- a/metadat/developer/Sega - SG-1000.dat
+++ b/metadat/developer/Sega - SG-1000.dat
@@ -322,30 +322,6 @@ game (
 )
 
 game (
-	comment "Chuugaku Hisshuu Eibunpou - Chuugaku 1-Nen (Japan) (SC-3000) (Program)"
-	developer "Stratford Computer"
-	rom ( crc 345C8BC8 )
-)
-
-game (
-	comment "Chuugaku Hisshuu Eisakubun - Chuugaku 1-Nen (Japan) (SC-3000) (Program)"
-	developer "Stratford Computer"
-	rom ( crc 9BAFD9E9 )
-)
-
-game (
-	comment "Chuugaku Hisshuu Eisakubun - Chuugaku 1-Nen (Japan) (SC-3000) (Program) (Alt)"
-	developer "Stratford Computer"
-	rom ( crc 9BAFD9E9 )
-)
-
-game (
-	comment "Chuugaku Hisshuu Eitango - Chuugaku 1-Nen (Japan) (SC-3000) (Program)"
-	developer "Stratford Computer"
-	rom ( crc 6CCB297A )
-)
-
-game (
 	comment "Circus Charlie (Taiwan) (Unl)"
 	developer "Konami"
 	rom ( crc 7F7F009D )
@@ -580,12 +556,6 @@ game (
 )
 
 game (
-	comment "Home BASIC (Japan) (SC-3000) (Program)"
-	developer "Mitec"
-	rom ( crc 78A37CBC )
-)
-
-game (
 	comment "Home Mahjong (Japan) (Rev 1)"
 	developer "SEGA"
 	rom ( crc E7E0F0E3 )
@@ -637,12 +607,6 @@ game (
 	comment "Hyper Sports 2 (Taiwan) (Unl)"
 	developer "Konami"
 	rom ( crc B0234E12 )
-)
-
-game (
-	comment "Kagaku (Gensokigou Master) (Japan) (SC-3000) (Program)"
-	developer "Stratford Computer"
-	rom ( crc F9C81FE1 )
 )
 
 game (
@@ -742,12 +706,6 @@ game (
 )
 
 game (
-	comment "Music Editor (Japan) (SC-3000) (Program)"
-	developer "Mitec"
-	rom ( crc 2EC28526 )
-)
-
-game (
 	comment "N-Sub (Taiwan) (Unl)"
 	developer "Compile"
 	rom ( crc CF1BF7E1 )
@@ -763,12 +721,6 @@ game (
 	comment "N-Sub (Japan) (Alt)"
 	developer "Compile"
 	rom ( crc B377D6E1 )
-)
-
-game (
-	comment "Nihonshi Nenpyou (Japan) (SC-3000) (Program)"
-	developer "Stratford Computer"
-	rom ( crc 129D6359 )
 )
 
 game (
@@ -1030,12 +982,6 @@ game (
 )
 
 game (
-	comment "Sekaishi Nenpyou (Japan) (SC-3000) (Program)"
-	developer "Stratford Computer"
-	rom ( crc 3274EE48 )
-)
-
-game (
 	comment "Serizawa Hachidan no Tsumeshougi (Japan)"
 	developer "SEGA"
 	rom ( crc 545FC9BB )
@@ -1198,27 +1144,9 @@ game (
 )
 
 game (
-	comment "Tanoshii Sansuu - Shougaku 4-Nen Ge (Japan) (SC-3000) (Program)"
-	developer "Stratford Computer Center"
-	rom ( crc 5FDE25BB )
-)
-
-game (
-	comment "Terebi Oekaki (Japan) (Program)"
-	developer "SEGA"
-	rom ( crc DD4A661B )
-)
-
-game (
 	comment "TwinBee (Taiwan) (Unl)"
 	developer "Konami"
 	rom ( crc C550B4F0 )
-)
-
-game (
-	comment "Uranai Angel Cutie (Japan) (SC-3000) (Program)"
-	developer "SEGA"
-	rom ( crc AE4F92CF )
 )
 
 game (

--- a/metadat/esrb/Sega - SG-1000.dat
+++ b/metadat/esrb/Sega - SG-1000.dat
@@ -934,12 +934,6 @@ game (
 )
 
 game (
-	comment "Terebi Oekaki (Japan) (Program)"
-	esrb_rating "E"
-	rom ( crc DD4A661B )
-)
-
-game (
 	comment "TwinBee (Taiwan) (Unl)"
 	esrb_rating "E"
 	rom ( crc C550B4F0 )

--- a/metadat/genre/Magnavox - Odyssey 2.dat
+++ b/metadat/genre/Magnavox - Odyssey 2.dat
@@ -34,18 +34,6 @@ game (
 )
 
 game (
-	comment "[BIOS] Magnavox Odyssey2 (USA, Europe)"
-	genre "Various"
-	rom ( crc 8016A315 )
-)
-
-game (
-	comment "[BIOS] Philips C52 (France)"
-	genre "Various"
-	rom ( crc A318E8D6 )
-)
-
-game (
 	comment "Attack of the Timelord (USA)"
 	genre "Shooter"
 	rom ( crc FC5A7F08 )

--- a/metadat/genre/Microsoft - MSX.dat
+++ b/metadat/genre/Microsoft - MSX.dat
@@ -748,12 +748,6 @@ game (
 )
 
 game (
-	comment "Cheese (Japan) (Program)"
-	genre "Various"
-	rom ( crc 325BB241 )
-)
-
-game (
 	comment "Chess Game, The (Europe)"
 	genre "Board game"
 	rom ( crc 28277362 )
@@ -982,12 +976,6 @@ game (
 )
 
 game (
-	comment "Designer's Pencil, The (Europe) (Program)"
-	genre "Various"
-	rom ( crc CE588C20 )
-)
-
-game (
 	comment "Dig Dug (Japan)"
 	genre "Action"
 	rom ( crc 3C749758 )
@@ -1102,18 +1090,6 @@ game (
 )
 
 game (
-	comment "Eddy 2 (Japan) (Program) (Alt)"
-	genre "Various"
-	rom ( crc 141A6300 )
-)
-
-game (
-	comment "Eddy 2 (Japan) (Program)"
-	genre "Various"
-	rom ( crc 2DE03477 )
-)
-
-game (
 	comment "Elevator Action (Japan)"
 	genre "Platform"
 	rom ( crc 39886593 )
@@ -1210,21 +1186,9 @@ game (
 )
 
 game (
-	comment "Family Automation Language Community (Japan) (Program)"
-	genre "Simulation"
-	rom ( crc FD8A5C1D )
-)
-
-game (
 	comment "Fantasy Zone (Japan)"
 	genre "Shoot'em Up"
 	rom ( crc 3E96D005 )
-)
-
-game (
-	comment "Farm Kit (Europe) (Program)"
-	genre "Educational"
-	rom ( crc 83E1AA1A )
 )
 
 game (
@@ -1984,12 +1948,6 @@ game (
 )
 
 game (
-	comment "Keiba, The (Japan) (Program)"
-	genre "Casino"
-	rom ( crc DF958ED5 )
-)
-
-game (
 	comment "Keystone Kapers (Japan)"
 	genre "Action"
 	rom ( crc 7FF117F9 )
@@ -2221,12 +2179,6 @@ game (
 	comment "Konami's Soccer (Japan) (Alt 2)"
 	genre "Sports"
 	rom ( crc E861D2BD )
-)
-
-game (
-	comment "Konami's Synthesizer (Japan) (Program)"
-	genre "Various"
-	rom ( crc B9B0999A )
 )
 
 game (
@@ -2638,18 +2590,6 @@ game (
 )
 
 game (
-	comment "MSX Basic-kun (Japan) (Program)"
-	genre "Various"
-	rom ( crc 0EA62A4D )
-)
-
-game (
-	comment "MSX Bunsetsu Henkan Jisyo (Japan) (Program)"
-	genre "Various"
-	rom ( crc 381B3431 )
-)
-
-game (
 	comment "MSX Rugby (Japan)"
 	genre "Sports"
 	rom ( crc 61B33748 )
@@ -2671,18 +2611,6 @@ game (
 	comment "MSX Soccer (Japan)"
 	genre "Sports"
 	rom ( crc 6824E45D )
-)
-
-game (
-	comment "MSX-Aid (Japan) (Program)"
-	genre "Various"
-	rom ( crc A7C4AC70 )
-)
-
-game (
-	comment "MSX-Logo (Netherlands) (Program)"
-	genre "Various"
-	rom ( crc 7AF0AA39 )
 )
 
 game (
@@ -2731,12 +2659,6 @@ game (
 	comment "Nemesis 3 - The Eve of Destruction (Japan, Europe) (En)"
 	genre "Shoot'em Up"
 	rom ( crc 4B61AE91 )
-)
-
-game (
-	comment "New Horizon - English Course 1 (Japan) (Program)"
-	genre "Educational"
-	rom ( crc 85D47F39 )
 )
 
 game (
@@ -2863,12 +2785,6 @@ game (
 	comment "Parodius (Japan) (Wii U Virtual Console)"
 	genre "Shoot'em Up"
 	rom ( crc 9BB308F5 )
-)
-
-game (
-	comment "Pasokon Sakkyokuka (Japan) (Program)"
-	genre "Various"
-	rom ( crc E74B7943 )
 )
 
 game (
@@ -3061,12 +2977,6 @@ game (
 	comment "Professional Mahjong (Japan)"
 	genre "Asiatic board game"
 	rom ( crc F1EC5E18 )
-)
-
-game (
-	comment "Psychedelia (Europe) (Program)"
-	genre "Various"
-	rom ( crc 9D89337A )
 )
 
 game (
@@ -3664,12 +3574,6 @@ game (
 )
 
 game (
-	comment "Super Synth (Japan) (Program) (Alt)"
-	genre "Various"
-	rom ( crc 31729CD0 )
-)
-
-game (
 	comment "Super Tennis (Japan)"
 	genre "Sports"
 	rom ( crc D560D9C0 )
@@ -3679,12 +3583,6 @@ game (
 	comment "Super Tripper (Spain)"
 	genre "Platform"
 	rom ( crc 0C36F5BD )
-)
-
-game (
-	comment "Super Synth (Japan) (Program)"
-	genre "Various"
-	rom ( crc 168832A2 )
 )
 
 game (
@@ -4081,12 +3979,6 @@ game (
 	comment "Zenji (Japan)"
 	genre "Strategy"
 	rom ( crc 77B3B0B9 )
-)
-
-game (
-	comment "Zen (Europe) (Program)"
-	genre "Various"
-	rom ( crc 95E3C098 )
 )
 
 game (

--- a/metadat/genre/Nintendo - Game Boy Advance.dat
+++ b/metadat/genre/Nintendo - Game Boy Advance.dat
@@ -4,24 +4,6 @@ clrmamepro (
 )
 
 game (
-	comment "[BIOS] Game Boy Advance (Japan) (Debug Version)"
-	genre "Shooter"
-	rom ( crc 15E1F676 )
-)
-
-game (
-	comment "[BIOS] Game Boy Advance (World)"
-	genre "Shooter"
-	rom ( crc 81977335 )
-)
-
-game (
-	comment "[BIOS] Game Boy Advance (World) (GameCube)"
-	genre "Shooter"
-	rom ( crc 3F02EA8F )
-)
-
-game (
 	comment "007 - NightFire (USA, Europe) (En,Fr,De)"
 	genre "Shooter"
 	rom ( crc 56C83C16 )

--- a/metadat/genre/Nintendo - Game Boy Color.dat
+++ b/metadat/genre/Nintendo - Game Boy Color.dat
@@ -4,30 +4,6 @@ clrmamepro (
 )
 
 game (
-	comment "[BIOS] Nintendo Game Boy Color Boot ROM (World) (Pokemon Stadium)"
-	genre "Shooter"
-	rom ( crc B18C78E8 )
-)
-
-game (
-	comment "[BIOS] Nintendo Game Boy Color Boot ROM (World) (Beta) (Virtual Console)"
-	genre "Shooter"
-	rom ( crc E95DC95D )
-)
-
-game (
-	comment "[BIOS] Nintendo Game Boy Color Boot ROM (Japan) (En)"
-	genre "Shooter"
-	rom ( crc E8EF5318 )
-)
-
-game (
-	comment "[BIOS] Nintendo Game Boy Color Boot ROM (World) (Rev 1)"
-	genre "Shooter"
-	rom ( crc 41884E46 )
-)
-
-game (
 	comment "007 - The World Is Not Enough (USA, Europe)"
 	genre "Shooter"
 	rom ( crc E038E666 )

--- a/metadat/genre/Sega - Master System - Mark III.dat
+++ b/metadat/genre/Sega - Master System - Mark III.dat
@@ -4,54 +4,6 @@ clrmamepro (
 )
 
 game (
-	comment "[BIOS] Sega Master System (Japan) (v2.1)"
-	genre "Strategy"
-	rom ( crc 48D44A13 )
-)
-
-game (
-	comment "[BIOS] Hang On & Safari Hunt (USA, Europe, Brazil) (En) (v2.4)"
-	genre "Race, Driving"
-	rom ( crc 91E93385 )
-)
-
-game (
-	comment "[BIOS] Missile Defense 3-D (USA, Europe) (v4.4)"
-	genre "Lightgun Shooter"
-	rom ( crc E79BB689 )
-)
-
-game (
-	comment "[BIOS] Hang On (USA, Europe) (v3.4)"
-	genre "Race, Driving"
-	rom ( crc 8EDF7AC6 )
-)
-
-game (
-	comment "[BIOS] Sega Master System (USA) (M404) (Proto)"
-	genre "Strategy"
-	rom ( crc 1A15DFCC )
-)
-
-game (
-	comment "[BIOS] Sega Master System (USA) (v1.0) (Proto)"
-	genre "Strategy"
-	rom ( crc 72BEC693 )
-)
-
-game (
-	comment "[BIOS] Sega Master System (USA, Europe) (v1.3)"
-	genre "Puzzle-Game"
-	rom ( crc 0072ED54 )
-)
-
-game (
-	comment "[BIOS] Sega Master System (USA) (Store Display Unit)"
-	genre "Strategy"
-	rom ( crc EE2C29BA )
-)
-
-game (
 	comment "20 em 1 (Brazil)"
 	genre "Action"
 	rom ( crc F0F35C22 )

--- a/metadat/genre/Sega - Mega Drive - Genesis.dat
+++ b/metadat/genre/Sega - Mega Drive - Genesis.dat
@@ -14410,12 +14410,6 @@ game (
 )
 
 game (
-	comment "Wonder Library (Japan) (Program)"
-	genre "Educational"
-	rom ( crc 9350E754 )
-)
-
-game (
 	comment "Wonder Boy V - Monster World III (Japan, Korea) (Ja) (Beta) (1991-07-25)"
 	genre "Platform"
 	rom ( crc 334035F8 )

--- a/metadat/genre/Sega - SG-1000.dat
+++ b/metadat/genre/Sega - SG-1000.dat
@@ -322,30 +322,6 @@ game (
 )
 
 game (
-	comment "Chuugaku Hisshuu Eibunpou - Chuugaku 1-Nen (Japan) (SC-3000) (Program)"
-	genre "Educational"
-	rom ( crc 345C8BC8 )
-)
-
-game (
-	comment "Chuugaku Hisshuu Eisakubun - Chuugaku 1-Nen (Japan) (SC-3000) (Program)"
-	genre "Educational"
-	rom ( crc 9BAFD9E9 )
-)
-
-game (
-	comment "Chuugaku Hisshuu Eisakubun - Chuugaku 1-Nen (Japan) (SC-3000) (Program) (Alt)"
-	genre "Educational"
-	rom ( crc 9BAFD9E9 )
-)
-
-game (
-	comment "Chuugaku Hisshuu Eitango - Chuugaku 1-Nen (Japan) (SC-3000) (Program)"
-	genre "Educational"
-	rom ( crc 6CCB297A )
-)
-
-game (
 	comment "Congo Bongo (Japan)"
 	genre "Platform"
 	rom ( crc 5EB48A20 )
@@ -622,12 +598,6 @@ game (
 )
 
 game (
-	comment "Kagaku (Gensokigou Master) (Japan) (SC-3000) (Program)"
-	genre "Educational"
-	rom ( crc F9C81FE1 )
-)
-
-game (
 	comment "Kamikaze (France) (En) (SF-7000) (Unl)"
 	genre "Shoot'em Up"
 	rom ( crc 786224DD )
@@ -724,12 +694,6 @@ game (
 )
 
 game (
-	comment "Music Editor (Japan) (SC-3000) (Program)"
-	genre "Educational"
-	rom ( crc 2EC28526 )
-)
-
-game (
 	comment "N-Sub (Taiwan) (Unl)"
 	genre "Shooter"
 	rom ( crc CF1BF7E1 )
@@ -745,12 +709,6 @@ game (
 	comment "N-Sub (Japan) (Alt)"
 	genre "Shooter"
 	rom ( crc B377D6E1 )
-)
-
-game (
-	comment "Nihonshi Nenpyou (Japan) (SC-3000) (Program)"
-	genre "Educational"
-	rom ( crc 129D6359 )
 )
 
 game (
@@ -1012,12 +970,6 @@ game (
 )
 
 game (
-	comment "Sekaishi Nenpyou (Japan) (SC-3000) (Program)"
-	genre "Educational"
-	rom ( crc 3274EE48 )
-)
-
-game (
 	comment "Serizawa Hachidan no Tsumeshougi (Japan)"
 	genre "Casual Game"
 	rom ( crc 545FC9BB )
@@ -1180,27 +1132,9 @@ game (
 )
 
 game (
-	comment "Tanoshii Sansuu - Shougaku 4-Nen Ge (Japan) (SC-3000) (Program)"
-	genre "Educational"
-	rom ( crc 5FDE25BB )
-)
-
-game (
-	comment "Terebi Oekaki (Japan) (Program)"
-	genre "Various"
-	rom ( crc DD4A661B )
-)
-
-game (
 	comment "TwinBee (Taiwan) (Unl)"
 	genre "Shoot'em Up"
 	rom ( crc C550B4F0 )
-)
-
-game (
-	comment "Uranai Angel Cutie (Japan) (SC-3000) (Program)"
-	genre "Casual Game"
-	rom ( crc AE4F92CF )
 )
 
 game (

--- a/metadat/maxusers/Magnavox - Odyssey 2.dat
+++ b/metadat/maxusers/Magnavox - Odyssey 2.dat
@@ -34,18 +34,6 @@ game (
 )
 
 game (
-	comment "[BIOS] Magnavox Odyssey2 (USA, Europe)"
-	users 1
-	rom ( crc 8016A315 )
-)
-
-game (
-	comment "[BIOS] Philips C52 (France)"
-	users 1
-	rom ( crc A318E8D6 )
-)
-
-game (
 	comment "Attack of the Timelord (USA)"
 	users 1
 	rom ( crc FC5A7F08 )

--- a/metadat/maxusers/Microsoft - MSX.dat
+++ b/metadat/maxusers/Microsoft - MSX.dat
@@ -1078,21 +1078,9 @@ game (
 )
 
 game (
-	comment "Family Automation Language Community (Japan) (Program)"
-	users 2
-	rom ( crc FD8A5C1D )
-)
-
-game (
 	comment "Fantasy Zone (Japan)"
 	users 1
 	rom ( crc 3E96D005 )
-)
-
-game (
-	comment "Farm Kit (Europe) (Program)"
-	users 1
-	rom ( crc 83E1AA1A )
 )
 
 game (
@@ -2674,12 +2662,6 @@ game (
 )
 
 game (
-	comment "Psychedelia (Europe) (Program)"
-	users 1
-	rom ( crc 9D89337A )
-)
-
-game (
 	comment "Psychic War - Cosmic Soldier 2 (Japan)"
 	users 1
 	rom ( crc B8FC19A4 )
@@ -3238,12 +3220,6 @@ game (
 )
 
 game (
-	comment "Super Synth (Japan) (Program) (Alt)"
-	users 1
-	rom ( crc 31729CD0 )
-)
-
-game (
 	comment "Super Tennis (Japan)"
 	users 2
 	rom ( crc D560D9C0 )
@@ -3253,12 +3229,6 @@ game (
 	comment "Super Tripper (Spain)"
 	users 1
 	rom ( crc 0C36F5BD )
-)
-
-game (
-	comment "Super Synth (Japan) (Program)"
-	users 1
-	rom ( crc 168832A2 )
 )
 
 game (

--- a/metadat/maxusers/Sega - Master System - Mark III.dat
+++ b/metadat/maxusers/Sega - Master System - Mark III.dat
@@ -4,54 +4,6 @@ clrmamepro (
 )
 
 game (
-	comment "[BIOS] Sega Master System (Japan) (v2.1)"
-	users 1
-	rom ( crc 48D44A13 )
-)
-
-game (
-	comment "[BIOS] Hang On & Safari Hunt (USA, Europe, Brazil) (En) (v2.4)"
-	users 1
-	rom ( crc 91E93385 )
-)
-
-game (
-	comment "[BIOS] Missile Defense 3-D (USA, Europe) (v4.4)"
-	users 1
-	rom ( crc E79BB689 )
-)
-
-game (
-	comment "[BIOS] Hang On (USA, Europe) (v3.4)"
-	users 1
-	rom ( crc 8EDF7AC6 )
-)
-
-game (
-	comment "[BIOS] Sega Master System (USA) (M404) (Proto)"
-	users 1
-	rom ( crc 1A15DFCC )
-)
-
-game (
-	comment "[BIOS] Sega Master System (USA) (v1.0) (Proto)"
-	users 1
-	rom ( crc 72BEC693 )
-)
-
-game (
-	comment "[BIOS] Sega Master System (USA, Europe) (v1.3)"
-	users 1
-	rom ( crc 0072ED54 )
-)
-
-game (
-	comment "[BIOS] Sega Master System (USA) (Store Display Unit)"
-	users 1
-	rom ( crc EE2C29BA )
-)
-
-game (
 	comment "20 em 1 (Brazil)"
 	users 1
 	rom ( crc F0F35C22 )

--- a/metadat/maxusers/Sega - SG-1000.dat
+++ b/metadat/maxusers/Sega - SG-1000.dat
@@ -322,30 +322,6 @@ game (
 )
 
 game (
-	comment "Chuugaku Hisshuu Eibunpou - Chuugaku 1-Nen (Japan) (SC-3000) (Program)"
-	users 1
-	rom ( crc 345C8BC8 )
-)
-
-game (
-	comment "Chuugaku Hisshuu Eisakubun - Chuugaku 1-Nen (Japan) (SC-3000) (Program)"
-	users 1
-	rom ( crc 9BAFD9E9 )
-)
-
-game (
-	comment "Chuugaku Hisshuu Eisakubun - Chuugaku 1-Nen (Japan) (SC-3000) (Program) (Alt)"
-	users 1
-	rom ( crc 9BAFD9E9 )
-)
-
-game (
-	comment "Chuugaku Hisshuu Eitango - Chuugaku 1-Nen (Japan) (SC-3000) (Program)"
-	users 1
-	rom ( crc 6CCB297A )
-)
-
-game (
 	comment "Circus Charlie (Taiwan) (Unl)"
 	users 2
 	rom ( crc 7F7F009D )
@@ -580,12 +556,6 @@ game (
 )
 
 game (
-	comment "Home BASIC (Japan) (SC-3000) (Program)"
-	users 1
-	rom ( crc 78A37CBC )
-)
-
-game (
 	comment "Home Mahjong (Japan) (Rev 1)"
 	users 2
 	rom ( crc E7E0F0E3 )
@@ -637,12 +607,6 @@ game (
 	comment "Hyper Sports 2 (Taiwan) (Unl)"
 	users 1
 	rom ( crc B0234E12 )
-)
-
-game (
-	comment "Kagaku (Gensokigou Master) (Japan) (SC-3000) (Program)"
-	users 1
-	rom ( crc F9C81FE1 )
 )
 
 game (
@@ -742,12 +706,6 @@ game (
 )
 
 game (
-	comment "Music Editor (Japan) (SC-3000) (Program)"
-	users 1
-	rom ( crc 2EC28526 )
-)
-
-game (
 	comment "N-Sub (Taiwan) (Unl)"
 	users 2
 	rom ( crc CF1BF7E1 )
@@ -763,12 +721,6 @@ game (
 	comment "N-Sub (Japan) (Alt)"
 	users 2
 	rom ( crc B377D6E1 )
-)
-
-game (
-	comment "Nihonshi Nenpyou (Japan) (SC-3000) (Program)"
-	users 1
-	rom ( crc 129D6359 )
 )
 
 game (
@@ -1030,12 +982,6 @@ game (
 )
 
 game (
-	comment "Sekaishi Nenpyou (Japan) (SC-3000) (Program)"
-	users 1
-	rom ( crc 3274EE48 )
-)
-
-game (
 	comment "Serizawa Hachidan no Tsumeshougi (Japan)"
 	users 1
 	rom ( crc 545FC9BB )
@@ -1198,21 +1144,9 @@ game (
 )
 
 game (
-	comment "Terebi Oekaki (Japan) (Program)"
-	users 1
-	rom ( crc DD4A661B )
-)
-
-game (
 	comment "TwinBee (Taiwan) (Unl)"
 	users 2
 	rom ( crc C550B4F0 )
-)
-
-game (
-	comment "Uranai Angel Cutie (Japan) (SC-3000) (Program)"
-	users 1
-	rom ( crc AE4F92CF )
 )
 
 game (

--- a/metadat/publisher/Magnavox - Odyssey 2.dat
+++ b/metadat/publisher/Magnavox - Odyssey 2.dat
@@ -34,18 +34,6 @@ game (
 )
 
 game (
-	comment "[BIOS] Magnavox Odyssey2 (USA, Europe)"
-	publisher "Magnavox"
-	rom ( crc 8016A315 )
-)
-
-game (
-	comment "[BIOS] Philips C52 (France)"
-	publisher "Philips Interactive Media"
-	rom ( crc A318E8D6 )
-)
-
-game (
 	comment "Attack of the Timelord (USA)"
 	publisher "Philips Interactive Media"
 	rom ( crc FC5A7F08 )

--- a/metadat/publisher/Microsoft - MSX.dat
+++ b/metadat/publisher/Microsoft - MSX.dat
@@ -940,12 +940,6 @@ game (
 )
 
 game (
-	comment "Cheese (Japan) (Program)"
-	publisher "Nippon Electronics (NEOS)"
-	rom ( crc 325BB241 )
-)
-
-game (
 	comment "Checkers in Tantan Tanuki (Japan)"
 	publisher "Pony Canyon"
 	rom ( crc D2B8C058 )
@@ -1348,12 +1342,6 @@ game (
 )
 
 game (
-	comment "Designer's Pencil, The (Europe) (Program)"
-	publisher "Activision"
-	rom ( crc CE588C20 )
-)
-
-game (
 	comment "Devil's Heaven (Japan)"
 	publisher "Paxon"
 	rom ( crc CE08F27D )
@@ -1540,18 +1528,6 @@ game (
 )
 
 game (
-	comment "Eddy 2 (Japan) (Program) (Alt)"
-	publisher "HAL Laboratory"
-	rom ( crc 141A6300 )
-)
-
-game (
-	comment "Eddy 2 (Japan) (Program)"
-	publisher "HAL Laboratory"
-	rom ( crc 2DE03477 )
-)
-
-game (
 	comment "Elevator Action (Japan)"
 	publisher "Nidecom"
 	rom ( crc 39886593 )
@@ -1684,21 +1660,9 @@ game (
 )
 
 game (
-	comment "Family Automation Language Community (Japan) (Program)"
-	publisher "ASCII Corporation"
-	rom ( crc FD8A5C1D )
-)
-
-game (
 	comment "Fantasy Zone (Japan)"
 	publisher "Pony Canyon"
 	rom ( crc 3E96D005 )
-)
-
-game (
-	comment "Farm Kit (Europe) (Program)"
-	publisher "Sony"
-	rom ( crc 83E1AA1A )
 )
 
 game (
@@ -2668,12 +2632,6 @@ game (
 )
 
 game (
-	comment "Keiba, The (Japan) (Program)"
-	publisher "Champion Soft"
-	rom ( crc DF958ED5 )
-)
-
-game (
 	comment "Keystone Kapers (Japan)"
 	publisher "Pony Canyon"
 	rom ( crc 7FF117F9 )
@@ -2935,12 +2893,6 @@ game (
 	comment "Konami's Soccer (Japan) (Alt 2)"
 	publisher "Konami"
 	rom ( crc E861D2BD )
-)
-
-game (
-	comment "Konami's Synthesizer (Japan) (Program)"
-	publisher "Konami"
-	rom ( crc B9B0999A )
 )
 
 game (
@@ -3508,18 +3460,6 @@ game (
 )
 
 game (
-	comment "MSX Basic-kun (Japan) (Program)"
-	publisher "ASCII Corporation"
-	rom ( crc 0EA62A4D )
-)
-
-game (
-	comment "MSX Bunsetsu Henkan Jisyo (Japan) (Program)"
-	publisher "National"
-	rom ( crc 381B3431 )
-)
-
-game (
 	comment "MSX Rugby (Japan)"
 	publisher "Panasonic"
 	rom ( crc 61B33748 )
@@ -3541,18 +3481,6 @@ game (
 	comment "MSX Soccer (Japan)"
 	publisher "Panasonic"
 	rom ( crc 6824E45D )
-)
-
-game (
-	comment "MSX-Aid (Japan) (Program)"
-	publisher "ASCII Corporation"
-	rom ( crc A7C4AC70 )
-)
-
-game (
-	comment "MSX-Logo (Netherlands) (Program)"
-	publisher "Philips Interactive Media"
-	rom ( crc 7AF0AA39 )
 )
 
 game (
@@ -3607,12 +3535,6 @@ game (
 	comment "Nemesis 3 - The Eve of Destruction (Japan, Europe) (En)"
 	publisher "Konami"
 	rom ( crc 4B61AE91 )
-)
-
-game (
-	comment "New Horizon - English Course 1 (Japan) (Program)"
-	publisher "Sony"
-	rom ( crc 85D47F39 )
 )
 
 game (
@@ -3769,12 +3691,6 @@ game (
 	comment "Parodius (Japan) (Wii U Virtual Console)"
 	publisher "Konami"
 	rom ( crc 9BB308F5 )
-)
-
-game (
-	comment "Pasokon Sakkyokuka (Japan) (Program)"
-	publisher "Rittor Music - MCS"
-	rom ( crc E74B7943 )
 )
 
 game (
@@ -3985,12 +3901,6 @@ game (
 	comment "Professional Baseball (Japan)"
 	publisher "Tecnopolis Soft"
 	rom ( crc 8CA4CD58 )
-)
-
-game (
-	comment "Psychedelia (Europe) (Program)"
-	publisher "Aackosoft"
-	rom ( crc 9D89337A )
 )
 
 game (
@@ -4357,12 +4267,6 @@ game (
 	comment "Shout Match (Japan)"
 	publisher "Victor Entertainment"
 	rom ( crc 729D2540 )
-)
-
-game (
-	comment "Simple ASM 1.0 (Japan) (Program)"
-	publisher "Coral"
-	rom ( crc 2D46778A )
 )
 
 game (
@@ -4738,12 +4642,6 @@ game (
 )
 
 game (
-	comment "Super Synth (Japan) (Program) (Alt)"
-	publisher "JVC"
-	rom ( crc 31729CD0 )
-)
-
-game (
 	comment "Super Tennis (Japan)"
 	publisher "Sony"
 	rom ( crc D560D9C0 )
@@ -4753,12 +4651,6 @@ game (
 	comment "Super Tripper (Spain)"
 	publisher "Indescomp"
 	rom ( crc 0C36F5BD )
-)
-
-game (
-	comment "Super Synth (Japan) (Program)"
-	publisher "JVC"
-	rom ( crc 168832A2 )
 )
 
 game (
@@ -5293,12 +5185,6 @@ game (
 	comment "Zenji (Japan)"
 	publisher "Pony Canyon"
 	rom ( crc 77B3B0B9 )
-)
-
-game (
-	comment "Zen (Europe) (Program)"
-	publisher "Kuma Computers"
-	rom ( crc 95E3C098 )
 )
 
 game (

--- a/metadat/publisher/Sega - Master System - Mark III.dat
+++ b/metadat/publisher/Sega - Master System - Mark III.dat
@@ -4,54 +4,6 @@ clrmamepro (
 )
 
 game (
-	comment "[BIOS] Sega Master System (Japan) (v2.1)"
-	publisher "SEGA"
-	rom ( crc 48D44A13 )
-)
-
-game (
-	comment "[BIOS] Hang On & Safari Hunt (USA, Europe, Brazil) (En) (v2.4)"
-	publisher "SEGA"
-	rom ( crc 91E93385 )
-)
-
-game (
-	comment "[BIOS] Missile Defense 3-D (USA, Europe) (v4.4)"
-	publisher "SEGA"
-	rom ( crc E79BB689 )
-)
-
-game (
-	comment "[BIOS] Hang On (USA, Europe) (v3.4)"
-	publisher "SEGA"
-	rom ( crc 8EDF7AC6 )
-)
-
-game (
-	comment "[BIOS] Sega Master System (USA) (M404) (Proto)"
-	publisher "SEGA"
-	rom ( crc 1A15DFCC )
-)
-
-game (
-	comment "[BIOS] Sega Master System (USA) (v1.0) (Proto)"
-	publisher "SEGA"
-	rom ( crc 72BEC693 )
-)
-
-game (
-	comment "[BIOS] Sega Master System (USA, Europe) (v1.3)"
-	publisher "SEGA"
-	rom ( crc 0072ED54 )
-)
-
-game (
-	comment "[BIOS] Sega Master System (USA) (Store Display Unit)"
-	publisher "SEGA"
-	rom ( crc EE2C29BA )
-)
-
-game (
 	comment "20 em 1 (Brazil)"
 	publisher "Tec Toy"
 	rom ( crc F0F35C22 )

--- a/metadat/publisher/Sega - Mega Drive - Genesis.dat
+++ b/metadat/publisher/Sega - Mega Drive - Genesis.dat
@@ -4,168 +4,6 @@ clrmamepro (
 )
 
 game (
-	comment "[BIOS] LaserActive (Japan) (v1.05)"
-	publisher "SEGA"
-	rom ( crc 474AAA44 )
-)
-
-game (
-	comment "[BIOS] Mega-CD (Japan) (Rev E)"
-	publisher "SEGA"
-	rom ( crc 9D2DA8F2 )
-)
-
-game (
-	comment "[BIOS] LaserActive (USA) (v1.04)"
-	publisher "SEGA"
-	rom ( crc 50CD3D23 )
-)
-
-game (
-	comment "[BIOS] Mega-CD (Europe) (v1.00)"
-	publisher "SEGA"
-	rom ( crc 529AC15A )
-)
-
-game (
-	comment "[BIOS] LaserActive (USA) (v1.02)"
-	publisher "SEGA"
-	rom ( crc 3B10CF41 )
-)
-
-game (
-	comment "[BIOS] Aiwa CSD-GM1 (Japan)"
-	publisher "SEGA"
-	rom ( crc 8052C7A0 )
-)
-
-game (
-	comment "[BIOS] LaserActive (Japan) (v1.02)"
-	publisher "SEGA"
-	rom ( crc 00EEDB3A )
-)
-
-game (
-	comment "[BIOS] Mega-CD (Asia) (Ja) (Rev H)"
-	publisher "SEGA"
-	rom ( crc 550F30BB )
-)
-
-game (
-	comment "[BIOS] Mega-CD (Japan) (Rev C)"
-	publisher "SEGA"
-	rom ( crc F18DDE5B )
-)
-
-game (
-	comment "[BIOS] Mega-CD (Japan) (Rev D)"
-	publisher "SEGA"
-	rom ( crc 2EA250C0 )
-)
-
-game (
-	comment "[BIOS] Mega-CD (Japan) (v1.11B)"
-	publisher "SEGA"
-	rom ( crc 4BE18FF6 )
-)
-
-game (
-	comment "[BIOS] Mega-CD (Japan) (Rev A)"
-	publisher "SEGA"
-	rom ( crc C49D3663 )
-)
-
-game (
-	comment "[BIOS] Mega-CD (Japan) (Rev B)"
-	publisher "SEGA"
-	rom ( crc 9BCE40B2 )
-)
-
-game (
-	comment "[BIOS] Mega-CD (Japan) (Rev H)"
-	publisher "SEGA"
-	rom ( crc 79F85384 )
-)
-
-game (
-	comment "[BIOS] Mega-CD 2 (Europe) (v2.11)"
-	publisher "SEGA"
-	rom ( crc C1AA217F )
-)
-
-game (
-	comment "[BIOS] Mega-CD 2 (Europe)"
-	publisher "SEGA"
-	rom ( crc 0507B590 )
-)
-
-game (
-	comment "[BIOS] Multi-Mega (Europe)"
-	publisher "SEGA"
-	rom ( crc AACB851E )
-)
-
-game (
-	comment "[BIOS] Mega-CD (Japan) (Beta)"
-	publisher "SEGA"
-	rom ( crc 41AF44C4 )
-)
-
-game (
-	comment "[BIOS] Mega-CD 2 (Japan)"
-	publisher "SEGA"
-	rom ( crc DD6CC972 )
-)
-
-game (
-	comment "[BIOS] Sega CD (USA) (v1.00)"
-	publisher "SEGA"
-	rom ( crc E7E3AFE2 )
-)
-
-game (
-	comment "[BIOS] Mega-CD 2 (Europe) (Rev A)"
-	publisher "SEGA"
-	rom ( crc 4D5CB8DA )
-)
-
-game (
-	comment "[BIOS] Sega CD (USA) (Rev B)"
-	publisher "SEGA"
-	rom ( crc C6D10268 )
-)
-
-game (
-	comment "[BIOS] Sega CD 2A (USA)"
-	publisher "SEGA"
-	rom ( crc 2E49D72C )
-)
-
-game (
-	comment "[BIOS] Sega CD 2 (USA) (Rev A)"
-	publisher "SEGA"
-	rom ( crc 9F6F6276 )
-)
-
-game (
-	comment "[BIOS] Sega CD 2 (USA)"
-	publisher "SEGA"
-	rom ( crc 8AF65F58 )
-)
-
-game (
-	comment "[BIOS] Sega CDX (USA)"
-	publisher "SEGA"
-	rom ( crc D48C44B5 )
-)
-
-game (
-	comment "[BIOS] Sega Mega Drive - Genesis Boot ROM (World)"
-	publisher "SEGA"
-	rom ( crc 3F888CF4 )
-)
-
-game (
 	comment "007 Shitou - The Duel (Japan)"
 	publisher "Domark"
 	rom ( crc AEB4B262 )
@@ -2095,18 +1933,6 @@ game (
 	comment "Castlevania - The New Generation (Europe) (Mega Drive Mini)"
 	publisher "Konami"
 	rom ( crc 6A5E58CD )
-)
-
-game (
-	comment "CDX Pro (World) (v1.70) (Program) (Unl) [b]"
-	publisher "SEGA"
-	rom ( crc E7F3A492 )
-)
-
-game (
-	comment "CDX Pro (World) (v1.8I) (Program) (Unl)"
-	publisher "SEGA"
-	rom ( crc 170CA9DA )
 )
 
 game (
@@ -4756,18 +4582,6 @@ game (
 )
 
 game (
-	comment "Flux (Europe) (Program)"
-	publisher "Virgin"
-	rom ( crc 2A1DA08C )
-)
-
-game (
-	comment "Flux (Europe) (Beta) (Program)"
-	publisher "Virgin"
-	rom ( crc 0BA20EE0 )
-)
-
-game (
 	comment "Foreman for Real (World)"
 	publisher "Acclaim"
 	rom ( crc BA6EAECA )
@@ -4969,12 +4783,6 @@ game (
 	comment "Garfield - Caught in the Act (USA, Europe)"
 	publisher "SEGA"
 	rom ( crc F0FF078E )
-)
-
-game (
-	comment "Game Toshokan (Japan) (Rev A) (Program)"
-	publisher "SEGA"
-	rom ( crc C185C819 )
 )
 
 game (
@@ -7231,12 +7039,6 @@ game (
 	comment "Medal City (Japan) (SegaNet)"
 	publisher "SEGA"
 	rom ( crc 3EF4135D )
-)
-
-game (
-	comment "Mega Anser (Japan) (Program)"
-	publisher "SEGA"
-	rom ( crc 08ECE367 )
 )
 
 game (
@@ -14557,12 +14359,6 @@ game (
 	comment "Wonder Boy V - Monster World III (Japan, Korea) (Ja)"
 	publisher "SEGA"
 	rom ( crc 45A50F96 )
-)
-
-game (
-	comment "Wonder Library (Japan) (Program)"
-	publisher "Victor Entertainment"
-	rom ( crc 9350E754 )
 )
 
 game (

--- a/metadat/publisher/Sega - SG-1000.dat
+++ b/metadat/publisher/Sega - SG-1000.dat
@@ -322,30 +322,6 @@ game (
 )
 
 game (
-	comment "Chuugaku Hisshuu Eibunpou - Chuugaku 1-Nen (Japan) (SC-3000) (Program)"
-	publisher "SEGA"
-	rom ( crc 345C8BC8 )
-)
-
-game (
-	comment "Chuugaku Hisshuu Eisakubun - Chuugaku 1-Nen (Japan) (SC-3000) (Program)"
-	publisher "SEGA"
-	rom ( crc 9BAFD9E9 )
-)
-
-game (
-	comment "Chuugaku Hisshuu Eisakubun - Chuugaku 1-Nen (Japan) (SC-3000) (Program) (Alt)"
-	publisher "SEGA"
-	rom ( crc 9BAFD9E9 )
-)
-
-game (
-	comment "Chuugaku Hisshuu Eitango - Chuugaku 1-Nen (Japan) (SC-3000) (Program)"
-	publisher "SEGA"
-	rom ( crc 6CCB297A )
-)
-
-game (
 	comment "Circus Charlie (Taiwan) (Unl)"
 	publisher "Aaronix"
 	rom ( crc 7F7F009D )
@@ -580,12 +556,6 @@ game (
 )
 
 game (
-	comment "Home BASIC (Japan) (SC-3000) (Program)"
-	publisher "SEGA"
-	rom ( crc 78A37CBC )
-)
-
-game (
 	comment "Home Mahjong (Japan) (Rev 1)"
 	publisher "SEGA"
 	rom ( crc E7E0F0E3 )
@@ -637,12 +607,6 @@ game (
 	comment "Hyper Sports 2 (Taiwan) (Unl)"
 	publisher "Aaronix"
 	rom ( crc B0234E12 )
-)
-
-game (
-	comment "Kagaku (Gensokigou Master) (Japan) (SC-3000) (Program)"
-	publisher "SEGA"
-	rom ( crc F9C81FE1 )
 )
 
 game (
@@ -742,12 +706,6 @@ game (
 )
 
 game (
-	comment "Music Editor (Japan) (SC-3000) (Program)"
-	publisher "SEGA"
-	rom ( crc 2EC28526 )
-)
-
-game (
 	comment "N-Sub (Taiwan) (Unl)"
 	publisher "SEGA"
 	rom ( crc CF1BF7E1 )
@@ -763,12 +721,6 @@ game (
 	comment "N-Sub (Japan) (Alt)"
 	publisher "SEGA"
 	rom ( crc B377D6E1 )
-)
-
-game (
-	comment "Nihonshi Nenpyou (Japan) (SC-3000) (Program)"
-	publisher "SEGA"
-	rom ( crc 129D6359 )
 )
 
 game (
@@ -1030,12 +982,6 @@ game (
 )
 
 game (
-	comment "Sekaishi Nenpyou (Japan) (SC-3000) (Program)"
-	publisher "SEGA"
-	rom ( crc 3274EE48 )
-)
-
-game (
 	comment "Serizawa Hachidan no Tsumeshougi (Japan)"
 	publisher "SEGA"
 	rom ( crc 545FC9BB )
@@ -1192,27 +1138,9 @@ game (
 )
 
 game (
-	comment "Tanoshii Sansuu - Shougaku 4-Nen Ge (Japan) (SC-3000) (Program)"
-	publisher "SEGA"
-	rom ( crc 5FDE25BB )
-)
-
-game (
-	comment "Terebi Oekaki (Japan) (Program)"
-	publisher "SEGA"
-	rom ( crc DD4A661B )
-)
-
-game (
 	comment "TwinBee (Taiwan) (Unl)"
 	publisher "Jumbo Team"
 	rom ( crc C550B4F0 )
-)
-
-game (
-	comment "Uranai Angel Cutie (Japan) (SC-3000) (Program)"
-	publisher "SEGA"
-	rom ( crc AE4F92CF )
 )
 
 game (

--- a/metadat/releasemonth/Sega - Mega Drive - Genesis.dat
+++ b/metadat/releasemonth/Sega - Mega Drive - Genesis.dat
@@ -1792,18 +1792,6 @@ game (
 )
 
 game (
-	comment "Flux (Europe) (Program)"
-	releasemonth "8"
-	rom ( crc 2A1DA08C )
-)
-
-game (
-	comment "Flux (Europe) (Beta) (Program)"
-	releasemonth "8"
-	rom ( crc 0BA20EE0 )
-)
-
-game (
 	comment "Formula One (USA)"
 	releasemonth "11"
 	rom ( crc CCD73738 )

--- a/metadat/releaseyear/Microsoft - MSX.dat
+++ b/metadat/releaseyear/Microsoft - MSX.dat
@@ -796,12 +796,6 @@ game (
 )
 
 game (
-	comment "Cheese (Japan) (Program)"
-	releaseyear "1984"
-	rom ( crc 325BB241 )
-)
-
-game (
 	comment "Checkers in Tantan Tanuki (Japan)"
 	releaseyear "1985"
 	rom ( crc D2B8C058 )
@@ -1144,12 +1138,6 @@ game (
 )
 
 game (
-	comment "Designer's Pencil, The (Europe) (Program)"
-	releaseyear "1984"
-	rom ( crc CE588C20 )
-)
-
-game (
 	comment "Devil's Heaven (Japan)"
 	releaseyear "1984"
 	rom ( crc CE08F27D )
@@ -1324,18 +1312,6 @@ game (
 )
 
 game (
-	comment "Eddy 2 (Japan) (Program) (Alt)"
-	releaseyear "1984"
-	rom ( crc 141A6300 )
-)
-
-game (
-	comment "Eddy 2 (Japan) (Program)"
-	releaseyear "1984"
-	rom ( crc 2DE03477 )
-)
-
-game (
 	comment "Elevator Action (Japan)"
 	releaseyear "1985"
 	rom ( crc 39886593 )
@@ -1468,21 +1444,9 @@ game (
 )
 
 game (
-	comment "Family Automation Language Community (Japan) (Program)"
-	releaseyear "1985"
-	rom ( crc FD8A5C1D )
-)
-
-game (
 	comment "Fantasy Zone (Japan)"
 	releaseyear "1986"
 	rom ( crc 3E96D005 )
-)
-
-game (
-	comment "Farm Kit (Europe) (Program)"
-	releaseyear "1986"
-	rom ( crc 83E1AA1A )
 )
 
 game (
@@ -2356,12 +2320,6 @@ game (
 )
 
 game (
-	comment "Keiba, The (Japan) (Program)"
-	releaseyear "1986"
-	rom ( crc DF958ED5 )
-)
-
-game (
 	comment "Keystone Kapers (Japan)"
 	releaseyear "1984"
 	rom ( crc 7FF117F9 )
@@ -3028,18 +2986,6 @@ game (
 )
 
 game (
-	comment "MSX Basic-kun (Japan) (Program)"
-	releaseyear "1986"
-	rom ( crc 0EA62A4D )
-)
-
-game (
-	comment "MSX Bunsetsu Henkan Jisyo (Japan) (Program)"
-	releaseyear "1985"
-	rom ( crc 381B3431 )
-)
-
-game (
 	comment "MSX Rugby (Japan)"
 	releaseyear "1985"
 	rom ( crc 61B33748 )
@@ -3073,12 +3019,6 @@ game (
 	comment "Nausicaa (Japan)"
 	releaseyear "1984"
 	rom ( crc E84994F7 )
-)
-
-game (
-	comment "New Horizon - English Course 1 (Japan) (Program)"
-	releaseyear "1985"
-	rom ( crc 85D47F39 )
 )
 
 game (
@@ -3241,12 +3181,6 @@ game (
 	comment "Parodius (Japan) (Wii U Virtual Console)"
 	releaseyear "1988"
 	rom ( crc 9BB308F5 )
-)
-
-game (
-	comment "Pasokon Sakkyokuka (Japan) (Program)"
-	releaseyear "1983"
-	rom ( crc E74B7943 )
 )
 
 game (
@@ -3439,12 +3373,6 @@ game (
 	comment "Professional Mahjong (Japan)"
 	releaseyear "1985"
 	rom ( crc F1EC5E18 )
-)
-
-game (
-	comment "Psychedelia (Europe) (Program)"
-	releaseyear "1984"
-	rom ( crc 9D89337A )
 )
 
 game (
@@ -4090,21 +4018,9 @@ game (
 )
 
 game (
-	comment "Super Synth (Japan) (Program) (Alt)"
-	releaseyear "1984"
-	rom ( crc 31729CD0 )
-)
-
-game (
 	comment "Super Tripper (Spain)"
 	releaseyear "1985"
 	rom ( crc 0C36F5BD )
-)
-
-game (
-	comment "Super Synth (Japan) (Program)"
-	releaseyear "1984"
-	rom ( crc 168832A2 )
 )
 
 game (

--- a/metadat/releaseyear/Sega - Mega Drive - Genesis.dat
+++ b/metadat/releaseyear/Sega - Mega Drive - Genesis.dat
@@ -4,72 +4,6 @@ clrmamepro (
 )
 
 game (
-	comment "[BIOS] LaserActive (Japan) (v1.05)"
-	releaseyear "1991"
-	rom ( crc 474AAA44 )
-)
-
-game (
-	comment "[BIOS] Mega-CD (Japan) (Rev E)"
-	releaseyear "1991"
-	rom ( crc 9D2DA8F2 )
-)
-
-game (
-	comment "[BIOS] Aiwa CSD-GM1 (Japan)"
-	releaseyear "1991"
-	rom ( crc 8052C7A0 )
-)
-
-game (
-	comment "[BIOS] Mega-CD (Japan) (Rev C)"
-	releaseyear "1991"
-	rom ( crc F18DDE5B )
-)
-
-game (
-	comment "[BIOS] Mega-CD (Japan) (Rev D)"
-	releaseyear "1991"
-	rom ( crc 2EA250C0 )
-)
-
-game (
-	comment "[BIOS] Mega-CD (Japan) (v1.11B)"
-	releaseyear "1991"
-	rom ( crc 4BE18FF6 )
-)
-
-game (
-	comment "[BIOS] Mega-CD (Japan) (Rev A)"
-	releaseyear "1991"
-	rom ( crc C49D3663 )
-)
-
-game (
-	comment "[BIOS] Mega-CD (Japan) (Rev B)"
-	releaseyear "1991"
-	rom ( crc 9BCE40B2 )
-)
-
-game (
-	comment "[BIOS] Mega-CD (Japan) (Rev H)"
-	releaseyear "1991"
-	rom ( crc 79F85384 )
-)
-
-game (
-	comment "[BIOS] Mega-CD (Japan) (Beta)"
-	releaseyear "1991"
-	rom ( crc 41AF44C4 )
-)
-
-game (
-	comment "[BIOS] Mega-CD 2 (Japan)"
-	releaseyear "1991"
-	rom ( crc DD6CC972 )
-)
-
-game (
 	comment "007 Shitou - The Duel (Japan)"
 	releaseyear "1993"
 	rom ( crc AEB4B262 )
@@ -3124,18 +3058,6 @@ game (
 )
 
 game (
-	comment "Flux (Europe) (Program)"
-	releaseyear "1995"
-	rom ( crc 2A1DA08C )
-)
-
-game (
-	comment "Flux (Europe) (Beta) (Program)"
-	releaseyear "1995"
-	rom ( crc 0BA20EE0 )
-)
-
-game (
 	comment "Formula One (USA)"
 	releaseyear "1993"
 	rom ( crc CCD73738 )
@@ -3211,12 +3133,6 @@ game (
 	comment "Gambler Jiko Chuushinha - Katayama Masayuki no Mahjong Doujou (Japan)"
 	releaseyear "1990"
 	rom ( crc 05650B7A )
-)
-
-game (
-	comment "Game Toshokan (Japan) (Rev A) (Program)"
-	releaseyear "1991"
-	rom ( crc C185C819 )
 )
 
 game (
@@ -4711,12 +4627,6 @@ game (
 	comment "Medal City (Japan) (SegaNet)"
 	releaseyear "1991"
 	rom ( crc 3EF4135D )
-)
-
-game (
-	comment "Mega Anser (Japan) (Program)"
-	releaseyear "1990"
-	rom ( crc 08ECE367 )
 )
 
 game (
@@ -9763,12 +9673,6 @@ game (
 	comment "Wolfchild (USA)"
 	releaseyear "1993"
 	rom ( crc EB5B1CBF )
-)
-
-game (
-	comment "Wonder Library (Japan) (Program)"
-	releaseyear "1993"
-	rom ( crc 9350E754 )
 )
 
 game (

--- a/metadat/releaseyear/Sega - SG-1000.dat
+++ b/metadat/releaseyear/Sega - SG-1000.dat
@@ -238,30 +238,6 @@ game (
 )
 
 game (
-	comment "Chuugaku Hisshuu Eibunpou - Chuugaku 1-Nen (Japan) (SC-3000) (Program)"
-	releaseyear "1983"
-	rom ( crc 345C8BC8 )
-)
-
-game (
-	comment "Chuugaku Hisshuu Eisakubun - Chuugaku 1-Nen (Japan) (SC-3000) (Program)"
-	releaseyear "1983"
-	rom ( crc 9BAFD9E9 )
-)
-
-game (
-	comment "Chuugaku Hisshuu Eisakubun - Chuugaku 1-Nen (Japan) (SC-3000) (Program) (Alt)"
-	releaseyear "1983"
-	rom ( crc 9BAFD9E9 )
-)
-
-game (
-	comment "Chuugaku Hisshuu Eitango - Chuugaku 1-Nen (Japan) (SC-3000) (Program)"
-	releaseyear "1983"
-	rom ( crc 6CCB297A )
-)
-
-game (
 	comment "Circus Charlie (Taiwan) (Unl)"
 	releaseyear "1984"
 	rom ( crc 7F7F009D )
@@ -484,12 +460,6 @@ game (
 )
 
 game (
-	comment "Kagaku (Gensokigou Master) (Japan) (SC-3000) (Program)"
-	releaseyear "1983"
-	rom ( crc F9C81FE1 )
-)
-
-game (
 	comment "King's Valley (Taiwan) (Unl)"
 	releaseyear "1984"
 	rom ( crc 223397A1 )
@@ -544,12 +514,6 @@ game (
 )
 
 game (
-	comment "Music Editor (Japan) (SC-3000) (Program)"
-	releaseyear "1983"
-	rom ( crc 2EC28526 )
-)
-
-game (
 	comment "N-Sub (Taiwan) (Unl)"
 	releaseyear "1983"
 	rom ( crc CF1BF7E1 )
@@ -565,12 +529,6 @@ game (
 	comment "N-Sub (Japan) (Alt)"
 	releaseyear "1983"
 	rom ( crc B377D6E1 )
-)
-
-game (
-	comment "Nihonshi Nenpyou (Japan) (SC-3000) (Program)"
-	releaseyear "1983"
-	rom ( crc 129D6359 )
 )
 
 game (
@@ -688,12 +646,6 @@ game (
 )
 
 game (
-	comment "Sekaishi Nenpyou (Japan) (SC-3000) (Program)"
-	releaseyear "1983"
-	rom ( crc 3274EE48 )
-)
-
-game (
 	comment "Serizawa Hachidan no Tsumeshougi (Japan)"
 	releaseyear "1983"
 	rom ( crc 545FC9BB )
@@ -805,18 +757,6 @@ game (
 	comment "Super Tank (Korea) (Unl)"
 	releaseyear "1986"
 	rom ( crc ACFE1BEA )
-)
-
-game (
-	comment "Terebi Oekaki (Japan) (Program)"
-	releaseyear "1986"
-	rom ( crc DD4A661B )
-)
-
-game (
-	comment "Uranai Angel Cutie (Japan) (SC-3000) (Program)"
-	releaseyear "1984"
-	rom ( crc AE4F92CF )
 )
 
 game (


### PR DESCRIPTION
Remove more BIOS and program entries from DATs. These entries were filtered out by logic in libretro-dats but still included in the final RDB due to the merge process. Confirmed they all had missing names and description fields in the RDB as a result.

There's still a lot more invalid entries for bad dumps and demos. I removed the ones in this PR manually but probably a tool that can filter and rewrite files would be needed to remove the bad or demo entries en masse.

Related to https://github.com/RobLoach/libretro-dats/issues/93