### PR TITLE
Update hashes for Dinothawr.zip

### DIFF
--- a/dat/System.dat
+++ b/dat/System.dat
@@ -91,7 +91,7 @@ game (
 	rom ( name JiffyDOS_1581.bin md5 20b6885c6dc2d42c38754a365b043d71 )
 
 	comment "Dinothawr"
-	rom ( name Dinothawr.zip size 5763199 crc fa7c2f65 md5 308eaf202d4c8105c6bfd99412e3ac8c sha1 6796b8f0c8a41be28d3ef27cba808c29e1a7aadb )
+	rom ( name Dinothawr.zip size 5763199 crc 683ed4ad md5 a2e891e330d146c4046c2b622fc31462 sha1 693d8bb4d992c645e6413a57195acf4eca2f5a2e )
 
 	comment "DOS"
 	rom ( name MT32_CONTROL.ROM md5 5626206284b22c2734f3e9efefcd2675 )


### PR DESCRIPTION
Updates the hashes for Dinothawr.zip to match the current https://buildbot.libretro.com/assets/system/Dinothawr.zip