### PR TITLE
Create franchise .dat for Nintendo DS

### DIFF
--- a/metadat/franchise/Nintendo - Nintendo DS.dat
+++ b/metadat/franchise/Nintendo - Nintendo DS.dat
@@ -1,16 +1,16 @@
 clrmamepro (
-	name “Nintendo - Nintendo DS”
-	description “Nintendo - Nintendo DS”
+	name "Nintendo - Nintendo DS"
+	description "Nintendo - Nintendo DS"
 )
 
 game (
-	comment “Assassin's Creed - Altair's Chronicles (Europe) (En,Fr,De,Es,It)”
-	rom ( serial “YAHP” )
-	franchise “Assassin’s Creed”
+	comment "Assassin's Creed - Altair's Chronicles (Europe) (En,Fr,De,Es,It)"
+	rom ( serial "YAHP" )
+	franchise "Assassin's Creed"
 )
 
 game (
-	comment “Assassin's Creed - Altair's Chronicles (USA) (En,Fr,Es)”
-	rom ( serial “YAHE” )
-	franchise “Assassin’s Creed”
+	comment "Assassin's Creed - Altair's Chronicles (USA) (En,Fr,Es)"
+	rom ( serial "YAHE" )
+	franchise "Assassin's Creed"
 )

--- a/metadat/franchise/Nintendo - Nintendo DS.dat
+++ b/metadat/franchise/Nintendo - Nintendo DS.dat
@@ -1,0 +1,16 @@
+clrmamepro (
+	name “Nintendo - Nintendo DS”
+	description “Nintendo - Nintendo DS”
+)
+
+game (
+	comment “Assassin's Creed - Altair's Chronicles (Europe) (En,Fr,De,Es,It)”
+	rom ( serial “YAHP” )
+	franchise “Assassin’s Creed”
+)
+
+game (
+	comment “Assassin's Creed - Altair's Chronicles (USA) (En,Fr,Es)”
+	rom ( serial “YAHE” )
+	franchise “Assassin’s Creed”
+)


### PR DESCRIPTION
Create Nintendo - Nintendo DS.dat in Franchise.

Added Assassin’s Creed - Altair’s Chronicles to the Assassin’s Creed franchise.