### PR TITLE
Update Super Mario All-Stars (USA).cht: Udated description for cheat code D5D4-F36D

### DIFF
--- a/cht/Nintendo - Super Nintendo Entertainment System/Super Mario All-Stars (USA).cht
+++ b/cht/Nintendo - Super Nintendo Entertainment System/Super Mario All-Stars (USA).cht
@@ -112,7 +112,7 @@ cheat27_desc = "Jumping in place charges super jump"
 cheat27_code = "7A60-A966"
 cheat27_enable = false
 
-cheat28_desc = "Select any world for FILE A game [Doesn't work on World 8]"
+cheat28_desc = "Select any world for FILE A game [Not usable for World 8: the two Hand Trap levels, which must be completed to unlock the pipe to Bowser’s Castle, are missing because the cheat code removes them, so no levels at all can be played]"
 cheat28_code = "D5D4-F36D"
 cheat28_enable = false
 


### PR DESCRIPTION
Clarified World 8 limitation—specified that the two Hand Trap levels required to unlock the pipe to Bowser’s Castle are missing, making all levels unplayable. Included a detailed explanation despite the length, as RetroArch’s Text Scrolling feature ensures the full message remains readable.