### PR TITLE
Retroplay WHDLoad update

### DIFF
--- a/dat/Commodore - Amiga.dat
+++ b/dat/Commodore - Amiga.dat
@@ -1,8 +1,8 @@
 clrmamepro (
 	name "Commodore - Amiga - WHDLoad"
-	date "2023-02-13"
+	date "2025-05-19"
 	author "libretro"
-	comment "Retroplay"
+	comment "Retroplay WHDLoad Games full set"
 )
 
 game (
@@ -11,7 +11,7 @@ game (
 )
 
 game (
-	name "1000 Miglia - 1927-1933 Volume 1 (Europe)"
+	name "1000 Miglia - 1927-1933 Volume 1 (Europe) (En,It)"
 	rom ( name "1000Miglia_v1.2.lha" size 779415 crc 754B8A10 sha1 2a82b5f47c00de451ea14ca9fe82880a79c08a7f )
 )
 
@@ -21,7 +21,7 @@ game (
 )
 
 game (
-	name "1869 - History Experience Part I (Germany) (AGA)"
+	name "1869 - Erlebte Geschichte Teil I (Germany) (AGA)"
 	rom ( name "1869_v1.0_De_AGA_1653.lha" size 1841278 crc 47BD143D sha1 92c9eb7c945bfb2bec87cd637c32a2e53baf3b27 )
 )
 
@@ -31,7 +31,7 @@ game (
 )
 
 game (
-	name "1869 - History Experience Part I (Germany)"
+	name "1869 - Erlebte Geschichte Teil I (Germany)"
 	rom ( name "1869_v1.2_De_0417.lha" size 1347664 crc B9E2FB36 sha1 5eb989b3be6318870d956b045b72e5618cd62bd6 )
 )
 
@@ -61,27 +61,27 @@ game (
 )
 
 game (
-	name "20 000 Leagues Under the Sea (France)"
+	name "20 000 Lieues Sous Les Mers (France)"
 	rom ( name "20000LieuesSousLesMers_v1.1_Fr.lha" size 486360 crc 081FBE4A sha1 2a713beed4ca9b411dfe73b5760518141f76a9dd )
 )
 
 game (
-	name "20 000 Leagues Under the Sea (Netherlands)"
+	name "20 000 Lieues Sous Les Mers (Netherlands)"
 	rom ( name "20000LieuesSousLesMers_v1.1_Nl.lha" size 484015 crc DCC47656 sha1 bdf9a00671611e5031f8991d4ea6d62303dafdcb )
 )
 
 game (
-	name "20 000 Leagues Under the Sea (Germany)"
+	name "20 000 Meilen Unter Dem Meer (Germany)"
 	rom ( name "20000MeilenUnterDemMeer_v1.1_De.lha" size 470188 crc B7BA4A83 sha1 a9da90c4b61d4ea0724146c7cfe9caebe4e92e1d )
 )
 
 game (
-	name "3001 O'Connor's Fight (Europe)"
+	name "3001 - O'Connor's Fight (Europe)"
 	rom ( name "3001OConnorsFight_v1.0.lha" size 147007 crc EF826734 sha1 7368b9d90a238be01b994603ed02a939cf8e2e00 )
 )
 
 game (
-	name "3D Construction Kit (Europe)"
+	name "3D Construction Kit (Europe) (En,Fr,De,It)"
 	rom ( name "3DConstructionKit_v1.0_1765.lha" size 240329 crc DDC267BC sha1 1f4d185e8d8bb867e0d2093431ebfff7c4fdce26 )
 )
 
@@ -96,17 +96,17 @@ game (
 )
 
 game (
-	name "3D World Boxing (Europe)"
+	name "3D World Boxing (Europe) (En,Fr,De,It)"
 	rom ( name "3DWorldBoxing_v1.0_2223.lha" size 754245 crc 005B0009 sha1 7a2e42df9627baafa7601646287f2553c6a60751 )
 )
 
 game (
-	name "3D World Soccer (Europe)"
+	name "3D World Soccer (Europe) (En,Fr,De,It)"
 	rom ( name "3DWorldSoccer_v1.0.lha" size 1497761 crc 74C1F56D sha1 2b214c26987db5536821988c9fe33c98df3f2762 )
 )
 
 game (
-	name "3D World Tennis (Europe)"
+	name "3D World Tennis (Europe) (En,Fr,De,It)"
 	rom ( name "3DWorldTennis_v1.0_2224.lha" size 631670 crc F08B9446 sha1 59a970dcbbd8074e2d688fe633a477d9a21c9978 )
 )
 
@@ -116,7 +116,7 @@ game (
 )
 
 game (
-	name "4D Sports Driving Master Tracks I (Europe)"
+	name "4D Sports Driving & Master Tracks I (Europe)"
 	rom ( name "4DSportsDriving&MasterTracks_v1.2_1461.lha" size 913143 crc B2071FF4 sha1 f16b9550688e681f892a99db79744a1872e4dba8 )
 )
 
@@ -156,17 +156,37 @@ game (
 )
 
 game (
-	name "A-10 Tank Killer (2 Disk) (Europe)"
+	name "A-10 Tank Killer (Europe) (v1.0)"
 	rom ( name "A10TankKiller_v2.0_2Disk_1396.lha" size 906728 crc 914623D7 sha1 7f19c4e6bef29af991ddc736b4ce63cb941e80b7 )
 )
 
 game (
-	name "A-10 Tank Killer (Europe)"
+	name "A-10 Tank Killer (Europe) (v1.5)"
 	rom ( name "A10TankKiller_v2.0_3Disk.lha" size 1835853 crc FDCAEC68 sha1 e3587869de432f33d4f7eba60b33cec490fabc3c )
 )
 
 game (
-	name "AAARGH! (Arcadia) (Europe)"
+	name "A320 Airbus (Europe)"
+	rom ( name "A320Airbus_v1.3.lha" size 448065 crc 9FF344FE sha1 187679f646d4356e4cd3771dc3273dafb99694f8 )
+)
+
+game (
+	name "A320 Airbus - Edition Europa (Europe)"
+	rom ( name "A320AirbusEditionEuropa_v1.3.lha" size 441936 crc A0D1E5AB sha1 f1154c9ed9ffaba17c193a6e699556c8239f19d8 )
+)
+
+game (
+	name "A320 Airbus - Edition USA (Europe)"
+	rom ( name "A320AirbusEditionUSA_v1.1.lha" size 462230 crc D0E9F7D7 sha1 c591f25f57a0a3f7000a809c257326c9a161285a )
+)
+
+game (
+	name "A320 Airbus Vol. 2 (Europe)"
+	rom ( name "A320AirbusVol2_v1.1_1592.lha" size 503299 crc ABAFFC8A sha1 f9daaacf1e7516e7090b234caa534b1f47a2b086 )
+)
+
+game (
+	name "AAARGH! (Europe) (Arcadia)"
 	rom ( name "Aaargh!_v0.1_Arcadia.lha" size 677038 crc CDD9419E sha1 7ff80d99ff66d5ad6667f7880ac85f0ec7c9b02c )
 )
 
@@ -176,7 +196,7 @@ game (
 )
 
 game (
-	name "Abandoned Places 2 (Europe)"
+	name "Abandoned Places 2 (Europe) (En,De,Fr)"
 	rom ( name "AbandonedPlaces2_v2.0.lha" size 2975982 crc 72D5863F sha1 c060e37208e78e3a783dde8deb5d15552efa19fb )
 )
 
@@ -201,13 +221,13 @@ game (
 )
 
 game (
-	name "Abracadabra (Europe)"
+	name "Abracadabra (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Abracadabra_v1.1_2451.lha" size 943669 crc C041E4AA sha1 34db03ba407961adc1afbda32189f001cf5ca97f )
 )
 
 game (
 	name "Academy - Tau Ceti II (Europe)"
-	rom ( name "Academy_v1.1.lha" size 130112 crc D4E90399 sha1 8b77ee73dc8f5bb5a4bf6cb5ce6f4c97fd2d2268 )
+	rom ( name "Academy_v1.2_2943.lha" size 112318 crc 64FD2BCA sha1 4def8046afea48f7dbb3fca23020f7de00137474 )
 )
 
 game (
@@ -231,8 +251,23 @@ game (
 )
 
 game (
-	name "Addams Family, The (Europe)"
+	name "Action Service (Europe)"
+	rom ( name "ActionService_v1.0_1950.lha" size 262627 crc 466b3313 sha1 a435d9255f41f7cd6c79bc23d5f18dc0fc3757fc )
+)
+
+game (
+	name "Addams Family, The (Europe) (En,Fr,De)"
 	rom ( name "AddamsFamily_v1.3_0419.lha" size 748319 crc 4476D5FB sha1 a54a35018bb1d7928de291f70a0adae7cf94b0a4 )
+)
+
+game (
+	name "Adidas Championship Football (Europe)"
+	rom ( name "AdidasChampionshipFootball_v1.1_Files.lha" size 330296 crc C0814ACC sha1 460b709b556f0feea052a843094cee3af95c3a90 )
+)
+
+game (
+	name "Adidas Championship Football (Europe) (Image)"
+	rom ( name "AdidasChampionshipFootball_v1.1_Image.lha" size 340054 crc 93694DAF sha1 9f26a74e94307e9a0e5407163479e294cb081e8e )
 )
 
 game (
@@ -246,13 +281,18 @@ game (
 )
 
 game (
-	name "Advanced Ski Simulator (Europe)"
-	rom ( name "AdvancedSkiSimulator_v1.1_0094.lha" size 567083 crc 11582336 sha1 e68f8bc7b6b100561b857998484833c0605e37bf )
+	name "Advanced Fruit Machine Simulator (Europe)"
+	rom ( name "AdvancedFruitMachineSimulator_v1.1_0622.lha" size 225312 crc 345B9663 sha1 cc4280f1e431644f282197f2f4950ffdc0664564 )
 )
 
 game (
-	name "Advantage Tennis (Europe)"
-	rom ( name "AdvantageTennis_v1.0.lha" size 588113 crc 88E1F4E9 sha1 d732bfb2179b262721019009d2e2f17096067e32 )
+	name "Advanced Ski Simulator (Europe)"
+	rom ( name "AdvancedSkiSimulator_v2.1_0094.lha" size 566002 crc 52529391 sha1 806d82e8b630397f685221b5e140d20bb047c5ab )
+)
+
+game (
+	name "Advantage Tennis (Europe) (En,Fr,De)"
+	rom ( name "AdvantageTennis_v2.1_2261.lha" size 587868 crc 2F96D3F2 sha1 1889e654a9079ab111ac617b8b86aeb3f1eeec0c )
 )
 
 game (
@@ -261,7 +301,7 @@ game (
 )
 
 game (
-	name "Adventures of Genlock Holmes, The (MicroEd) (Europe)"
+	name "Adventures of Genlock Holmes, The (Europe)"
 	rom ( name "AdventuresOfGenlockHolmes_v1.0.lha" size 241293 crc 0847DE93 sha1 3286724780bf321908057c058755e6b020a284f1 )
 )
 
@@ -271,7 +311,7 @@ game (
 )
 
 game (
-	name "Adventures of Robin Hood, The (Europe)"
+	name "Adventures of Robin Hood, The (Europe) (En,Fr,De,It)"
 	rom ( name "AdventuresOfRobinHood_v1.1.lha" size 781333 crc 6D3D09CD sha1 f85d1b202a50a07e1120a7a1de4cc4c4afc11b03 )
 )
 
@@ -286,13 +326,13 @@ game (
 )
 
 game (
-	name "After Burner (Activision) (Europe)"
+	name "After Burner (Europe) (Activision)"
 	rom ( name "AfterBurner_v1.0_0095.lha" size 834571 crc DD662BF0 sha1 68a17f1a5c0dc029929d14442231ab5dc7b0c414 )
 )
 
 game (
-	name "After Burner (Sega) (USA)"
-	rom ( name "AfterBurner_v1.4_NTSC_0947.lha" size 827315 crc C1288608 sha1 2460c87dbc7b78501230102e6af8cdc9bd8c6a2a )
+	name "After Burner (USA) (Sega)"
+	rom ( name "AfterBurner_v1.4a_NTSC_0947.lha" size 827503 crc C1C8B4C9 sha1 3d2fc301e1001497cf520fd521e6405862a372f9 )
 )
 
 game (
@@ -321,13 +361,18 @@ game (
 )
 
 game (
+	name "Aigle d'Or - Le Retour, L' (France) (512 kB)"
+	rom ( name "AigleDOr_v1.2_512k_Fr_2600.lha" size 1541808 crc 18CA4867 sha1 658f9929cf4662786e610f318c30a2c3f3b9ddbb )
+)
+
+game (
 	name "Aigle d'Or - Le Retour, L' (France)"
-	rom ( name "AigleDOr_v1.1_Fr_2600.lha" size 1563863 crc 55B9AA66 sha1 8c603e8ec30561c6d18d803b52849bc1fb1dbd47 )
+	rom ( name "AigleDOr_v1.2_Fr_2600.lha" size 1541263 crc F41159D6 sha1 dc99927e02e3e63bf88ca9c4612bc69474ec1dd5 )
 )
 
 game (
 	name "Airball (Europe)"
-	rom ( name "Airball_v1.1.lha" size 352166 crc BADBFB9A sha1 64af7bea5cfb9e6d8ecf664728ce2fd418c9da10 )
+	rom ( name "Airball_v1.2_3034.lha" size 358274 crc C1789A9C sha1 1ad58b3abad1ae4b76fe118e1bcf343df7417a7b )
 )
 
 game (
@@ -336,28 +381,53 @@ game (
 )
 
 game (
+	name "Air Supply (Europe)"
+	rom ( name "AirSupply_v1.0.lha" size 598608 crc 75751AA4 sha1 a8e0b5727746beb20b6d55a4c52e95accc9191c2 )
+)
+
+game (
 	name "Air Support (Europe)"
-	rom ( name "AirSupport_v1.1_1320.lha" size 842057 crc 6C4AABFB sha1 2dcba06581bbc9760ff3889d6c9c161fbe241bf7 )
+	rom ( name "AirSupport_v1.2_1320.lha" size 842358 crc 62F0DCF5 sha1 5c6c4d5d297dd43e88529d4b5d3d93e6652c981b )
+)
+
+game (
+	name "Air Support (Europe) (512 kB)"
+	rom ( name "AirSupport_v1.2_512k_1320.lha" size 842423 crc FF64757E sha1 3de6e1c476874c8e53596ecf9acff7ae7f42ea5b )
+)
+
+game (
+	name "Air Support (USA) (512 kB)"
+	rom ( name "AirSupport_v1.2_512k_NTSC_1325.lha" size 842583 crc 389A7E4F sha1 3a94c1334df94e77affadc1be50df6fe43081178 )
 )
 
 game (
 	name "Air Support (USA)"
-	rom ( name "AirSupport_v1.1_NTSC_1325.lha" size 843038 crc C17A2557 sha1 3125046c56e141a298deb5ef1ed30fabcf4a967c )
+	rom ( name "AirSupport_v1.2_NTSC_1325.lha" size 842521 crc 32D87350 sha1 16ba968ada3abc9a59417247aa08db57348bdb19 )
 )
 
 game (
 	name "Akira (Europe)"
-	rom ( name "Akira_v1.2.lha" size 2222057 crc E675E255 sha1 968bf988c7b6d2ecd8be97081545e344698561de )
+	rom ( name "Akira_v1.3.lha" size 2222831 crc 469E2171 sha1 dcf2a1914e50de6a42a1b3e3e7297f3d1e9b5698 )
 )
 
 game (
 	name "Akira (Europe) (CD32)"
-	rom ( name "Akira_v1.2_CD32.lha" size 5476000 crc 6D5B64A0 sha1 81540b452a9709852c4f4a7d2ca5ac3afffa081a )
+	rom ( name "Akira_v1.3_CD32.lha" size 5475332 crc B929E595 sha1 20aeb0862c96b2b47ffb306d7897acd5d471980d )
 )
 
 game (
 	name "Aladdin (Europe) (AGA)"
-	rom ( name "Aladdin_v1.7_AGA_0420.lha" size 1982160 crc 154146AE sha1 aafd52f82bf09dd4be55b00749e7928d1f2a7c30 )
+	rom ( name "Aladdin_v1.8_AGA_0420.lha" size 1982352 crc C4B873E3 sha1 6fb49f54177a87807d1978cd440ed5605630a13c )
+)
+
+game (
+	name "Aladdin's Magic Lamp (Europe)"
+	rom ( name "AladdinsMagicLamp_v1.0.lha" size 307311 crc 2D3632EF sha1 e89b3455f537cd0aca9b7bdc130e36da9573994c )
+)
+
+game (
+	name "Albedo (France)"
+	rom ( name "Albedo_v1.0_Fr.lha" size 328875 crc 194F3DEA sha1 f112b0dde6b8eae69d81e21d7faf5f409d2d735e )
 )
 
 game (
@@ -366,7 +436,7 @@ game (
 )
 
 game (
-	name "Alchemy (Unreleased) (Europe) (Demo)"
+	name "Alchemy (Europe) (Demo)"
 	rom ( name "AlchemyDemo_v1.0.lha" size 286711 crc 70E2EDE8 sha1 6b9b3fcd88890e13406ec266eb026bfc82774141 )
 )
 
@@ -391,13 +461,13 @@ game (
 )
 
 game (
-	name "Alien³ (Europe)"
-	rom ( name "Alien3_v2.1_0261.lha" size 1552709 crc B03095EB sha1 a02e37aa72bd6eecd3aa732bd88fbbfabd861c16 )
+	name "Alianator (Europe)"
+	rom ( name "Alienator_v1.0_1905.lha" size 220644 crc 5D45DD5E sha1 eb5ea2b399a04598ca2941d0e8d0ce2adf1269d7 )
 )
 
 game (
-	name "Alianator (Europe)"
-	rom ( name "Alienator_v1.0_1905.lha" size 220644 crc 5D45DD5E sha1 eb5ea2b399a04598ca2941d0e8d0ce2adf1269d7 )
+	name "Alien 3 (Europe)"
+	rom ( name "Alien3_v2.1_0261.lha" size 1552709 crc B03095EB sha1 a02e37aa72bd6eecd3aa732bd88fbbfabd861c16 )
 )
 
 game (
@@ -412,12 +482,12 @@ game (
 
 game (
 	name "Alien Breed II - The Horror Continues (Europe)"
-	rom ( name "AlienBreed2_v1.4_0278.lha" size 2815582 crc 0B5EBEFD sha1 1d000090bc9f2a4818b43fcecbcea7c1647460af )
+	rom ( name "AlienBreed2_v1.6_0278.lha" size 2816130 crc E487F72C sha1 c086ca574fbcd5478326bc5ae6dd58a6382f38bc )
 )
 
 game (
 	name "Alien Breed II - The Horror Continues (Europe) (AGA)"
-	rom ( name "AlienBreed2_v1.4_AGA_0044.lha" size 2826399 crc C7C638BF sha1 39a2af01c8cce51cf0aeda4b48a3cbf26f7e5c0f )
+	rom ( name "AlienBreed2_v1.6_AGA_0044.lha" size 2827090 crc A3D8F540 sha1 55a945c9155908a38bdd2e7f059397527e013ff0 )
 )
 
 game (
@@ -427,36 +497,36 @@ game (
 
 game (
 	name "Alien Breed 3D (Europe) (AGA)"
-	rom ( name "AlienBreed3D_v1.2_AGA_0624.lha" size 1638904 crc F1C4F788 sha1 f4210972334715f45a2464252d425c6511855625 )
+	rom ( name "AlienBreed3D_v1.3_AGA_0624.lha" size 1639355 crc AAE9B324 sha1 9d887d733ab6ed959d5b9bd9c3ebb063ec025ffa )
 )
 
 game (
 	name "Alien Breed 3D (Europe) (CD32)"
-	rom ( name "AlienBreed3D_v1.2_CD32.lha" size 1643126 crc 8463AF32 sha1 f25cf4c52464f9c1d5235388913445fc4c7706ca )
+	rom ( name "AlienBreed3D_v1.3_CD32.lha" size 1643535 crc 3D62FD31 sha1 a7f6198892957e42eefe2f6b31ac858a3a58041c )
 )
 
 game (
-	name "Alien Breed 3D (No Music) (Europe) (AGA)"
-	rom ( name "AlienBreed3D_v1.2_NoMusic_AGA_0624.lha" size 1530440 crc 0320F5BC sha1 0bbc89e65a77a0450ee5186076f6954459b53ed6 )
+	name "Alien Breed 3D (Europe) (AGA) (No Music)"
+	rom ( name "AlienBreed3D_v1.3_NoMusic_AGA_0624.lha" size 1530875 crc A1477EAD sha1 85d160ea713a7f1dc51b208d2428cb6705677aa8 )
 )
 
 game (
-	name "Alien Breed 3D (No Music) (Europe) (CD32)"
-	rom ( name "AlienBreed3D_v1.2_NoMusic_CD32.lha" size 1534619 crc E6A2C677 sha1 3b012a3b76ef69abde76cd7d4acea29cb84a627c )
+	name "Alien Breed 3D (Europe) (CD32) (No Music)"
+	rom ( name "AlienBreed3D_v1.3_NoMusic_CD32.lha" size 1535052 crc EDBC6136 sha1 435093ba684c475ed2a3d9e86a54dd1789d726b0 )
 )
 
 game (
-	name "Alien Breed 3D (Europe) (AGA) (Demo)"
+	name "Alien Breed 3D (Europe) (AGA) (Demo 2)"
 	rom ( name "AlienBreed3DDemoLatestDemo_v1.0_AGA.lha" size 663644 crc 134460C8 sha1 d9d46792f60860842f3d53a16d57b4605f26c85b )
 )
 
 game (
-	name "Alien Breed 3D (Europe) (AGA) (Demo)"
+	name "Alien Breed 3D (Europe) (AGA) (Demo 1)"
 	rom ( name "AlienBreed3DDemoPlayableDemo_v1.0_AGA.lha" size 443638 crc D8B5BB53 sha1 69fe0d3ca9bc1affc84b8465503e77e4b5502a18 )
 )
 
 game (
-	name "Alien Breed 3D (Europe) (AGA) (Demo)"
+	name "Alien Breed 3D (Europe) (AGA) (Rolling Demo)"
 	rom ( name "AlienBreed3DDemoRollingDemo_v1.0_AGA.lha" size 357151 crc F835D487 sha1 1ad25da549357bd0523d0d298ff2c6d0ecd8b879 )
 )
 
@@ -496,13 +566,18 @@ game (
 )
 
 game (
+	name "Alien Fires 2199 A.D. (USA)"
+	rom ( name "AlienFires2199AD_v1.0_NTSC_2356.lha" size 1169555 crc 5EEA4D24 sha1 5ea6e0ddc11d7e51aa1eb65b36e5ac0eb07a25cc )
+)
+
+game (
 	name "Alien Fish Finger (Europe)"
-	rom ( name "AlienFishFinger_v1.0.lha" size 213312 crc 321037A0 sha1 2c4254696c912cf9c1976858c29ef0b3beaf770d )
+	rom ( name "AlienFishFinger_v1.1.lha" size 547504 crc B64CB029 sha1 4945ff186bacf95c46100db3861198d5cbba38f2 )
 )
 
 game (
 	name "Alien Legion (Europe)"
-	rom ( name "AlienLegion_v1.0.lha" size 314869 crc 48E2FC98 sha1 531b079a2f1039b532d8f5d706dacf39c27c7fca )
+	rom ( name "AlienLegion_v1.01_2859.lha" size 315349 crc 2B08F131 sha1 4336c934ccd4c608919d47f93d363388d46343a9 )
 )
 
 game (
@@ -522,7 +597,7 @@ game (
 
 game (
 	name "Aliex (Europe)"
-	rom ( name "Aliex_v1.1.lha" size 336496 crc E149580D sha1 69540abac0919e0b1b1c242daf353f992391b197 )
+	rom ( name "Aliex_v2.0_2961.lha" size 360376 crc 6F0EEAC5 sha1 1b9990b4c224a9d140f51da0f1e61f1902e9f87c )
 )
 
 game (
@@ -537,7 +612,7 @@ game (
 
 game (
 	name "'Allo 'Allo - Cartoon Fun! (Europe)"
-	rom ( name "AlloAllo_v1.0.lha" size 1139829 crc ACE98030 sha1 83e2111eb291ea911e5ec0789b772718de222bb0 )
+	rom ( name "AlloAllo_v1.1_1005.lha" size 780454 crc 9B40C751 sha1 ade636f96be0575898ec114d44cd00c04144d4f9 )
 )
 
 game (
@@ -546,8 +621,13 @@ game (
 )
 
 game (
+	name "ATR - All Terrain Racing (Europe) (CD32)"
+	rom ( name "AllTerrainRacing_v1.6_CD32.lha" size 646058 crc CB8BBBAB sha1 dccc50176b88a67ace473928cc039d4ead619622 )
+)
+
+game (
 	name "ATR - All Terrain Racing Christmas Edition (Europe) (Demo)"
-	rom ( name "AllTerrainRacingXmasDemo_v1.3.lha" size 398708 crc A2CBE550 sha1 1b708b1f54987026d3032277105399fb9bb24af0 )
+	rom ( name "AllTerrainRacingXmasDemo_v1.2.lha" size 394966 crc D44DD95F sha1 fd2a54fcad916a8cb42d8cdf5b798dba4cf05b70 )
 )
 
 game (
@@ -556,13 +636,13 @@ game (
 )
 
 game (
-	name "Alpha Waves (Europe)"
+	name "Alpha Waves (Europe) (En,Fr,De,Es,It)"
 	rom ( name "AlphaWaves_v1.0_0626.lha" size 227865 crc C2BED176 sha1 dca8bd8d2f1e509a320a32e24c13951ff33dc93f )
 )
 
 game (
 	name "Altered Beast (Europe)"
-	rom ( name "AlteredBeast_v2.0_0819.lha" size 675422 crc 85C9C6A3 sha1 7dbb3cc774edbb7fa65118da0e6b0c7e5b9cc721 )
+	rom ( name "AlteredBeast_v2.2_0819.lha" size 677766 crc 4390D057 sha1 172c33cc8c867c66845a7c009b6acfa36b4e4701 )
 )
 
 game (
@@ -572,12 +652,12 @@ game (
 
 game (
 	name "Amazing Spider-Man, The (Europe) (En,Fr,De,Es,It)"
-	rom ( name "AmazingSpiderMan_v2.0_1006.lha" size 288970 crc 368E778B sha1 6cc46f92db40288934fd770b85005138bba7cf89 )
+	rom ( name "AmazingSpiderMan_v2.1_1006.lha" size 295373 crc E8C9AD18 sha1 7c941ada086625327eeecd69de4073a82d24ec22 )
 )
 
 game (
 	name "Amazing Spider-Man, The (USA)"
-	rom ( name "AmazingSpiderMan_v2.0_NTSC.lha" size 286583 crc B8B9E4C7 sha1 df434e9f02e9e3060b8e348ecf981554de055a40 )
+	rom ( name "AmazingSpiderMan_v2.1_NTSC.lha" size 293195 crc CE2A95FA sha1 a944d21a9ef5ca356a730c5ff0c19b80f6b08afa )
 )
 
 game (
@@ -587,7 +667,12 @@ game (
 
 game (
 	name "Ambermoon (Germany)"
-	rom ( name "Ambermoon_v2.0_De.lha" size 6072814 crc D3265FBB sha1 14cf0a78a4b54dda1f89fd94606f559c5837cc86 )
+	rom ( name "Ambermoon_v2.3_De.lha" size 6238793 crc 61E6A3F6 sha1 c91dca647aca81ab0619fb546c0d0bd0fca6cffd )
+)
+
+game (
+	name "Ambermoon (France)"
+	rom ( name "Ambermoon_v2.3_Fr.lha" size 6169033 crc C82F2A53 sha1 0669f34304139f507cb89bed85caad1fe7effbad )
 )
 
 game (
@@ -596,18 +681,18 @@ game (
 )
 
 game (
+	name "Amberstar (Europe) (Fast)"
+	rom ( name "Amberstar_v1.2_Fast_1969.lha" size 1510685 crc 964D3B7E sha1 42cc3a9aa58ab476de4263925362de4d99ece254 )
+)
+
+game (
 	name "Amberstar (Germany)"
 	rom ( name "Amberstar_v1.2_De.lha" size 1523635 crc 44FE750E sha1 7d93276e96e8491af45081f4dd8414d245982839 )
 )
 
 game (
-	name "Amberstar (Fast) (Germany)"
+	name "Amberstar (Germany) (Fast)"
 	rom ( name "Amberstar_v1.2_De_Fast.lha" size 1523802 crc 0C3D1B4C sha1 49bef560baee0d0a758cd0228bfd16b629a32a9b )
-)
-
-game (
-	name "Amberstar (Fast) (Europe)"
-	rom ( name "Amberstar_v1.2_Fast_1969.lha" size 1510685 crc 964D3B7E sha1 42cc3a9aa58ab476de4263925362de4d99ece254 )
 )
 
 game (
@@ -646,8 +731,18 @@ game (
 )
 
 game (
+	name "Amnios (USA)"
+	rom ( name "Amnios_v1.3_NTSC.lha" size 1451277 crc 93E7FB58 sha1 afb08a2333d7c890fbbc108bb14ff84948c9ee17 )
+)
+
+game (
 	name "Anarchy (Europe)"
 	rom ( name "Anarchy_v1.5.lha" size 935461 crc 6D53A089 sha1 72c87a7c93f002ae2b066a3807e2a75ace59d428 )
+)
+
+game (
+	name "Ancient Art Of War, The (Europe)"
+	rom ( name "AncientArtOfWar_v1.1.lha" size 384115 crc C5E2D33E sha1 d4ae5b72e0a6de02e86a10906ff93e464fd61918 )
 )
 
 game (
@@ -656,28 +751,53 @@ game (
 )
 
 game (
+	name "Andromeda Mission (Europe)"
+	rom ( name "AndromedaMission_v1.0.lha" size 516884 crc 0D83E419 sha1 48f64b7010f414c8f526326012d6aeb0ed2485cb )
+)
+
+game (
+	name "Andromeda Mission (Germany)"
+	rom ( name "AndromedaMission_v1.0_De.lha" size 517110 crc E3080108 sha1 237e96dce810c4568a525e84951b5311de80f496 )
+)
+
+game (
 	name "Another World (Europe)"
-	rom ( name "AnotherWorld_v2.4_0425.lha" size 994984 crc AD184D5F sha1 6996e93d543fde5944a7789039ce73310d143753 )
+	rom ( name "AnotherWorld_v2.8_0425.lha" size 996541 crc 3E3D6AB5 sha1 d3431aefdd1917d9620c351a9509fe8d9d687482 )
 )
 
 game (
 	name "Another World (France)"
-	rom ( name "AnotherWorld_v2.4_Fr_2377.lha" size 995008 crc 5F7AA79E sha1 604972744dff543f3ab27a7c8d7dfec289915be3 )
+	rom ( name "AnotherWorld_v2.8_Fr_2377.lha" size 996549 crc 6A394312 sha1 3af2358f69c22ae68983a49f72d2f1d621ff23be )
 )
 
 game (
 	name "Another World (Italy)"
-	rom ( name "AnotherWorld_v2.4_It.lha" size 991080 crc 1027E081 sha1 a1bd7bacb48a89fba945931a8d247a98e4d6cee8 )
+	rom ( name "AnotherWorld_v2.8_It.lha" size 992617 crc 41D63C4C sha1 dbe46e4dd6cefd5059e48053dd05588ad816c07b )
 )
 
 game (
 	name "Anstoss (Germany)"
-	rom ( name "Anstoss_v1.2_De_0798.lha" size 2450148 crc B11C9BAD sha1 efcdebad62e796968c02143f407a695580b9c58d )
+	rom ( name "Anstoss_v2.0_De_0798.lha" size 2451103 crc BF94E4F9 sha1 db02c3e2a2d5936de7dd65a2c3bc621bbd98afe9 )
+)
+
+game (
+	name "Anstoss (Germany) (AGA)"
+	rom ( name "Anstoss_v2.0_AGA_De.lha" size 3235662 crc 212CA26B sha1 40e54a508f275d99ad6c0ff6ed2a0c4882f40d64 )
+)
+
+game (
+	name "Anstoss - World Cup Edition (Germany)"
+	rom ( name "AnstossWorldCupEdition_v1.0_De.lha" size 3136685 crc C627FD74 sha1 d5ad3246f97cfd9a37b965d746dcd6a73c2c4f1e )
+)
+
+game (
+	name "Anstoss - World Cup Edition (Germany) (AGA)"
+	rom ( name "AnstossWorldCupEdition_v1.0_AGA_De.lha" size 4441984 crc B61E249D sha1 7ad1e644424d5e813986382a5fc2e17beaadbacc )
 )
 
 game (
 	name "Antago (Europe)"
-	rom ( name "Antago_v1.1_0857.lha" size 284630 crc A01E24F9 sha1 4fadc26cab5a91cdb4e059307fe574ab911cba1a )
+	rom ( name "Antago_v1.2_0857.lha" size 287260 crc 7A4BC561 sha1 cd835ce80fb44c70ccf7f54916236d7eb3ab6b12 )
 )
 
 game (
@@ -686,7 +806,7 @@ game (
 )
 
 game (
-	name "Apache + Overdrive (Europe) (Demo)"
+	name "Apache & Overdrive (Europe) (Demo)"
 	rom ( name "Apache&OverdriveDemo_v1.1_0426.lha" size 935428 crc FD582C7B sha1 bed38ad593c099db7bb41b64bc4c823be2144ffc )
 )
 
@@ -707,22 +827,17 @@ game (
 
 game (
 	name "APB (Europe)"
-	rom ( name "APB_v1.1_Files_1708.lha" size 414465 crc B50ABEB6 sha1 aa8ff120ab799427674274cf7cbc15b8f0bcdeb0 )
+	rom ( name "APB_v1.2a_1240.lha" size 377082 crc 25B7D509 sha1 70c1104541e574f660a77d3e5c746f0a5f45b73f )
 )
 
 game (
-	name "APB (Image) (Europe)"
-	rom ( name "APB_v1.1_Image_1240.lha" size 459903 crc A63C998F sha1 3c02f2963c4602a9a23a82fa86971a1893330892 )
+	name "Apidya (Europe) (Audios)"
+	rom ( name "Apidya_v2.06_Audios_2465.lha" size 1630528 crc E829234A sha1 e93feeefc60aa57871715ff14d626c674dd23ea4 )
 )
 
 game (
-	name "Apidya (Audios) (Europe)"
-	rom ( name "Apidya_v2.05_Audios_2465.lha" size 1628364 crc 5E391298 sha1 0ab897aa36ccdd2bb5ec8c9c8a37858ade79bbd4 )
-)
-
-game (
-	name "Apidya (Europe)"
-	rom ( name "Apidya_v2.05_Kaiko_0764.lha" size 1622182 crc BDF5E98B sha1 facc9b3ebc56417571a2710355a02bf4a85ae383 )
+	name "Apidya (Europe) (Kaiko)"
+	rom ( name "Apidya_v2.06_Kaiko_0764.lha" size 1630598 crc 5009A768 sha1 9f76cccb16b20939f2ed5aa2293431ea9c6c43a8 )
 )
 
 game (
@@ -731,13 +846,13 @@ game (
 )
 
 game (
-	name "Apple Hunt (Ecthelion) (Europe)"
-	rom ( name "AppleHunt_v1.0.lha" size 125055 crc 2C1E4861 sha1 89dcd6317de8e1aecd6715fd6627c13cbc38e588 )
+	name "Apple Hunt (Europe) (PD/Freeware)"
+	rom ( name "AppleHunt_v1.0.lha" size 119744 crc 29BB12FE sha1 4a27e7af77f7a22a79c3ee0d8452f299fee6ee34 )
 )
 
 game (
 	name "Apprentice (Europe)"
-	rom ( name "Apprentice_v1.3_2288.lha" size 876074 crc 2B3147C7 sha1 39d97b0d129136ce9afe6f0adc290ef81701f0e6 )
+	rom ( name "Apprentice_v2.1_2288.lha" size 877391 crc 3BD898B4 sha1 cf0a16d0e242622a21a154bb68e76f5acec819bd )
 )
 
 game (
@@ -746,13 +861,13 @@ game (
 )
 
 game (
-	name "Aquanaut (F1 Licenceware) (Europe)"
+	name "Aquanaut (Europe) (Licenceware)"
 	rom ( name "Aquanaut_v1.3.1_F1Licenceware.lha" size 440725 crc A4DC68D0 sha1 af3b94db90c35bf4ef675ece7c4aec3757c4d871 )
 )
 
 game (
 	name "Aquatic Games Starring James Pond and the Aquabats, The (Europe)"
-	rom ( name "AquaticGames_v1.1a_1351.lha" size 374797 crc 7EB98A3F sha1 8ee4e722ce2377a3659ffe44ea10d0072891362e )
+	rom ( name "AquaticGames_v1.2_1351.lha" size 374850 crc C41B1ABF sha1 ba2f498094e54cc3181c319261f71556e51804b0 )
 )
 
 game (
@@ -766,13 +881,18 @@ game (
 )
 
 game (
-	name "Arabian Nights (Europe)"
+	name "Arabian Nights (Europe) (En,Fr,De,It)"
 	rom ( name "ArabianNights_v2.0_1454.lha" size 1335594 crc F60D6A8A sha1 2e81138976b191913aedba8663c44b41cf51afa1 )
 )
 
 game (
-	name "Arabian Nights (Europe) (CD32)"
-	rom ( name "ArabianNights_v1.4_CD32.lha" size 1326756 crc AF9F005B sha1 cf54e73d550016804cf4d93f52a62f53ae743cc9 )
+	name "Arabian Nights (Europe) (En,Fr,De,It) (512 kB)"
+	rom ( name "ArabianNights_v2.0_512k_1454.lha" size 1336195 crc D5C9FA0B sha1 0dbff1d51233243a4781aac279d69471fb5e10e4 )
+)
+
+game (
+	name "Arabian Nights (Europe) (En,Fr,De,It) (CD32)"
+	rom ( name "ArabianNights_v2.0_CD32.lha" size 1328276 crc 27227042 sha1 9e7b64f2299949d0eadde531c4caa9944192c94d )
 )
 
 game (
@@ -782,22 +902,22 @@ game (
 
 game (
 	name "Arcade Fruit Machine (Europe)"
-	rom ( name "ArcadeFruitMachine_v1.0.lha" size 400593 crc 1EC9F817 sha1 04294df53abac3dfc362b2ee9a7a6233a0dabefb )
+	rom ( name "ArcadeFruitMachine_v1.1.lha" size 404523 crc A958BABD sha1 5d03a9f288cefc4a03f8e745bc3d6769809848bb )
 )
 
 game (
 	name "Arcade Pool (Europe)"
-	rom ( name "ArcadePool_v3.0_0298.lha" size 683446 crc 19097A51 sha1 21431328839e45c90da3b5379fe0dc7b03cb89c8 )
+	rom ( name "ArcadePool_v3.1_0298.lha" size 684258 crc 55F9EECE sha1 64491be8dbf95b1ae6afeba85cd62b7cc372f454 )
 )
 
 game (
 	name "Arcade Pool (Europe) (AGA)"
-	rom ( name "ArcadePool_v3.0_AGA_0298.lha" size 683482 crc 4011A846 sha1 e5c7b584470e8a0effb159fbdfe5240610d26c8a )
+	rom ( name "ArcadePool_v3.1_AGA_0298.lha" size 684142 crc 4B25750A sha1 a50817e6158f37cb785ec5d5680d165a0ec9623f )
 )
 
 game (
 	name "Arcade Pool (Europe) (CD32)"
-	rom ( name "ArcadePool_v3.0_CD32.lha" size 538849 crc 0C4B1A7C sha1 c5ef4ceb433c1cebf651a2b828d553ed931734e9 )
+	rom ( name "ArcadePool_v3.1_CD32.lha" size 537419 crc 58F6FABE sha1 3c7f9036d410f146e228ac16b990e663b034c790 )
 )
 
 game (
@@ -811,7 +931,7 @@ game (
 )
 
 game (
-	name "Billard Americain (Europe)"
+	name "Archer MacLean's Le Billard Américain (France)"
 	rom ( name "ArcherMacLeansBillardAmericain_v1.2.lha" size 221466 crc 5D827474 sha1 6daef347ec5256805b689b5e92066e1c99de0c87 )
 )
 
@@ -822,12 +942,12 @@ game (
 
 game (
 	name "Archipelagos (Europe)"
-	rom ( name "Archipelagos_v1.2_0627.lha" size 158625 crc 045BD9EC sha1 2735b0cbabc4d68311351da86a503c3c45f7973e )
+	rom ( name "Archipelagos_v1.2_0627.lha" size 158769 crc 6152D0A5 sha1 c9540b11654bdc7fab7af40b26ed55365a291fe3 )
 )
 
 game (
 	name "Archipelagos (USA)"
-	rom ( name "Archipelagos_v1.2_NTSC_0628.lha" size 165778 crc 902F690D sha1 ba381a75ad3f6882859db6e4c875c85532da8f83 )
+	rom ( name "Archipelagos_v1.2_NTSC_0628.lha" size 165917 crc F90C88C2 sha1 7a1d157640efc311dfac2859b47b350c08275526 )
 )
 
 game (
@@ -852,7 +972,11 @@ game (
 
 game (
 	name "Arena (Europe)"
-	rom ( name "Arena_v1.2.lha" size 324355 crc A30FA461 sha1 76df7e440b9903cf0378e9d8b67e663aca6e3e8e )
+	rom ( name "Arena_v1.3_1191.lha" size 201666 crc 21766834 sha1 895aad183f59c1c05c64883a9d72014c9d66f979 )
+)
+game (
+	name "Arena (USA)"
+	rom ( name "Arena_v1.3_NTSC_1190.lha" size 201716 crc C4123FB6 sha1 a6cafff6568c4fac840769f3653a833e6a13a910 )
 )
 
 game (
@@ -862,7 +986,7 @@ game (
 
 game (
 	name "Arkanoid (USA)"
-	rom ( name "Arkanoid_v1.9_NTSC_1136.lha" size 238624 crc 59CDCC28 sha1 217656ffcbac7219b5b4b73542db1d43b0eb78a8 )
+	rom ( name "Arkanoid_v1.9_NTSC_1136.lha" size 238786 crc CD2BB285 sha1 09aa50a221287f4f4cd57e965b58311ffc9c35a2 )
 )
 
 game (
@@ -877,7 +1001,7 @@ game (
 
 game (
 	name "Armalyte - The Final Run (Europe)"
-	rom ( name "Armalyte_v1.2.lha" size 1297303 crc 2F5BA193 sha1 c1b8c753ae365a758d7148f08627f982f2c63e2e )
+	rom ( name "Armalyte_v2.0_1686.lha" size 1323407 crc 97474171 sha1 64fac3fde1300edbcea87324904db418298b1281 )
 )
 
 game (
@@ -887,12 +1011,12 @@ game (
 
 game (
 	name "Armour-Geddon (Europe)"
-	rom ( name "ArmourGeddon_v1.0.lha" size 1270781 crc 21756DC0 sha1 21fe4ece66c5a4b2b65e2e080d91d433ec264d3b )
+	rom ( name "ArmourGeddon_v1.1.lha" size 1265338 crc 77366DCB sha1 c1bbd2a670facd48e1aa1412697a4211b6aecc90 )
 )
 
 game (
 	name "Armour-Geddon (USA)"
-	rom ( name "ArmourGeddon_v1.0_NTSC.lha" size 1257762 crc 62138531 sha1 b565d64e1e64c4ec6e431f0169b89a95174df6ef )
+	rom ( name "ArmourGeddon_v1.1_NTSC.lha" size 1260973 crc 838FCA4B sha1 b7d0223c5b051995a80637cc84567fb8abc41f3f )
 )
 
 game (
@@ -911,8 +1035,23 @@ game (
 )
 
 game (
+	name "Art De La Guerre, L' (France)"
+	rom ( name "ArtDeLaGuerre_v1.1_Fr_2447.lha" size 364284 crc CE818CA8 sha1 f5916623f47ed20cc70b97d3c05107a98893e094 )
+)
+
+game (
+	name "Arte De La Guerra, El (Spain)"
+	rom ( name "ArteDeLaGuerra_v1.1_Es.lha" size 362301 crc C71E169E sha1 5abebbc2b407cf4f36cc1c150d3e1be6aea64053 )
+)
+
+game (
+	name "Artificial Dreams (Europe)"
+	rom ( name "ArtificialDreams_v1.1_0493.lha" size 183312 crc 63577206 sha1 0cfba9f69077392e14c63937dab3a8ff4ab45b81 )
+)
+
+game (
 	name "Art of Chess, The (Europe)"
-	rom ( name "ArtOfChess_v1.1_1008.lha" size 230238 crc C0B20606 sha1 e1a5c4a70ae86988a3c2b2b4688fd52796f6afcb )
+	rom ( name "ArtOfChess_v1.2_1008.lha" size 230675 crc 2796BCDA sha1 15787bf866a647c194ecbab7481a0125c25adb62 )
 )
 
 game (
@@ -932,12 +1071,12 @@ game (
 
 game (
 	name "Assassin (Europe)"
-	rom ( name "Assassin_v1.2a_1214.lha" size 1783037 crc 306AC3AD sha1 12ce30badf5d30e287060e4de956c1359384b2ef )
+	rom ( name "Assassin_v1.2c_1214.lha" size 1783187 crc 37A22E3E sha1 f8ef9b873e701471413b61e311712ec27a136ce4 )
 )
 
 game (
 	name "Assassin - Special Edition (Europe)"
-	rom ( name "AssassinSpecialEdition_v3.0a_0766.lha" size 1907407 crc E68C64BB sha1 feef52eab00a2a3376e5459815d4ab3bef9b7e94 )
+	rom ( name "AssassinSpecialEdition_v3.0b_0766.lha" size 1907457 crc 541B0D22 sha1 bb23102ed37eab530c2d620880058d655b7c0b01 )
 )
 
 game (
@@ -946,23 +1085,48 @@ game (
 )
 
 game (
+	name "Astate - La Malédiction Des Templiers (France)"
+	rom ( name "Astate_v1.0_2823.lha" size 530588 crc 2ED08F1D sha1 17448e92bcab7a30a490ba1d7ec72c056680b793 )
+)
+
+game (
 	name "Astatin (Europe)"
 	rom ( name "Astatin_v1.0.lha" size 591972 crc 8D5B403F sha1 f1ff4945a223453ec8dad8a2245dc92e6a66bf66 )
 )
 
 game (
+	name "Astérix Chez Rahàzade (France)"
+	rom ( name "AsterixChezRahazade_v1.0_Fr.lha" size 463269 crc 182223C3 sha1 bcc4369ff2e8faf9eba8e3df763777d9b9d9efb5 )
+)
+
+game (
+	name "Astérix - El Golpe Del Menhir (Spain)"
+	rom ( name "AsterixElGolpeDelMenhir_v2.0_Es.lha" size 411973 crc 2305B702 sha1 05b3d4bd5475266c03babe0894fdaaacb7a8e8c0 )
+)
+
+game (
+	name "Astérix Im Morgenland (Germany)"
+	rom ( name "AsterixImMorgenland_v1.0_De_0631.lha" size 458650 crc 18A807DB sha1 439b7a5154baf0e2dc53ebab3fcd622fbaddf710 )
+)
+
+game (
+	name "Astérix - Le Coup Du Menhir (France)"
+	rom ( name "AsterixLeCoupDuMenhir_v2.0_Fr.lha" size 412412 crc C6AB955D sha1 d37c92ed4fc5e8f1ff178562cd67179d1d44e0cb )
+)
+
+game (
 	name "Asterix - Operation Getafix (Europe)"
-	rom ( name "AsterixOperationGetafix_v1.3_1009.lha" size 408372 crc 85ED2203 sha1 0912f45f8ecfde181139d1344dbed6498471b3cb )
+	rom ( name "AsterixOperationGetafix_v2.0_1009.lha" size 410668 crc 3E428617 sha1 9fcd038dd7f64ecd75c224b741ef802aa57abcb2 )
 )
 
 game (
 	name "Asterix und Operation Hinkelstein (Germany)"
-	rom ( name "AsterixOperationHinkelstein_v1.3_De_0630.lha" size 407201 crc 7E5513BB sha1 9aaf9ef7cfa18532b3a245bd44419475d4059ed7 )
+	rom ( name "AsterixOperationHinkelstein_v2.0_De_0630.lha" size 409495 crc BFFBC418 sha1 56a1d3c3f47566fb4ec8e686a41a1cb67387dba3 )
 )
 
 game (
 	name "Astro Marine Corps (A.M.C.) (Europe)"
-	rom ( name "AstroMarineCorps_v1.2.lha" size 1289623 crc C7C9C00B sha1 eeb61783c22bcf7fd021489175206684e2e1cbd4 )
+	rom ( name "AstroMarineCorps_v1.21.lha" size 1289690 crc 909F27FF sha1 8196e6f0698892b987e65501dd3074a3ecdf362c )
 )
 
 game (
@@ -982,11 +1146,11 @@ game (
 
 game (
 	name "Atomic Robo-Kid (Europe)"
-	rom ( name "AtomicRoboKid_v1.4_2243.lha" size 659392 crc 7BD67AF7 sha1 261c231d7aa2382f38fec28a336b2bef9c6d0351 )
+	rom ( name "AtomicRoboKid_v1.5_2243.lha" size 660150 crc AD958046 sha1 56330784e2c33ca74625d038fb338cc2cd0d6214 )
 )
 
 game (
-	name "Atomino (Europe)"
+	name "Atomino (Europe) (En,Fr,It)"
 	rom ( name "Atomino_v1.11_0632.lha" size 384515 crc B160A6DE sha1 f05e112311191dc1f8e5fdbd3f3ac3644eeb695f )
 )
 
@@ -996,13 +1160,13 @@ game (
 )
 
 game (
-	name "Atomino (USA)"
+	name "Atomino (USA) (En,Fr,It)"
 	rom ( name "Atomino_v1.11_NTSC_1972.lha" size 384846 crc D852BA28 sha1 00ca3af6115361f595c3be8d818a65f491fecba1 )
 )
 
 game (
 	name "Atomix (Europe)"
-	rom ( name "Atomix_v1.3_1356.lha" size 263023 crc A509A405 sha1 2c2dbe0cab1b2892e11ff42bc35da2ac74225950 )
+	rom ( name "Atomix_v1.4_1356.lha" size 263442 crc EE18F9C0 sha1 4a904f7895a24ef7b11c9657755a316016963c68 )
 )
 
 game (
@@ -1011,67 +1175,67 @@ game (
 )
 
 game (
-	name "A-Train Construction Set (Europe)"
-	rom ( name "ATrain&ConstructionSet_v1.2_1010&1469.lha" size 884146 crc 0D8DC060 sha1 2659aec41cf39b4ca2ab4e5f9ee05ffef1b7eb9c )
+	name "A-Train & Construction Set (Europe)"
+	rom ( name "ATrain&ConstructionSet_v1.4_1010&1469.lha" size 884417 crc CB8B07DE sha1 0a12bae3b903cc40475e34048b5ee002a121ed09 )
 )
 
 game (
-	name "A-Train Construction Set (512 KB) (Europe)"
-	rom ( name "ATrain&ConstructionSet_v1.2_512k_1010&1469.lha" size 883820 crc 6C620C11 sha1 11af192ed097ac55979183d2f420cb262e6123c8 )
-)
-
-game (
-	name "A-Train (512 KB) (Poland)"
-	rom ( name "ATrain_v1.1_512k_Pl.lha" size 619184 crc A80C52C4 sha1 ca3f2a921fee5be93d8f2140c3627c37b4931965 )
-)
-
-game (
-	name "A-Train (Poland)"
-	rom ( name "ATrain_v1.1_Pl.lha" size 618917 crc A16D9EDE sha1 056739521f335b52db097deb1c82d7de4daf7e83 )
+	name "A-Train & Construction Set (Europe) (512 kB)"
+	rom ( name "ATrain&ConstructionSet_v1.4_512k_1010&1469.lha" size 884093 crc AE6FA147 sha1 b2fd29b86bbd42ad50f4ce33e45eeebf7a428719 )
 )
 
 game (
 	name "A-Train (Europe)"
-	rom ( name "ATrain_v1.2_1010.lha" size 615004 crc 0AD536A7 sha1 5980659e2812563888a5a0b533b229f5938b313c )
+	rom ( name "ATrain_v1.4_1010.lha" size 615432 crc B424A8AE sha1 0d78cb2386cd7209765625fd9334f163539b8ad2 )
 )
 
 game (
-	name "A-Train (512 KB) (Europe)"
-	rom ( name "ATrain_v1.2_512k_1010.lha" size 615320 crc 34050377 sha1 bd763b7185cd69087aad2929623938e0770bdb7b )
+	name "A-Train (Europe) (512 kB)"
+	rom ( name "ATrain_v1.4_512k_1010.lha" size 615593 crc 892E6E18 sha1 201f2dedfd509a2f80947f727c45a5a40a7ab50d )
 )
 
 game (
-	name "A-Train (512 KB) (Czech)"
-	rom ( name "ATrain_v1.2_512k_Cz.lha" size 621455 crc D6E144A2 sha1 4d049573d90a1508748e2a1314b432baa3fcc202 )
+	name "A-Train (Czech) (512 kB)"
+	rom ( name "ATrain_v1.4_512k_Cz.lha" size 621728 crc 34D314B3 sha1 ae099ba2591c6c2bb9a3f815702cb8ef9efbdbc0 )
 )
 
 game (
-	name "A-Train (512 KB) (Germany)"
-	rom ( name "ATrain_v1.2_512k_De_0428.lha" size 627353 crc E76CDAEB sha1 f896ae7b93353bc6f22164df2bcb5d5e236fbc37 )
+	name "A-Train (Germany) (512 kB)"
+	rom ( name "ATrain_v1.4_512k_De_0428.lha" size 627626 crc DDA8D607 sha1 667762d260d24d66ac88cbff025c44f1466c3913 )
 )
 
 game (
-	name "A-Train (512 KB) (France)"
-	rom ( name "ATrain_v1.2_512k_Fr_2579.lha" size 627824 crc 9A824981 sha1 a21f62371bf7df0c824ad5162ad0904250bd01b4 )
+	name "A-Train (France) (512 kB)"
+	rom ( name "ATrain_v1.4_512k_Fr_2579.lha" size 628097 crc 12604122 sha1 1ea23e7e377d59fb77b0b40cee8fd57dd5a4a604 )
+)
+
+game (
+	name "A-Train (Poland) (512 kB)"
+	rom ( name "ATrain_v1.4_512k_Pl.lha" size 617370 crc 07EB164B sha1 acc7437c2123ec26c59c8feba311f72934419ca2 )
 )
 
 game (
 	name "A-Train (Czech)"
-	rom ( name "ATrain_v1.2_Cz.lha" size 621084 crc 6FD15D49 sha1 eb1cfd76f747bc730b5898ef4b303145c5ba1e05 )
+	rom ( name "ATrain_v1.4_Cz.lha" size 621355 crc 57E97912 sha1 b227714b2ceb1b116ad3d9bad47d0fc0ab15e5dd )
 )
 
 game (
 	name "A-Train (Germany)"
-	rom ( name "ATrain_v1.2_De_0428.lha" size 627045 crc 31B32020 sha1 971f5b4ec029ba63781437fbe56f024eef0539a7 )
+	rom ( name "ATrain_v1.4_De_0428.lha" size 627316 crc 4348B1C8 sha1 8df7c83c463d511c6a902f167b7365065063cb04 )
 )
 
 game (
 	name "A-Train (France)"
-	rom ( name "ATrain_v1.2_Fr_2579.lha" size 627513 crc 06901D04 sha1 d49243430a02017cedbf2ee701dbb415f1c2a9bb )
+	rom ( name "ATrain_v1.4_Fr_2579.lha" size 627784 crc 6AE3EBFC sha1 01d2483b18e937a413b62aa734b7465d1e926a19 )
 )
 
 game (
-	name "Attack of the Green Smelly Aliens from Planet 27b (Europe)"
+	name "A-Train (Poland)"
+	rom ( name "ATrain_v1.4_Pl.lha" size 617046 crc 4D9207EF sha1 a5e7ac99aa6b2e4e419e18760443b999a34d9e9b )
+)
+
+game (
+	name "Attack of the Green Smelly Aliens from Planet 27b (Europe) (Coverdisk - Amiga Power #14)"
 	rom ( name "AttackOfTheGreenSmellyAliensFromPlanet27b6_v1.0.lha" size 211531 crc 577FC17E sha1 78998276c6317e0a659fd09c00c8d899b5d77b1c )
 )
 
@@ -1082,12 +1246,17 @@ game (
 
 game (
 	name "Aunt Arctic Adventure (Europe)"
-	rom ( name "AuntArcticAdventure_v1.0_1757.lha" size 307922 crc 30B13481 sha1 dbd05cc7d59286e46c6eef6d35e09258639b72f7 )
+	rom ( name "AuntArcticAdventure_v2.01_1757.lha" size 310886 crc 77550E8E sha1 c5e0e00a74a2265a90310c927eeb2f774ac94061 )
+)
+
+game (
+	name "Aunt Arctic Adventure (Germany)"
+	rom ( name "AuntArcticAdventure_v2.01_De.lha" size 349234 crc F221F3A8 sha1 6149fe7e80c3020bfd4811acef2ee20e5f0a99bf )
 )
 
 game (
 	name "Australopiticus Mechanicus (Europe)"
-	rom ( name "AustraloPiticusMechanicus_v1.0a_0809.lha" size 307761 crc 9F6E0262 sha1 c2c49b30b06b2d30597c7cc0541ed1196914d57d )
+	rom ( name "AustraloPiticusMechanicus_v2.0_0809.lha" size 307870 crc FC678370 sha1 ca4cd1c9f6eebc5bb9b54e8d12731863cc592f11 )
 )
 
 game (
@@ -1102,22 +1271,22 @@ game (
 
 game (
 	name "Aventura Espacial, La (Spain)"
-	rom ( name "AventuraEspacial_v1.0_Es.lha" size 854183 crc DB6C1CC4 sha1 f2f86c0cd1c73ad339830a48ff6da04c560fd45a )
+	rom ( name "AventuraEspacial_v1.0_Es.lha" size 1693402 crc F08C0946 sha1 4393dc3528227b3904f2f2c23b29e56de8ad531f )
 )
 
 game (
 	name "Aventura Original, La (Spain)"
-	rom ( name "AventuraOriginal_v1.0_Es.lha" size 558646 crc 66DF9ECC sha1 7222e0e268f502c9ba035a75aac8fe00fe3d6218 )
+	rom ( name "AventuraOriginal_v1.0_Es.lha" size 793242 crc 4C108D7F sha1 f94ecc4cf739e2ced9c9c4e2d08b64a17ba223d9 )
 )
 
 game (
 	name "Aventures de Moktar, Les (France)"
-	rom ( name "AventuresDeMoktar_v2.0_Fr_1636.lha" size 702890 crc FF9620AD sha1 bba9e6e054842f076bce6ea7f3174515812bf5bc )
+	rom ( name "AventuresDeMoktar_v2.3_Fr_1636.lha" size 745751 crc BCB508EC sha1 694b8781c9d8c0d9de6efba8705b5be6cd15bb55 )
 )
 
 game (
 	name "Awesome (Europe)"
-	rom ( name "Awesome_v2.1_0431.lha" size 2061361 crc 61DC336E sha1 83f14f45d95cbecab6c44b2bce35f73ce14b6ca0 )
+	rom ( name "Awesome_v2.5_0431.lha" size 2062149 crc 77A997C8 sha1 4361dc9fb542498de67fcb5e242d218d2c3ee57d )
 )
 
 game (
@@ -1136,7 +1305,7 @@ game (
 )
 
 game (
-	name "Aztec Challenge (Europe)"
+	name "Aztec Challenge (Europe) (Shareware)"
 	rom ( name "AztecChallenge_v1.0.lha" size 208141 crc A494CD48 sha1 b82b99d449f5c1684eee56eabf45e9d12427b31f )
 )
 
@@ -1161,7 +1330,7 @@ game (
 )
 
 game (
-	name "Baby Jo in 'Going Home' (Europe)"
+	name "Baby Jo in 'Going Home' (Europe) (En,Fr,De,Es)"
 	rom ( name "BabyJoInGoingHome_v1.1_2291.lha" size 530701 crc 8BAA0CD3 sha1 0d51287436ff422c3634af1b758b66f3140be195 )
 )
 
@@ -1177,7 +1346,7 @@ game (
 
 game (
 	name "Back to the Future Part II (Europe)"
-	rom ( name "BackToTheFuturePart2_v1.2_0005.lha" size 508149 crc CBD9AFD3 sha1 00c023c514b9967d6af7a01c66f65faaa17d5fdf )
+	rom ( name "BackToTheFuturePart2_v1.3a_0005.lha" size 510248 crc E7BA85D6 sha1 83667fda294e3df7ad3d796c80088927720b35ee )
 )
 
 game (
@@ -1201,13 +1370,23 @@ game (
 )
 
 game (
+	name "Bad Dudes (USA) (Chip)"
+	rom ( name "BadDudes_v1.3_Chip_NTSC_2425.lha" size 578464 crc E5FE49A1 sha1 1aa64c1be3b3230ba0db64bf01f6e838f1f2061a )
+)
+
+game (
 	name "Bad Dudes (USA)"
-	rom ( name "BadDudes_v1.2_NTSC_2425.lha" size 574098 crc 687DA678 sha1 bf14c96a7cbe91749edf4b464eebda0591ea289c )
+	rom ( name "BadDudes_v1.3_NTSC_2425.lha" size 577934 crc 157DCED3 sha1 864bf77cc6ca8738de47f8f2e5ab4345225eb051 )
 )
 
 game (
 	name "Bad Dudes vs. Dragon Ninja (Europe)"
-	rom ( name "BadDudesVsDragonNinja_v1.2_0098.lha" size 561945 crc 84A911D0 sha1 d03ae55f0483f3d3c1fdbea8b1a68beafcf6a325 )
+	rom ( name "BadDudesVsDragonNinja_v1.3_0098.lha" size 564042 crc BB4C3897 sha1 8380f138ab3406541150768e585a875fee3f9dc2 )
+)
+
+game (
+	name "Bad Dudes vs. Dragon Ninja (Europe) (Chip)"
+	rom ( name "BadDudesVsDragonNinja_v1.3_Chip_0098.lha" size 564103 crc 24B77632 sha1 697fbf207cd473849ab0177fad96aa75d553bcd8 )
 )
 
 game (
@@ -1226,6 +1405,11 @@ game (
 )
 
 game (
+	name "Balade Au Pays De Big Ben (France)"
+	rom ( name "BaladeAuPaysDeBigBen_v1.1_Fr.lha" size 345430 crc 0C8675D4 sha1 12c487d39c23f2cdbef2c10f172eacaccab8bb30 )
+)
+
+game (
 	name "Balance of Power - The 1990 Edition (Europe)"
 	rom ( name "BalanceOfPower1990Edition_v1.0_1818.lha" size 183728 crc 767468B9 sha1 019e06d1e8801b677394f64c30b8e00e537d0e0d )
 )
@@ -1236,13 +1420,13 @@ game (
 )
 
 game (
-	name "Ball Game, The (Europe)"
+	name "Ball Game, The (Europe) (En,Fr,De,Es,It)"
 	rom ( name "BallGame_v1.0_2051.lha" size 218212 crc 471C0F54 sha1 ac3ad7384573e179ca4842b0a9c22c54e6238bce )
 )
 
 game (
 	name "Ballistix (Europe)"
-	rom ( name "Ballistix_v1.3_0433.lha" size 437598 crc 10F6D8BC sha1 dca8d8daacf6a5f3db9a5578491eb4f3fab0f902 )
+	rom ( name "Ballistix_v1.4_0433.lha" size 438215 crc 290BF5A3 sha1 6d2965379b5796efb1441f7d6232c1c198d4c4b2 )
 )
 
 game (
@@ -1266,12 +1450,12 @@ game (
 )
 
 game (
-	name "Banshee (Europe) (AGA)"
+	name "Banshee (Europe) (En,Fr,De,Da) (AGA)"
 	rom ( name "Banshee_v3.3_AGA_0633.lha" size 2954097 crc EAA73733 sha1 5249043ca0d28c2a2aec5eb901037f9fddf4131b )
 )
 
 game (
-	name "Banshee (Europe) (CD32)"
+	name "Banshee (Europe) (En,Fr,De,Da) (CD32)"
 	rom ( name "Banshee_v3.3_CD32.lha" size 2812925 crc 8DB86779 sha1 7ed5eb571843a084dc8935461ae29b947ccfead4 )
 )
 
@@ -1281,13 +1465,13 @@ game (
 )
 
 game (
-	name "Barbarian II (Europe) (En,Fr,De,It) (Psygnosis)"
-	rom ( name "Barbarian2_v1.1_Psygnosis_0611.lha" size 2227229 crc A4C546D0 sha1 5751209bd89a1dadd11a1cf6f1d3cff229d95154 )
+	name "Barbarian II (Europe) (Palace)"
+	rom ( name "Barbarian2_v1.2_Palace_2264.lha" size 745982 crc 21EB72AB sha1 26cb87b4cb07a3deb47a229f3e95b26e4027026e )
 )
 
 game (
-	name "Barbarian II (Europe) (Palace)"
-	rom ( name "Barbarian2_v1.2_Palace_2264.lha" size 745982 crc 21EB72AB sha1 26cb87b4cb07a3deb47a229f3e95b26e4027026e )
+	name "Barbarian II (Europe) (En,Fr,De,It) (Psygnosis)"
+	rom ( name "Barbarian2_v2.0_Psygnosis_0611.lha" size 2224321 crc A80C5EC8 sha1 c744723ac041a390ed587a429124475d6c81dda6 )
 )
 
 game (
@@ -1297,12 +1481,12 @@ game (
 
 game (
 	name "Barbarian (Europe)"
-	rom ( name "Barbarian_v1.1b_Psygnosis_1011.lha" size 500290 crc C6F477D2 sha1 4d89bdfc71cbf220a9a4fa56d2ea3456f043e921 )
+	rom ( name "Barbarian_v2.0_Psygnosis_1011.lha" size 507583 crc A1BAF791 sha1 913db28f58bab8750122bca2c41a47aa53a3ac0a )
 )
 
 game (
 	name "Bard's Tale II, The - The Destiny Knight (Europe)"
-	rom ( name "BardsTale2_v1.0_0046.lha" size 660909 crc B696E64B sha1 2dca2d874bd266d5e083a071ee372c09eef72217 )
+	rom ( name "BardsTale2_v1.01_0046.lha" size 706390 crc 3AB053E3 sha1 66028317b136e2ac1b2ba692faea1ff5181165ab )
 )
 
 game (
@@ -1312,27 +1496,27 @@ game (
 
 game (
 	name "Bard's Tale, The - Tales of the Unknown (Europe)"
-	rom ( name "BardsTale_v1.2_0010.lha" size 892968 crc 239E6452 sha1 32b35964d6ba04a02600246d2ae424bed56b9485 )
+	rom ( name "BardsTale_v1.4_0010.lha" size 849022 crc 17EC5490 sha1 a96db9f80357afbb5ed2f5ac2024a99b2fb54491 )
 )
 
 game (
 	name "Bard's Tale, The - Tales of the Unknown (USA)"
-	rom ( name "BardsTale_v1.2_NTSC_1978.lha" size 888461 crc 3DAB3F50 sha1 756c2cc78bf2298abd3c0a02399e3db17f4ad01b )
+	rom ( name "BardsTale_v1.4_NTSC_1978.lha" size 846043 crc A6422CE3 sha1 5ff6bcce1cef936bced4239a910845aa5b9ce0b3 )
 )
 
 game (
 	name "Bar Games (Europe)"
-	rom ( name "BarGames_v1.0_2947.lha" size 1399715 crc 02A2E4DD sha1 1375472df68b07774631ef8dd576d9adbdee6b14 )
+	rom ( name "BarGames_v1.2_2947.lha" size 1391188 crc 90417BF2 sha1 cda1e629380ede62258316231246fabe1d0810db )
 )
 
 game (
 	name "Bargon Attack (Europe)"
-	rom ( name "BargonAttack_v1.0.lha" size 2420370 crc A8DF98CD sha1 4dc89d6a9e58273ca827c07db8dbd1c14d8a73a7 )
+	rom ( name "BargonAttack_v1.1.lha" size 2418693 crc 0D010D35 sha1 0c3b7c19ae50f34c6fb0e10abd8d20e195b46df4 )
 )
 
 game (
 	name "Bargon Attack (France)"
-	rom ( name "BargonAttack_v1.0_Fr_2486.lha" size 2406198 crc 21528D94 sha1 1ebebbb96094922620f85e52831f3e5efc920f1f )
+	rom ( name "BargonAttack_v1.1_Fr_2486.lha" size 2404536 crc 22D43B77 sha1 52b88a805950b12903f76368a966ea4a36278457 )
 )
 
 game (
@@ -1346,7 +1530,12 @@ game (
 )
 
 game (
-	name "Simpsons, The - Bart vs. The Space Mutants (1 Disk) (Europe)"
+	name "Barney Mouse (Europe)"
+	rom ( name "BarneyMouse_v1.0.lha" size 586224 crc 20FAB718 sha1 5a2fb0f687341d29621cf1cf23c403accc6005cc )
+)
+
+game (
+	name "Simpsons, The - Bart vs. The Space Mutants (Europe) (1 Disk)"
 	rom ( name "BartVsTheSpaceMutants_v1.1_1Disk_0884.lha" size 458145 crc DEB267DD sha1 eb4b8a09a893ed01dacf1c8a153194ad6d635041 )
 )
 
@@ -1371,12 +1560,12 @@ game (
 )
 
 game (
-	name "Basket Island (Europe) (AGA) (Demo)"
+	name "Basket Island (Europe) (AGA) (Demo 1)"
 	rom ( name "BasketIslandDemo1_v1.1_AGA.lha" size 347967 crc 28E841F2 sha1 f67c60caccfc931651fac95c99806e1ca972685d )
 )
 
 game (
-	name "Basket Island (Europe) (AGA) (Demo)"
+	name "Basket Island (Europe) (AGA) (Demo 2)"
 	rom ( name "BasketIslandDemo2_v1.1_AGA.lha" size 323793 crc E841CE15 sha1 048a8e1ba34868716fc2ca16a878e7fe0b92f173 )
 )
 
@@ -1391,28 +1580,38 @@ game (
 )
 
 game (
+	name "B.A.T. II (Spain)"
+	rom ( name "BAT2_v1.1_Es.lha" size 2864352 crc 329A7BD5 sha1 ef298cd3472c9749ce468dac34d8f3f36bb25c7e )
+)
+
+game (
 	name "B.A.T. II (France)"
 	rom ( name "BAT2_v1.1_Fr_1635.lha" size 2864417 crc 31C6E799 sha1 e31ee48380981e1789c0a6d8dbe698717c24d23b )
 )
 
 game (
 	name "B.A.T. (Europe)"
-	rom ( name "BAT_v1.3b_2072.lha" size 1196690 crc F233A56C sha1 81210ce77e983343e32166ee8d5c35391ea48a8a )
+	rom ( name "BAT_v1.5_2072.lha" size 1193403 crc AB36DB81 sha1 aa573e1b0a945c43fc2a05362cf47359e5328ae7 )
 )
 
 game (
 	name "B.A.T. (Germany)"
-	rom ( name "BAT_v1.3b_De_2197.lha" size 1195465 crc 5A7A9C2F sha1 18f8e0ef47c356ab2ff29131da7f5b9e12d7d7df )
+	rom ( name "BAT_v1.5_De_2197.lha" size 1192187 crc 5EB15057 sha1 977520716b55bab9bffd8f3bc244aab8cfdf61b7 )
 )
 
 game (
 	name "B.A.T. (France)"
-	rom ( name "BAT_v1.3b_Fr_2641.lha" size 1197137 crc 3883566B sha1 2e9375129e726578edc5d54cf30f6dd239a9ecb6 )
+	rom ( name "BAT_v1.5_Fr_2641.lha" size 1193849 crc 576D8113 sha1 9ad16baaf0f9bd8de8ad3a50348e045486bbbac6 )
+)
+
+game (
+	name "B.A.T. (Italy)"
+	rom ( name "BAT_v1.5_It.lha" size 1193343 crc 86646D64 sha1 590f2e30521114f528be846759d6ebf9caee91b7 )
 )
 
 game (
 	name "Batman - The Caped Crusader (Europe)"
-	rom ( name "BatmanCapedCrusader_v1.1_0050.lha" size 422881 crc 0CF2C306 sha1 d6a71d6a321151f1ec71d7d17e55bf1881b6b1c6 )
+	rom ( name "BatmanCapedCrusader_v2.0_0050.lha" size 424262 crc 6592354A sha1 60a53d42c967b9f51930de0c192545e98affa103 )
 )
 
 game (
@@ -1421,18 +1620,18 @@ game (
 )
 
 game (
-	name "Batman (Europe) (1 Disk)"
+	name "Batman the Movie (Europe) (1 Disk)"
 	rom ( name "BatmanTheMovie_v1.5_1Disk_0019.lha" size 725183 crc 2DB46406 sha1 41a165d48ce7d6ab1d3eb5c658b855a476a0bea0 )
 )
 
 game (
-	name "Batman (Europe)"
+	name "Batman the Movie (Europe)"
 	rom ( name "BatmanTheMovie_v1.5_2Disk_0006.lha" size 698209 crc B3F602E3 sha1 892f4f8dfde7fb627c1df4d4aa85a1f2d0226503 )
 )
 
 game (
 	name "Battle Bound (Europe)"
-	rom ( name "BattleBound_v1.0.lha" size 619457 crc 8AFA1BE6 sha1 c75387c05f78d1418266adbb757da0d39567ff6b )
+	rom ( name "BattleBound_v1.1_2950.lha" size 540855 crc D864A2C1 sha1 e0ae26f1c766d95228bf4f3339871bd3ee4e4eb8 )
 )
 
 game (
@@ -1456,8 +1655,13 @@ game (
 )
 
 game (
-	name "Battle Command (Europe)"
-	rom ( name "BattleCommand_v1.2_0858.lha" size 587369 crc 4B608071 sha1 036c1da40e1ddae64f09df739fadd6b63f908874 )
+	name "Battle Command (Europe) (En,Fr,De)"
+	rom ( name "BattleCommand_v2.0_0858.lha" size 511874 crc 9F3F156C sha1 a08d09cbf761def73423197047d3e063fda6bcdf )
+)
+
+game (
+	name "Battle Command (USA)"
+	rom ( name "BattleCommand_v2.0_NTSC_2044.lha" size 510062 crc 144205A6 sha1 9e1d84f24d8a86d3dedd31f74dd80c85d8e5c6d6 )
 )
 
 game (
@@ -1466,7 +1670,7 @@ game (
 )
 
 game (
-	name "Battle for the Ashes (Amiga Power) (Europe)"
+	name "Battle for the Ashes (Europe) (Coverdisk - Amiga Power #63)"
 	rom ( name "BattleForTheAshes_v1.0_AmigaPower.lha" size 561112 crc 23F278B0 sha1 3f0ab102fa1c98850396badfa2715380a3fa09e5 )
 )
 
@@ -1477,12 +1681,12 @@ game (
 
 game (
 	name "Battle Isle & Data Disks (Europe)"
-	rom ( name "BattleIsle&DataDisks_v1.9_1991&0460&0667.lha" size 2617617 crc A6BBC1E2 sha1 4c6f610b9eaa8756e7086cdce2c55ac69d0dde63 )
+	rom ( name "BattleIsle&DataDisks_v1.10_0460&0667&1991.lha" size 2457225 crc 96AFF392 sha1 1ff76f88dc494660230feb1207cd607871554704 )
 )
 
 game (
 	name "Battle Isle (Europe)"
-	rom ( name "BattleIsle_v1.9_1991.lha" size 1708623 crc 5CB930F8 sha1 14d7c0c53396e65807a7ff327a7576a2bbe8fac8 )
+	rom ( name "BattleIsle_v1.10_1991.lha" size 1595235 crc FE8BD7BD sha1 da1c58dcfbee97e3b99abad933ee34f400f196d4 )
 )
 
 game (
@@ -1491,8 +1695,13 @@ game (
 )
 
 game (
+	name "Battleships (USA)"
+	rom ( name "Battleship_v2.1_NTSC.lha" size 152813 crc FBE9CA06 sha1 1e8f746c377c6cf20eacd419150d8162c611bcfd )
+)
+
+game (
 	name "Battleships (Europe)"
-	rom ( name "Battleships_v1.0.lha" size 152071 crc B0F91790 sha1 22c8a5c7d28c843c645a23b9ca7a571b6a41796e )
+	rom ( name "Battleships_v2.1_3003.lha" size 155791 crc 8F232690 sha1 fbf5f447003b0b7bdfc09b96568aa1cf2346583f )
 )
 
 game (
@@ -1512,12 +1721,12 @@ game (
 
 game (
 	name "Battlestorm (Europe) (CDTV)"
-	rom ( name "Battlestorm_v1.2_CDTV.lha" size 439677 crc A50F2E16 sha1 6cfefc894725e31ccf1f7344ba5392ace14389eb )
+	rom ( name "Battlestorm_v1.3_CDTV.lha" size 439370 crc FF23990B sha1 ab998a4d1309654e8e017de5769258fcdf2b1b1c )
 )
 
 game (
 	name "Battlestorm (USA)"
-	rom ( name "Battlestorm_v1.2_NTSC_2008.lha" size 434609 crc B9A09C1F sha1 2e9d1e840ce0946e3ce29d5e0ba2c54333da8171 )
+	rom ( name "Battlestorm_v1.3_NTSC_2008.lha" size 434304 crc 83ECCDB3 sha1 19061ecfa247983a39c10fbf135a2291c5f3592d )
 )
 
 game (
@@ -1527,12 +1736,12 @@ game (
 
 game (
 	name "Battletoads (Europe)"
-	rom ( name "Battletoads_v1.2_1816.lha" size 1239709 crc F86F0BBB sha1 e3463090bab42eedf4a70261671e8de36dff8e39 )
+	rom ( name "Battletoads_v1.4_1816.lha" size 1243275 crc 12081842 sha1 bee680283ba0fbed6cb3ab547b03b1fb859a64bc )
 )
 
 game (
 	name "Battletoads (Europe) (CD32)"
-	rom ( name "Battletoads_v1.2_CD32.lha" size 1239760 crc B513A050 sha1 1c40db409e30987e7bbe44bdae9893df06d1fa99 )
+	rom ( name "Battletoads_v1.4_CD32.lha" size 1252964 crc FAF03566 sha1 5f98aece8df34563cbf20f23f5b6373b921843f0 )
 )
 
 game (
@@ -1557,17 +1766,22 @@ game (
 
 game (
 	name "Beast Busters (Europe)"
-	rom ( name "BeastBusters_v1.1_1012.lha" size 1179137 crc D7D035C1 sha1 374aaf4eafa8de7669cd9dc371bd2f3c35ff86e0 )
+	rom ( name "BeastBusters_v1.2_1012.lha" size 1180266 crc 0D5FF867 sha1 d01f3ac7d2f9ab669e82735f64df2401da2e772d )
 )
 
 game (
 	name "Beastlord (Europe)"
-	rom ( name "Beastlord_v1.01_2452.lha" size 1265634 crc FCE61D51 sha1 79627962bb56329845e6948e3ea367237ef47fe5 )
+	rom ( name "Beastlord_v1.02_2452.lha" size 1588029 crc 8758F283 sha1 c4f53afeb7649346f9c4a82c5fdc23822e6e4182 )
 )
 
 game (
 	name "Beavers (Europe)"
-	rom ( name "Beavers_v1.1_2575.lha" size 2523998 crc FA19CC96 sha1 dbffeac645cd100b85280f1919d2b5f9b161534a )
+	rom ( name "Beavers_v2.0_2575.lha" size 2549481 crc 5163B917 sha1 9b7f727bb4d9d82fba051f31c0ed1ee6843f61b0 )
+)
+
+game (
+	name "Beavers (Europe) (CD32)"
+	rom ( name "Beavers_v2.0_CD32.lha" size 2634621 crc 8BDBC640 sha1 214ad576a0bee0ba075a628d3708240d40208538 )
 )
 
 game (
@@ -1587,47 +1801,47 @@ game (
 
 game (
 	name "Beneath a Steel Sky (Europe)"
-	rom ( name "BeneathASteelSky_v2.1_0207.lha" size 6458078 crc F322AF3D sha1 9b9f3ff6556ba67b9211cac09ccdddea88e4891e )
+	rom ( name "BeneathASteelSky_v2.1_0207.lha" size 6458308 crc 7AB23A43 sha1 65697086d8e0bd3f62c22487e504ad31b6514c58 )
 )
 
 game (
 	name "Beneath a Steel Sky (Europe) (CD32)"
-	rom ( name "BeneathASteelSky_v2.1_CD32.lha" size 66992224 crc 8948F6FD sha1 6c9920254c734f983f77ba92bfd5705604b98b27 )
+	rom ( name "BeneathASteelSky_v2.2_CD32.lha" size 66993137 crc 25D35CD9 sha1 bb62501dd8f77361aafe02b66045bde52cb38414 )
 )
 
 game (
-	name "Beneath a Steel Sky (No Voice) (Europe) (CD32)"
-	rom ( name "BeneathASteelSky_v2.1_CD32_NoVoice.lha" size 9204191 crc 865CADA7 sha1 723983ab05722426d1b4bc67e43a6b359993d921 )
+	name "Beneath a Steel Sky (Europe) (CD32) (No Voice)"
+	rom ( name "BeneathASteelSky_v2.2_CD32_NoVoice.lha" size 9205104 crc CD226BCF sha1 afa0409a3e54f19f03af1febc8bb8c12724d89a4 )
 )
 
 game (
 	name "Beneath a Steel Sky (Germany)"
-	rom ( name "BeneathASteelSky_v2.1_De_0461.lha" size 6478173 crc 94323E1E sha1 5144aa2fad5487181ba18ad5d37508e385b5342e )
+	rom ( name "BeneathASteelSky_v2.1_De_0461.lha" size 6478403 crc FB696085 sha1 ed1f5e84183b84ffe0c64c85debbec10fb9a74da )
 )
 
 game (
 	name "Beneath a Steel Sky (France)"
-	rom ( name "BeneathASteelSky_v2.1_Fr_2340.lha" size 6479595 crc 37AD2AB7 sha1 322896cf45b3532e0ebdea9e0ddafdd8f5b7117e )
+	rom ( name "BeneathASteelSky_v2.1_Fr_2340.lha" size 6479825 crc F0558542 sha1 12819f3a4d557de30638664092b7156c130faa3e )
 )
 
 game (
 	name "Beneath a Steel Sky (Italy)"
-	rom ( name "BeneathASteelSky_v2.1_It.lha" size 6473063 crc 27E1968F sha1 93d494db79394000d73624b0e3141b48084091bb )
+	rom ( name "BeneathASteelSky_v2.1_It.lha" size 6473293 crc 294BCA6D sha1 475df9c1ee022d653100a3e8097c43d2eb80839e )
 )
 
 game (
 	name "Beneath a Steel Sky (Sweden)"
-	rom ( name "BeneathASteelSky_v2.1_Se.lha" size 6472845 crc 6B063A4D sha1 6e72c0756e9d6ce7c8de7df6b312c5c6f3d53f75 )
+	rom ( name "BeneathASteelSky_v2.1_Se.lha" size 6473075 crc 78586770 sha1 bfade061b58838625cf886ad090585a5749101c9 )
 )
 
 game (
 	name "Benefactor (Europe)"
-	rom ( name "Benefactor_v1.1_0636.lha" size 2108250 crc 145B16C5 sha1 c6343a1041a48aa36cbf024bba3eee82f9145408 )
+	rom ( name "Benefactor_v1.2_0636.lha" size 2109188 crc 01E059C2 sha1 a3f1348a75cd01b2b81f62ef81eb58cd5e0cea51 )
 )
 
 game (
 	name "Benefactor (Europe) (CD32)"
-	rom ( name "Benefactor_v1.1_CD32.lha" size 1746651 crc 4FB8FE33 sha1 85346619207728e9627d929365bae60a56cef5ab )
+	rom ( name "Benefactor_v1.2a_CD32.lha" size 1748353 crc 4DECD5F5 sha1 cdee91b32caf80ef9d2b41c6250649b6d17d7a65 )
 )
 
 game (
@@ -1687,7 +1901,7 @@ game (
 
 game (
 	name "Big Business (Europe)"
-	rom ( name "BigBusiness_v1.0.lha" size 457745 crc 7895E493 sha1 e90a152284e0ce02337469e43164b3426a7736a4 )
+	rom ( name "BigBusiness_v1.01_2816.lha" size 457999 crc 8C40E79C sha1 75674103960cdd8b36b5fa1abc4f4cb8c5e76aee )
 )
 
 game (
@@ -1702,17 +1916,37 @@ game (
 
 game (
 	name "Biing! - Sex, Intrigen und Skalpelle (Germany) (AGA)"
-	rom ( name "Biing_v1.0_AGA_De_0442.lha" size 20131581 crc DE125682 sha1 ec037315d65ca761e5f37e1aa69cb6e8321a5718 )
+	rom ( name "Biing_v1.1_AGA_De_0442.lha" size 20133137 crc F31BBDD2 sha1 666067d856db17ff54574b3e6bf959dd8aa5bbf8 )
+)
+
+game (
+	name "Bill & Ted's Excellent Adventure (USA)"
+	rom ( name "Bill&TedsExcellentAdventure_v1.2_NTSC.lha" size 821316 crc 28901632 sha1 6903a6fb8d769076abe2c1e9ced34c21c2a283c7 )
+)
+
+game (
+	name "Billiards II Simulator (Europe)"
+	rom ( name "Billiards2Simulator_v1.0_1865.lha" size 304627 crc 41C92B6B sha1 b342a67bbb0076ec8bf28223c13ef5bac42acfb1 )
+)
+
+game (
+	name "Billiards Simulator (Europe) (En,Fr,De)"
+	rom ( name "BilliardsSimulator_v1.0_1806.lha" size 343577 crc 602D9813 sha1 8c0032e9121684911ab2b95986bc85d60b54b285 )
 )
 
 game (
 	name "Bill's Tomato Game (Europe)"
-	rom ( name "BillsTomatoGame_v2.0_1748.lha" size 878058 crc 029EE4B6 sha1 1ee0cf1c9175f7a9c66521b440e158029e34b1ca )
+	rom ( name "BillsTomatoGame_v2.1_1748.lha" size 880895 crc 7CFE5F3F sha1 5b7c52d719425cec270db9dbfe537223fcbfeecc )
+)
+
+game (
+	name "Bill's Tomato Game (USA)"
+	rom ( name "BillsTomatoGame_v2.1_NTSC.lha" size 879993 crc C2702847 sha1 021b8184a9537fcd0f32e57e800d6246a6dfe8ac )
 )
 
 game (
 	name "Bio Challenge (Europe)"
-	rom ( name "BioChallenge_v1.1a_1733.lha" size 394794 crc DA0EE77F sha1 0c14c68d3dd66935bd5035ab393e0e44332a4089 )
+	rom ( name "BioChallenge_v1.2_1733.lha" size 394010 crc 00BE33DA sha1 235955f463ae3ffc18d8f8fa2c7e7c706da8de40 )
 )
 
 game (
@@ -1737,7 +1971,12 @@ game (
 
 game (
 	name "Bismarck (Europe)"
-	rom ( name "Bismarck_v1.0_2563&2702.lha" size 197057 crc 57485B1A sha1 6f3a443ded68adb77df7b89decdff0ba826320ce )
+	rom ( name "Bismarck_v1.1_EnFrDe_2563&2702.lha" size 244720 crc 5284B1DD sha1 00e015c4402e8e8e0a0c1a65571eabac374d3cac )
+)
+
+game (
+	name "Bivouac (France)"
+	rom ( name "Bivouac_v1.2_Fr.lha" size 414319 crc 1C67B1F3 sha1 6bba0e72f7440403f06541d3de425fdd42be8828 )
 )
 
 game (
@@ -1751,6 +1990,27 @@ game (
 )
 
 game (
+	name "Black Dawn II (Europe) (Licenceware)"
+	rom ( name "BlackDawn2_v1.1.lha" size 498130 crc 2BC9F286 sha1 10c743553afc51d135fc01f79636cb2ac26ab652 )
+)
+
+game (
+	name "Black Dawn VI: Hellbound (Europe) (Licenceware)"
+	rom ( name "BlackDawn6_v1.0.lha" size 599002 crc EAB6FA6B sha1 ccb13d755f6c43f65cbdc36adee9133ed87a390c )
+)
+
+game (
+	name "Black Dawn (Europe) (PD/Freeware)"
+	rom ( name "BlackDawn_v1.0.lha" size 378758 crc 1A5FE9A9 sha1 79bab0a2d156b922e473d3875815ba8328f6e3e6 )
+)
+
+game (
+	name "Black Dawn Rebirth (Europe)"
+	rom ( name "BlackDawnRebirth_v1.2.lha" size 2401712 crc D9F92441 sha1 ec6cf15731c1dcfbe95fb783cab295de279b00fa )
+)
+
+
+game (
 	name "Black Gold (Europe)"
 	rom ( name "BlackGold_v1.6_ReLINE.lha" size 669181 crc 537EC67F sha1 105445fdc6e6507ee9fc4f917616bb1a6408ff86 )
 )
@@ -1762,7 +2022,7 @@ game (
 
 game (
 	name "Black Lamp (Europe)"
-	rom ( name "BlackLamp_v1.0_0826.lha" size 213851 crc ED52EFE9 sha1 680596b009a60ff25cee0bb873fde952673d92a4 )
+	rom ( name "BlackLamp_v1.3_0826.lha" size 209758 crc AEC54325 sha1 9ff4cc280e3eb3b24d1f04fb41eac1f38c328515 )
 )
 
 game (
@@ -1772,7 +2032,12 @@ game (
 
 game (
 	name "Black Shadow (Europe)"
-	rom ( name "BlackShadow_v1.0_0997.lha" size 335847 crc EC408670 sha1 44c88e81a1e43e071368709850fcb4f988939717 )
+	rom ( name "BlackShadow_v1.1_0997.lha" size 294739 crc 1EA8E919 sha1 ab9bc3c245f02dc53b8947b6316218abc7858b83 )
+)
+
+game (
+	name "Black Strawberry Cake (Europe)"
+	rom ( name "BlackStrawberryCake_v1.0.lha" size 712104 crc E6FBF91C sha1 c8655531d68001cf39ee6a9e295522fa08ab1dcd )
 )
 
 game (
@@ -1782,37 +2047,52 @@ game (
 
 game (
 	name "Black Viper (Europe)"
-	rom ( name "BlackViper_v1.0.lha" size 3138316 crc 97ACB5EE sha1 3b3ddd49df362ffcaed382a53e14a5d270dc0fbd )
+	rom ( name "BlackViper_v1.1.lha" size 3138271 crc C9D60F3A sha1 c0254305e7567185e3e431de1bb1fc448eec7444 )
 )
 
 game (
 	name "Black Viper (Europe) (AGA)"
-	rom ( name "BlackViper_v1.0_AGA.lha" size 3140001 crc B0413B58 sha1 f6626e5f48d9e7c9030abef9a8b0f8e996f13431 )
+	rom ( name "BlackViper_v1.1_AGA.lha" size 3140318 crc CE6EDE9C sha1 e527990c74e59314e2a4a07ee22673ed8f9e6c50 )
 )
 
 game (
 	name "Black Viper (Europe) (CD32)"
-	rom ( name "BlackViper_v1.0_CD32.lha" size 10190599 crc 98F4C274 sha1 e28306e677df9942d011faf28d0c8afd214104cd )
+	rom ( name "BlackViper_v1.1_CD32.lha" size 10193314 crc C920276F sha1 ec6896c765c75f33a783363282ca3cdac05ee345 )
+)
+
+game (
+	name "Blade (Europe) (En,De,Pl)"
+	rom ( name "Blade_v1.0_1801.lha" size 426775 crc 20002CA7 sha1 bbf875695da330b671e87e6a1a2367533f1cc6c1 )
+)
+
+game (
+	name "Blade (Europe) (En,De,Pl) (AGA)"
+	rom ( name "Blade_v1.0_AGA_1801.lha" size 2014639 crc 3BD044B7 sha1 a6fb2cf73ea32fea0e360a197e2bfc11371b5ade )
 )
 
 game (
 	name "Blades of Steel (Europe)"
-	rom ( name "BladesOfSteel_v1.0.lha" size 268477 crc 56424F1A sha1 8aecd11a5a3c4cd5ed444ea6857155749ece2fe1 )
+	rom ( name "BladesOfSteel_v1.01.lha" size 274292 crc 9021687F sha1 564c1a8d5a3a9c60c72f359fa6fbb0ce03beff79 )
 )
 
 game (
 	name "Blade Warrior (Europe)"
-	rom ( name "BladeWarrior_v1.3_2201.lha" size 437700 crc 08312130 sha1 0f6aa0316c32c9646add079de37e88fe53d9054c )
+	rom ( name "BladeWarrior_v2.0_2201.lha" size 437741 crc 56D5C193 sha1 087000bd728545a58517853db36ede0fd5b6a7e2 )
 )
 
 game (
-	name "Blastaball (Arcadia) (Europe)"
+	name "Blastaball (Europe) (Arcadia)"
 	rom ( name "BlastaBall_v0.1_Arcadia.lha" size 269913 crc C3F94BD5 sha1 c873dbc87d9ba5529fe09319f48b97d8da68fa09 )
 )
 
 game (
+	name "Blastaball (Europe)"
+	rom ( name "Blastaball_v1.0_1557.lha" size 196400 crc 32A5A597 sha1 205be9ff0a5febf1691cb43eb2d1045d26ad8423 )
+)
+
+game (
 	name "Blastar (Europe)"
-	rom ( name "Blastar_v2.1.lha" size 2456805 crc 04B0A887 sha1 f5e7e7bc7ee68f154d2889edd3da5de0b49d7b9c )
+	rom ( name "Blastar_v3.0_2814.lha" size 2451315 crc 9ADA5D41 sha1 59dc1861780f60213e40ee10a17d3e006e668f72 )
 )
 
 game (
@@ -1822,12 +2102,12 @@ game (
 
 game (
 	name "Blazing Thunder (Europe)"
-	rom ( name "BlazingThunder_v1.1_2082.lha" size 603148 crc 7DC00016 sha1 02351869d7cb1532d3f433a2d7927b792e36861e )
+	rom ( name "BlazingThunder_v1.2_2082.lha" size 603407 crc BA1BA486 sha1 83acc23286093ef254f0124781f2467df0b90433 )
 )
 
 game (
 	name "Blinky's Scary School (Europe)"
-	rom ( name "BlinkysScarySchool_v1.1_0437.lha" size 289860 crc 40FE9F23 sha1 756f08b8689b6c2b13f585dfb65a590f881f4cd4 )
+	rom ( name "BlinkysScarySchool_v1.2_0437.lha" size 290461 crc 0A29133C sha1 a88108645b0cdfe88cca42018f36220a6956a403 )
 )
 
 game (
@@ -1841,8 +2121,13 @@ game (
 )
 
 game (
+	name "Blockbuster (USA)"
+	rom ( name "Blockbuster_v1.2_NTSC_2058.lha" size 229263 crc 43EF7F44 sha1 bce9420faff0204eb390533d54f279a956b0513f )
+)
+
+game (
 	name "Block Out (Europe)"
-	rom ( name "BlockOut_v1.2_0208.lha" size 220402 crc E1AB4500 sha1 a77dae1ec6b37ccdeaba2d657e46f950984647dd )
+	rom ( name "BlockOut_v1.4_0208.lha" size 227053 crc 55A61F27 sha1 f3705812ba8719c34d64d2a42bfa740f009f7b45 )
 )
 
 game (
@@ -1857,22 +2142,27 @@ game (
 
 game (
 	name "BloodNet - A Cyberpunk Gothic (Europe)"
-	rom ( name "BloodNet_v2.0_2345.lha" size 3498904 crc B4264197 sha1 351b83cbeb875b347f2b9329727a1cf1b03e07a0 )
+	rom ( name "BloodNet_v2.2_2345.lha" size 3500024 crc B24F86D1 sha1 8b4d879e06b5b8842a96b7609a03973e23342408 )
 )
 
 game (
 	name "BloodNet - A Cyberpunk Gothic (Europe) (AGA)"
-	rom ( name "BloodNet_v2.0_AGA_1667.lha" size 7199466 crc 5CFD1BB5 sha1 a424dca299ca23e03f230b64da34f1317236b6d0 )
+	rom ( name "BloodNet_v2.1_AGA_1667.lha" size 7200526 crc 8F123C09 sha1 26e8eaf03adbfd2f69c7d25eec59c6fba8f2b3c2 )
 )
 
 game (
-	name "Bloodwych - The Extended Levels (Europe)"
+	name "Bloodwych & The Extended Levels (Europe)"
 	rom ( name "Bloodwych&ExtendedLevels_v2.51_0439&0043.lha" size 403566 crc C349B39C sha1 f0bb11fdbb8526d7430bc3b0c4ddbfa574594602 )
 )
 
 game (
 	name "Bloodwych (Europe)"
 	rom ( name "Bloodwych_v2.51_0439.lha" size 214170 crc CD8D50E4 sha1 3387ce5c62818e2b038f34ca9519532762718d1c )
+)
+
+game (
+	name "Blork (Europe)"
+	rom ( name "Blork_v1.0.lha" size 365662 crc D8A74A0E sha1 102944e982e01f836d645ac71801bcabc2656ef4 )
 )
 
 game (
@@ -1887,7 +2177,22 @@ game (
 
 game (
 	name "Blueberry (Germany)"
-	rom ( name "Blueberry_v1.0_De.lha" size 536990 crc C37A215A sha1 857af62bec30e1ec2388aa1f133a0f64bf5b5fa6 )
+	rom ( name "BlueBerry_v1.1_De.lha" size 503414 crc 80B723FE sha1 266d1c53a72e2198fadde1e3c4317080d1165f3e )
+)
+
+game (
+	name "Blueberry (Spain)"
+	rom ( name "BlueBerry_v1.1_Es.lha" size 549726 crc 87F31FED sha1 53a2009391332d8643d9656a12105899e8f8c927 )
+)
+
+game (
+	name "Blueberry (France)"
+	rom ( name "BlueBerry_v1.1_Fr.lha" size 550554 crc F1245BA6 sha1 f4023dba5ff5da764c59ca091c0473c32d210033 )
+)
+
+game (
+	name "Blue Boy (Europe)"
+	rom ( name "BlueBoy_v1.0.lha" size 774200 crc 87FF399E sha1 9cdb3d6c9516f41c9b87ff6ed97ff74946edbd21 )
 )
 
 game (
@@ -1906,8 +2211,13 @@ game (
 )
 
 game (
+	name "Bobo (Europe)"
+	rom ( name "Bobo_v1.1.lha" size 445260 crc 9C4E3570 sha1 faacb944ab08c87f05e72acd631074f9bcdd0eae )
+)
+
+game (
 	name "Bobo (France)"
-	rom ( name "Bobo_v1.0b_Fr_1951.lha" size 493935 crc 6F517805 sha1 57352d08a05035fefcd3220806c9088402a7acbe )
+	rom ( name "Bobo_v1.1_Fr_1951.lha" size 445401 crc F9C8F36D sha1 6f0a42c326da5e5f17402832bbec89300fa23036 )
 )
 
 game (
@@ -1918,6 +2228,11 @@ game (
 game (
 	name "Bob's Garden (Europe)"
 	rom ( name "BobsGarden_v1.0.lha" size 50722 crc AE052C7C sha1 b6f33dd873581d877ce7d1af1d7db622c2516fc2 )
+)
+
+game (
+	name "Body Blows (Europe) (Fast)"
+	rom ( name "BodyBlows_v2.0_Fast_1147.lha" size 2872236 crc E00151C8 sha1 874c93486c49f6d7c85863a5c7c3c5af98ba030d )
 )
 
 game (
@@ -1942,7 +2257,12 @@ game (
 
 game (
 	name "Bomber Bob (Europe)"
-	rom ( name "BomberBob_v1.0_1628.lha" size 428456 crc 83FE620F sha1 ebaaeac297ea9edd85593428f82c23a75ff73c47 )
+	rom ( name "BomberBob_v1.1_1628.lha" size 373278 crc 7E3DF497 sha1 640c3c3873a7e9e341e0974248b001476b93f003 )
+)
+
+game (
+	name "Bomber Bob (Italy)"
+	rom ( name "BomberBob_v1.0_It.lha" size 490363 crc 32624CED sha1 02a79f64b47bf83fb81d1e6e6797a5ed76b544e2 )
 )
 
 game (
@@ -1952,37 +2272,52 @@ game (
 
 game (
 	name "Bomb Jack (Europe)"
-	rom ( name "BombJack_v1.1_2797.lha" size 116389 crc BADB368E sha1 548940cdd6e9ca1fd87d8312855a525b059550e2 )
+	rom ( name "BombJack_v1.1_2797.lha" size 121534 crc 0E1422FD sha1 a16c257ca5c9bc96321e6dd59053a28ce47555dc )
 )
 
 game (
-	name "Bombjack - Beer Edition (Europe)"
-	rom ( name "BombJackBeerEdition_v1.0-B.lha" size 224441 crc 46E16BF0 sha1 fb546c8b6154b86bbeddfef8a90fcdde02e3fdb1 )
+	name "Bombjack - Beer Edition (Europe) (PD/Freeware)"
+	rom ( name "BombJackBeerEdition_v1.1.lha" size 211742 crc 90BF6127 sha1 9874e75c2c3c7bd785a221caba361b6cbab6ee04 )
 )
 
 game (
-	name "BombPac (Europe) (AGA)"
+	name "BombPac CD32 (Europe) (AGA) (Shareware)"
 	rom ( name "BombPacCD32_v1.0_AGA.lha" size 323710 crc 49BD88F9 sha1 6052ab9a63716939eed22296c4d973aa51f921aa )
 )
 
 game (
-	name "BombPac (Aminet) (Europe) (AGA)"
+	name "BombPac CD32 (Europe) (AGA) (Shareware) (Aminet)"
 	rom ( name "BombPacCD32_v1.0_AGA_Aminet.lha" size 324226 crc 679607B0 sha1 3d4907d9f9293f5b5ea6135eb5545aec6602e65c )
 )
 
 game (
 	name "Bombuzal (Europe)"
-	rom ( name "Bombuzal_v1.23_1739.lha" size 236928 crc 9A1401FD sha1 c332d6482ed296bd8478635833a4b1bd02781d93 )
+	rom ( name "Bombuzal_v2.0_1738.lha" size 242474 crc E44DDD2B sha1 c01efc4cf6dbf526acadf5e9953faad831236ddb )
 )
 
 game (
-	name "Bomb'X (Europe)"
-	rom ( name "BombX_v1.1.lha" size 348430 crc 05AC36FA sha1 7fca3f5680181d24ed062ca76ddafcad58beb7db )
+	name "Bomb'X (Europe) (Fr)"
+	rom ( name "BombX_v1.1.lha" size 338337 crc CF750F11 sha1 f2ec57c8106bb940e49e7e0ea1aee248357a5cab )
+)
+
+game (
+	name "Bomb'X 1995 - The Scene's Levels (Europe) (En,Fr) (PD/Freeware)"
+	rom ( name "BombXNewLevels_v1.1.lha" size 339982 crc 057B8D1E sha1 2279dee79cf9838069acc2e264bd67dc6d66f97a )
 )
 
 game (
 	name "Bonanza Bros. (Europe)"
 	rom ( name "BonanzaBros_v1.0_0859.lha" size 510140 crc AFA42693 sha1 269f1daf162f0f6072302534a598a8f9eb15c95e )
+)
+
+game (
+	name "BoneCruncher (Europe)"
+	rom ( name "BoneCruncher_v1.0.lha" size 208311 crc B4793395 sha1 9ec3aad2107403c50021391730b37eaa2250c9d2 )
+)
+
+game (
+	name "BoneCruncher (Europe) (Enhanced)"
+	rom ( name "BoneCruncherEnhanced_v1.0.lha" size 155397 crc C9B5578C sha1 9aa051eafd88dca9c5ed95fe1db0049576eae365 )
 )
 
 game (
@@ -2006,17 +2341,37 @@ game (
 )
 
 game (
+	name "Bosse Des Maths 3ème, La (France)"
+	rom ( name "BosseDesMaths3eme_v1.0_Fr.lha" size 263911 crc CA975950 sha1 3b4685942151f64b175868b2d4fe673dccf0effa )
+)
+
+game (
+	name "Bosse Des Maths 4ème, La (France)"
+	rom ( name "BosseDesMaths4eme_v1.0_Fr.lha" size 200348 crc 46F9B10D sha1 aa9ed8a903772ca5589f505307a467ad551edfc4 )
+)
+
+game (
+	name "Bosse Des Maths 5ème, La (France)"
+	rom ( name "BosseDesMaths5eme_v1.0_Fr.lha" size 319124 crc F3205892 sha1 faf64566e46de44949acef92f18bb4e3b086eaf4 )
+)
+
+game (
+	name "Bosse Des Maths 6ème, La (France)"
+	rom ( name "BosseDesMaths6eme_v1.0_Fr.lha" size 323500 crc 68A5AF4D sha1 2a40569a500ef28b3cd373ad399c6291c018af6c )
+)
+
+game (
 	name "Boston Bomb Club (Europe)"
 	rom ( name "BostonBombClub_v1.3_1502.lha" size 317952 crc E52B3488 sha1 8e3f61243bd7786081193a9dd689cd37a1eb758b )
 )
 
 game (
-	name "Boston Bomb Club (Fast) (Europe)"
+	name "Boston Bomb Club (Europe) (Fast)"
 	rom ( name "BostonBombClub_v1.3_Fast_1502.lha" size 318114 crc E0B49A6C sha1 adb31044db04ab21cdaf739b58904a97abc2097e )
 )
 
 game (
-	name "Botics (Europe)"
+	name "Botics (Europe) (En,Fr,De,It)"
 	rom ( name "Botics_v1.1.lha" size 381676 crc 30DA3FB5 sha1 6f6a87649aa3e52bf515c065782ebb43c394111e )
 )
 
@@ -2057,12 +2412,17 @@ game (
 
 game (
 	name "Breach 2 (Europe)"
-	rom ( name "Breach2_v1.0_1195.lha" size 426082 crc A8258260 sha1 1ade0fd52332754c49ccae953ea7af8894d96221 )
+	rom ( name "Breach2_v1.1_1195.lha" size 427342 crc 6DCB58A5 sha1 50b839e282d5437367400e49cf55b6449f489cbe )
+)
+
+game (
+	name "Breach (Europe)"
+	rom ( name "Breach_v1.1.lha" size 227974 crc 3A1EA443 sha1 9085f26f5df4e0107a33a9b7f456497312515fbe )
 )
 
 game (
 	name "Breach (USA)"
-	rom ( name "Breach_v1.0_NTSC_1487.lha" size 227242 crc E429E0E0 sha1 fd8113f183399935948112071e34fab4ba83355d )
+	rom ( name "Breach_v1.1_NTSC_1487.lha" size 227757 crc ABEFF844 sha1 aad91193ffce5b6f135564666faa062426ea3d82 )
 )
 
 game (
@@ -2071,18 +2431,23 @@ game (
 )
 
 game (
+	name "BreakThru (Europe)"
+	rom ( name "BreakThru_v1.1.lha" size 493839 crc 7B610290 sha1 7e9f2c306b89b5c96fbf4019dc8c53ec720a8ae5 )
+)
+
+game (
 	name "Breathless (Europe) (AGA)"
 	rom ( name "Breathless_v1.1_AGA_0178.lha" size 1444110 crc 71347782 sha1 9aeccce532dcee1711190fef38fbd181a89ec168 )
 )
 
 game (
-	name "Breathless (68060) (Europe) (AGA)"
+	name "Breathless (Europe) (AGA) (68060)"
 	rom ( name "Breathless_v1.1_AGA_68060_0178.lha" size 1444990 crc 4B654D83 sha1 65810a1ea1ff4b0f3ad584233a222c4420bb1302 )
 )
 
 game (
-	name "Breathless (Europe) (Demo)"
-	rom ( name "BreathlessDemo_v1.1.lha" size 596167 crc 27A3B758 sha1 7a2911cb4b70864b931f2d849d62cd40b9635500 )
+	name "Breathless (Europe) (AGA) (Demo)"
+	rom ( name "BreathlessDemo_v1.1_AGA.lha" size 596362 crc E9B149E1 sha1 13d1d99ca2b374b64263017d747c9ea130e51542 )
 )
 
 game (
@@ -2096,18 +2461,18 @@ game (
 )
 
 game (
-	name "Brian the Lion (Europe)"
-	rom ( name "BrianTheLion_v1.4_0240.lha" size 2328438 crc CBE5CDDA sha1 9bb3785b9b2b6edcd0e4fd2535c63bdbe2195ed4 )
+	name "Brian the Lion (Europe) (En,Fr,De,It)"
+	rom ( name "BrianTheLion_v2.0_0240.lha" size 2330204 crc DF022682 sha1 2c3d68419f1f50bab0a5fad8e58162819fac4eb1 )
 )
 
 game (
 	name "Brian the Lion (Europe) (En,Fr,De,It) (AGA)"
-	rom ( name "BrianTheLion_v1.4_AGA_0843.lha" size 2464491 crc EF843F05 sha1 3e05f4b8d6b6499c0495ebb934b2b82b8a1262c5 )
+	rom ( name "BrianTheLion_v2.0_AGA_0843.lha" size 2466472 crc 06645772 sha1 9c0f1c8a86c12856fc76f492ba80a6dd7fd2dc78 )
 )
 
 game (
-	name "Brides of Dracula (Europe)"
-	rom ( name "BridesOfDracula_v1.1_0303.lha" size 432628 crc BC1565C7 sha1 038daa610b5180ecb96bdbac2f8d5370b2ae089b )
+	name "Brides of Dracula (Europe) (En,Fr,De,It)"
+	rom ( name "BridesOfDracula_v1.2_0303.lha" size 433056 crc 7C8928BF sha1 049e3fd080118111d499a9149f1e414e0a85407f )
 )
 
 game (
@@ -2126,28 +2491,28 @@ game (
 )
 
 game (
-	name "Brutal - Paws of Fury (Europe)"
+	name "Brutal - Paws of Fury (Europe) (En,Fr,De)"
 	rom ( name "BrutalPawsOfFury_v1.0_0181.lha" size 1508276 crc 87B0CCCE sha1 fd516c24767300fc19adbbc1bfc7a1ca52cc356f )
 )
 
 game (
-	name "Brutal - Paws of Fury (Europe) (CD32)"
+	name "Brutal - Paws of Fury (Europe) (En,Fr,De) (CD32)"
 	rom ( name "BrutalPawsOfFury_v1.0_CD32.lha" size 1204553 crc F36D5417 sha1 434527d9d17c892ca336f3b84018a4550db0a357 )
 )
 
 game (
-	name "Federation Quest 1 - B.S.S. Jane Seymour (Europe)"
+	name "Federation Quest 1 - B.S.S. Jane Seymour (Europe) (En,Fr,De)"
 	rom ( name "BSSJaneSeymour_v1.2_0177.lha" size 1264182 crc 932752CD sha1 9dce47d276351713ec34c8a0249cacc396260f6c )
 )
 
 game (
 	name "Bubba 'n' Stix (Europe)"
-	rom ( name "BubbaNStix_v3.0_1323.lha" size 1457300 crc 049EF24F sha1 eeca5011d4c6617f350a67ad5642395c7cd9b9e6 )
+	rom ( name "BubbaNStix_v3.1_1323.lha" size 1459719 crc 14B2F82F sha1 20d160be64ea0bd20e3144a0814f48bc4f187f8f )
 )
 
 game (
 	name "Bubba 'n' Stix (Europe) (CD32)"
-	rom ( name "BubbaNStix_v3.0_CD32.lha" size 1859313 crc B45D02A7 sha1 c22606c2341b59f39c6afa8a35e4baf2f82ce7c7 )
+	rom ( name "BubbaNStix_v3.1_CD32.lha" size 1859704 crc 4C0DC727 sha1 f872a42ce045f817ca6de629c3b28c11c9f7061b )
 )
 
 game (
@@ -2172,17 +2537,22 @@ game (
 
 game (
 	name "Bubble Bobble (Europe)"
-	rom ( name "BubbleBobble_v2.0_2518.lha" size 137485 crc A7CE26A2 sha1 0d67f5e7495543d67d266e15e262bd0a89732903 )
+	rom ( name "BubbleBobble_v1.3_2518.lha" size 138009 crc B0EE74E5 sha1 91b7c38eb155e5d691b8d9505dd4d55d6846c09b )
 )
 
 game (
 	name "Bubble Bobble (USA)"
-	rom ( name "BubbleBobble_v2.0_NTSC_1342.lha" size 138666 crc 14E5CD33 sha1 74a1aa6ac4e23280468a429bb2c71d7b44a0bf0b )
+	rom ( name "BubbleBobble_v1.3_NTSC_1342.lha" size 139191 crc F2FBCC4B sha1 63346c8ffa2212b570a51bd3ff3ecfc99e290643 )
 )
 
 game (
 	name "Bubble Dizzy (Europe)"
-	rom ( name "BubbleDizzy_v1.1_1644.lha" size 253913 crc F1B4DCD4 sha1 1f0ac3a8fa62a9ee56c8697166552c4b166f1549 )
+	rom ( name "BubbleDizzy_v1.2_1644.lha" size 259585 crc 1BD565E6 sha1 1bd4a4fa6c3e2488b848402f5bfe4d4489408e2d )
+)
+
+game (
+	name "Bubble Ghost (Europe)"
+	rom ( name "BubbleGhost_v1.0_0932.lha" size 221544 crc 729A00A5 sha1 24148c3555864ee8acbbc0adacf25233fb142022 )
 )
 
 game (
@@ -2191,13 +2561,13 @@ game (
 )
 
 game (
-	name "Buck Rogers - Countdown to Doomsday - Science Fiction Role-Playing Computer Game, Vol.I (Germany)"
-	rom ( name "BuckRogers_v1.2_De_0445.lha" size 1054307 crc 4846728B sha1 af19ef1a2ba2ff1aa37da971aa1490cb90c23612 )
+	name "Buck Rogers - Countdown to Doomsday (Germany)"
+	rom ( name "BuckRogers_v1.3_De_0445.lha" size 1055385 crc DA3D1CCD sha1 5a1b83457b7facbb3c1069f00e01c63622d86239 )
 )
 
 game (
-	name "Buck Rogers - Countdown to Doomsday - Science Fiction Role-Playing Computer Game, Vol.I (USA) (v1.0) (Europe)"
-	rom ( name "BuckRogers_v1.2_NTSC_1994.lha" size 1052613 crc 738D635E sha1 05a1bf47c9989a5945eac681d426195017a8a2f3 )
+	name "Buck Rogers - Countdown to Doomsday (USA)"
+	rom ( name "BuckRogers_v1.3_NTSC_1994.lha" size 1053693 crc 3467876D sha1 0f5019f620c23748c3eada8ffa4b1467fe3a1968 )
 )
 
 game (
@@ -2217,27 +2587,27 @@ game (
 
 game (
 	name "Bug Bomber (Europe)"
-	rom ( name "BugBomber_v1.0_1579.lha" size 176114 crc 72ECB2BA sha1 2bb1eaf2bfbdca0c0909e75ac41cf2b378c79474 )
+	rom ( name "BugBomber_v1.1_1579.lha" size 176426 crc 7BDFE6EA sha1 d9eb6a69cee6df35369bd4ee3dbceac49fd58d39 )
 )
 
 game (
 	name "Buggy Boy (Europe)"
-	rom ( name "BuggyBoy_v1.2_0465.lha" size 171429 crc 8BE76265 sha1 11e8b3035413296e9e3c84872107e5a27b7da5bf )
+	rom ( name "BuggyBoy_v1.3_0465.lha" size 172665 crc 903A3D7B sha1 454f7a169ff8d64632e97144e3f734c620165ee5 )
 )
 
 game (
 	name "Builderland (Europe)"
-	rom ( name "Builderland_v1.0a_1923.lha" size 323447 crc A327436D sha1 d8bf101ee7864f506cb3d0325914b8c5584df399 )
+	rom ( name "Builderland_v1.1_1923.lha" size 323490 crc 5835D905 sha1 78dad95081e24f7a83873876b858814183d44e22 )
 )
 
 game (
 	name "Bump 'n' Burn (Europe) (CD32)"
-	rom ( name "BumpNBurn_v1.0_CD32.lha" size 5158805 crc 77559978 sha1 3caf82166813faadcca8097b2715ced0ea0255d3 )
+	rom ( name "BumpNBurn_v1.2_CD32.lha" size 5159859 crc 5A3466E7 sha1 8c11c3bb8cc3c1799afc12661dbee3a459288d43 )
 )
 
 game (
 	name "Bump 'n' Burn (Europe)"
-	rom ( name "BumpNBurn_v1.1.lha" size 4941702 crc 6D08A8BB sha1 9dba7f8bf5993509a3dbbd260ee7466e4317b7c6 )
+	rom ( name "BumpNBurn_v1.2_2920.lha" size 4941942 crc 120BAF5F sha1 d3187adde80302e754a4ab3de721459eb6552487 )
 )
 
 game (
@@ -2247,12 +2617,12 @@ game (
 
 game (
 	name "Bundesliga Manager Hattrick (Germany) (AGA)"
-	rom ( name "BundesligaManagerHattrick_v0.9_De_AGA_0791.lha" size 1544345 crc 001F4F00 sha1 d8c3c2bf506fe43103e2ff9723552ecb901e32b2 )
+	rom ( name "BundesligaManagerHattrick_v1.0_AGA_De.lha" size 2156882 crc 365FAD5D sha1 3d41411bee161955933b1920cc9ec53a947593c4 )
 )
 
 game (
 	name "Bundesliga Manager Professional (Germany)"
-	rom ( name "BundesligaManagerProfessional_v1.01_De.lha" size 1081686 crc A0D90E41 sha1 586649d089da1ae09bd1fd8dc0117bebc01911f9 )
+	rom ( name "BundesligaManagerProfessional_v1.02_De.lha" size 1082020 crc 0EEAA05F sha1 3102f271b1d45a67ffd9c8f8da5021aad2bcf3d0 )
 )
 
 game (
@@ -2261,7 +2631,7 @@ game (
 )
 
 game (
-	name "Bunny Bricks (Fast) (Europe)"
+	name "Bunny Bricks (Europe) (Fast)"
 	rom ( name "BunnyBricks_v1.2_Fast_0211.lha" size 722322 crc 42711D17 sha1 96faf9dde388e8d277761e0d1c8aca457b202e5b )
 )
 
@@ -2271,13 +2641,13 @@ game (
 )
 
 game (
-	name "Burning Rubber (2 MB) (Europe)"
-	rom ( name "BurningRubber_v1.3_2MB_2181.lha" size 2924910 crc E34FDC0F sha1 3c0a1fb68280d2eb2076397cddcfec99d7bbd2da )
+	name "Burning Rubber (Europe)"
+	rom ( name "BurningRubber_v1.5a.lha" size 2706137 crc E2CC642B sha1 6d9cebf3b80478cc7a27971ab61f5816f8ad7546 )
 )
 
 game (
-	name "Burning Rubber (Europe)"
-	rom ( name "BurningRubber_v1.4.lha" size 2679272 crc 46E21E2F sha1 969a31b257286f448e1c6c9cce214c107aa99301 )
+	name "Burning Rubber (Europe) (Enhanced)"
+	rom ( name "BurningRubber_v1.5a_Enhanced_2181.lha" size 2960699 crc CF754F65 sha1 f1c02b746d4db9a5820beab1e87559eee91dbada )
 )
 
 game (
@@ -2307,12 +2677,12 @@ game (
 
 game (
 	name "Butcher Hill (Europe)"
-	rom ( name "ButcherHill_v1.0.lha" size 673852 crc 860AFA2E sha1 cf7a01e853c1804a303f18f3ac9c1e143c630c94 )
+	rom ( name "ButcherHill_v1.0.1.lha" size 689445 crc 8D413367 sha1 45e15314537a4c50e7e06cfae76489c4b3c0b3b1 )
 )
 
 game (
 	name "Cabal (Europe)"
-	rom ( name "Cabal_v1.2a_0638.lha" size 598730 crc 1A1CA806 sha1 e72a22863ede5b0044360c32718ad3172b690063 )
+	rom ( name "Cabal_v1.3_0638.lha" size 599281 crc D6E3E829 sha1 9b7cbf4b23715b87511ac490215be7dda4118df2 )
 )
 
 game (
@@ -2321,28 +2691,33 @@ game (
 )
 
 game (
-	name "Cabaret Asteroids (Repacked) (Europe)"
+	name "Cabaret Asteroids (Europe) (Repacked)"
 	rom ( name "CabaretAsteroids_v1.1_Repacked.lha" size 54269 crc 084289DE sha1 25841d53508739d1f36876320ceea837cf83df8f )
 )
 
 game (
-	name "Cadaver + Cadaver - The Pay Off (Europe)"
-	rom ( name "Cadaver&ThePayoff_v2.4_0900.lha" size 2169581 crc 721F24F2 sha1 912996df5303309937047dcafd24e2cf0a266e9d )
+	name "Cadaver + Cadaver - The Pay Off (Europe) (En,Fr,De)"
+	rom ( name "Cadaver&ThePayoff_v3.2_0900.lha" size 2171581 crc 12018128 sha1 ea5c928cc1341d4ae67644f0aa0ddf33c6fe4217 )
 )
 
 game (
-	name "Cadaver (Europe) (Demo)"
-	rom ( name "CadaverDemos_v1.1.lha" size 568949 crc B4707A6F sha1 7ae03ae8c9c7f9c2e4466c7ac48f9a1745307370 )
+	name "Cadaver (Europe) (Demos)"
+	rom ( name "CadaverDemos_v1.2.lha" size 569025 crc F841A92B sha1 882a1f0dbb546d480c34fa6d2c2bd556870dff1a )
 )
 
 game (
-	name "Caesar (Europe)"
+	name "Caesar (Europe) (En,Fr,De)"
 	rom ( name "Caesar_v1.0_3085.lha" size 577944 crc 286F4AED sha1 863127615a58f0ce2d550d774f8913c433803720 )
 )
-
+	
 game (
 	name "Calephar (Europe)"
-	rom ( name "Calephar_v1.0_Image.lha" size 794923 crc C656ABEA sha1 851a0dc4e6f9871f8a4a9f92d802d554cc18cc5f )
+	rom ( name "Calephar_v1.1_Files_2661.lzx" size 768623 crc 15B43493 sha1 1d8fb76701b08c5f607ccf55daef4a816db5f467 )
+)
+
+game (
+	name "Calephar (Europe) (Image)"
+	rom ( name "Calephar_v1.1_Image_2661.lha" size 795027 crc EEBC4B3E sha1 e94c1f2186fe80f2c1cd061147578d21b54cb062 )
 )
 
 game (
@@ -2352,22 +2727,27 @@ game (
 
 game (
 	name "California Games (Europe)"
-	rom ( name "CaliforniaGames_v1.0_1445.lha" size 569976 crc 21FB01A4 sha1 cc01d557e0da7229b70613b41413ce3695735ed1 )
+	rom ( name "CaliforniaGames_v1.1_1445.lha" size 570701 crc 2628FC99 sha1 58e18e36965998d27ded909f0a17fdb807c01fe5 )
 )
 
 game (
 	name "Campaign & From North Africa to Northern Europe (Europe)"
-	rom ( name "Campaign&DataDisk_v1.1.lha" size 1728199 crc 13A926B9 sha1 06b3aaa9394558959c4dbc2d7fb0e0ce2f1ce339 )
+	rom ( name "Campaign&DataDisk_v1.2.lha" size 1728871 crc E9553E28 sha1 a66a5d83dc33165d7d0b29787a35a51cb36e9605 )
 )
 
 game (
-	name "Campaign II - 50 Years of Global Conflict (Europe)"
+	name "Campaign II - 50 Years of Global Conflict (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Campaign2_v1.2.lha" size 1187780 crc 630720F0 sha1 66c24fe7c6fe5a4b1b02d648d8a9ef7a1bb026ba )
 )
 
 game (
 	name "Campaign - Tactical & Strategic War Simulation (Europe)"
-	rom ( name "Campaign_v1.1.lha" size 1030477 crc 1D3E6D14 sha1 0b7ba3ca19f0d4b1707c46f24dcc81509e08f07f )
+	rom ( name "Campaign_v1.2.lha" size 1031144 crc B3D63815 sha1 3de9196135137e4742efefbf4c1daea25aeef1b0 )
+)
+
+game (
+	name "Candy Puzzle (Europe)"
+	rom ( name "CandyPuzzle_v1.0_CD32.lha" size 1673431 crc 1FD9BBD6 sha1 394ea3e55ae9684e980249358019dabbfa38157d )
 )
 
 game (
@@ -2386,7 +2766,7 @@ game (
 )
 
 game (
-	name "Cannon Fodder 2 - Alien Levels (Europe)"
+	name "Cannon Fodder 2 - Alien Levels (Europe) (Coverdisk - Amiga Power #45)"
 	rom ( name "CannonFodder2AlienLevels_v1.0.lha" size 253700 crc 6C1A6722 sha1 c53ed056b80967187e649cc771559ba2b7695fe8 )
 )
 
@@ -2416,28 +2796,28 @@ game (
 )
 
 game (
-	name "Cannon Fodder - New Campaign (Europe)"
-	rom ( name "CannonFodderNewCampaign_v1.3.lha" size 1532481 crc CEB84237 sha1 caef1911c1ad5fc6be0aca29d9f7dac541c364f9 )
+	name "Cannon Fodder - New Campaign (Europe) (Unl)"
+	rom ( name "CannonFodderNewCampaign_v2.0.lha" size 1533244 crc B08193DF sha1 54f118602d8b751533f11c9b3f92f26cf23abeed )
 )
 
 game (
-	name "Cannon Fodder Plus! (Europe)"
+	name "Cannon Fodder Plus! (Europe) (Coverdisk - Amiga Power #31)"
 	rom ( name "CannonFodderPlus_v1.0_0060.lha" size 400024 crc A441056E sha1 562e72390bfc41eddcb9a06458eeec5ce166f4f9 )
 )
 
 game (
-	name "Cannon Fodder - Amiga Format Christmas Special (Europe)"
+	name "Cannon Soccer (Europe) (Coverdisk - Amiga Format #54)"
 	rom ( name "CannonSoccer_v1.0_0165.lha" size 213762 crc 5D66A688 sha1 5969aaea36cfb84526596e978b63d1dbe31fb1e2 )
 )
 
 game (
 	name "Capital Punishment (Europe) (En,De) (AGA)"
-	rom ( name "CapitalPunishment_v1.1a_AGA_1758.lha" size 5704117 crc D73BB667 sha1 afcdd2076eacc15ea9ca217a0c8038846b38e48d )
+	rom ( name "CapitalPunishment_v1.2_AGA_1758.lha" size 5706043 crc D7D62CAD sha1 d7d8f50bd9702767c4e4e11f9cb2f76c0ec86713 )
 )
 
 game (
-	name "Capital Punishment (CD) (Europe) (AGA)"
-	rom ( name "CapitalPunishment_v1.1a_AGA_CD.lha" size 5683989 crc FA8B511A sha1 eddfc790bfea5f1950be339fb789aa8522a24906 )
+	name "Capital Punishment (Europe) (En,De) (AGA) (CD)"
+	rom ( name "CapitalPunishment_v1.2_AGA_CD.lha" size 5685913 crc BE01A31B sha1 832590b7438258853dfcdeac386bb17a4b597d88 )
 )
 
 game (
@@ -2447,32 +2827,37 @@ game (
 
 game (
 	name "Capone (Europe)"
-	rom ( name "Capone_v1.1.lha" size 328269 crc 9D506194 sha1 fafa13785d25b58c9a6b85ef58bf82965fa123b3 )
+	rom ( name "Capone_v1.2.lha" size 328856 crc C030F752 sha1 b33bc9d5eac3377a737732357080d27d496e0536 )
 )
 
 game (
 	name "Captain Blood (Europe)"
-	rom ( name "CaptainBlood_v1.1_0443.lha" size 464360 crc 4D66834D sha1 96653465d4a0349459c038394860557dc8fde32f )
+	rom ( name "CaptainBlood_v1.2_0443.lha" size 474260 crc BED8B9BD sha1 0ff65bcd01cefb6a7fe6e9ff70bef2094460536f )
 )
 
 game (
 	name "Captain Blood (USA)"
-	rom ( name "CaptainBlood_v1.1_NTSC_0466.lha" size 544838 crc 11020A68 sha1 e04aba04e383bfff98cfcf626f4b3a78a75a1db0 )
+	rom ( name "CaptainBlood_v1.2_NTSC_0466.lha" size 545104 crc EC8E14EC sha1 7a59cb6a2a1dadaf42f1db7bdd5a176ea61403b4 )
 )
 
 game (
-	name "Captain Fizz Meets the Blaster-Trons (Europe)"
+	name "Captain Fizz Meets the Blaster-Trons (Europe) (En,Fr,De)"
 	rom ( name "CaptainFizz_v1.1_1777.lha" size 274544 crc 56E62A26 sha1 e580fdf350e05036421d1acbb8b6f3527e93ce17 )
 )
 
 game (
 	name "Captain Planet and the Planeteers (Europe)"
-	rom ( name "CaptainPlanet&ThePlaneteers_v1.0_1448.lha" size 769665 crc 132D0747 sha1 c0a15037b5fc9e8d32cc17912caa8f8e93e05f89 )
+	rom ( name "CaptainPlanet_v2.0a.lha" size 851138 crc 2234134F sha1 7522dbc3da2275a4530e5b7ca1d73fbb44ad065f )
+)
+
+game (
+	name "Captain Planet and the Planeteers (Europe) (A600 Pack)"
+	rom ( name "CaptainPlanet_v2.0a_A600Pack_1448.lha" size 776250 crc E0D51A71 sha1 4009cbe60094742bc1682cc23739724c8c9ad5a5 )
 )
 
 game (
 	name "Captive (Europe)"
-	rom ( name "Captive_v1.0_2164.lha" size 828120 crc 212B7631 sha1 07a4414ce6b5756dcf300b2497d220902358b347 )
+	rom ( name "Captive_v2.0_2164.lha" size 842479 crc 0F1FDCAA sha1 01a386cc5f0ce6b01d6c0a669186aa76866fe8f0 )
 )
 
 game (
@@ -2482,17 +2867,17 @@ game (
 
 game (
 	name "Cardiaxx (Europe)"
-	rom ( name "Cardiaxx_v1.0a_ElectronicZoo_1601.lha" size 467149 crc 785B0023 sha1 d96ccec984cd710c219de592355c54388d6e7e55 )
+	rom ( name "Cardiaxx_v2.1_ElectronicZoo_1601.lha" size 467381 crc 88AB22C4 sha1 44949ec4a8adfec0e6eaac3caeef55c7ecb026b3 )
 )
 
 game (
 	name "Cardiaxx (Europe) (Budget - Team 17)"
-	rom ( name "Cardiaxx_v1.0a_Team17_2362.lha" size 460810 crc 522F39F1 sha1 3706d610fa311eea2a491d5280e721c0e7f0aa05 )
+	rom ( name "Cardiaxx_v2.1_Team17_2362.lha" size 462176 crc 63A9A923 sha1 aee4cf2f1a3cb2e76cdf92fe4c0b4c3aa8ad2962 )
 )
 
 game (
 	name "Cardinal of the Kremlin, The (Europe)"
-	rom ( name "CardinalOfTheKremlin_v1.0.lha" size 380122 crc 4800C809 sha1 767589dde632aee8bc9e2d7edc3be8070aae9fbf )
+	rom ( name "CardinalOfTheKremlin_v1.01.lha" size 382489 crc 607CAAB5 sha1 25645e1f7c940a6759720bd915c658bbda527a3a )
 )
 
 game (
@@ -2501,43 +2886,48 @@ game (
 )
 
 game (
-	name "Carlos (Europe)"
-	rom ( name "Carlos_v1.0_2299.lha" size 717043 crc 7BAA0ACA sha1 c627e20b10b231063a310dd9f0ed899c3a657b7f )
+	name "Carl Lewis Challenge, The (USA)"
+	rom ( name "CarlLewisChallenge_v1.1_NTSC.lha" size 660254 crc 827E5E41 sha1 54fc140a4605418913fe48d97ca521ff64f7bc1d )
 )
 
 game (
-	name "Carnage (Zeppelin Platinum) (Europe)"
-	rom ( name "Carnage_v1.0.lha" size 372501 crc D00720FE sha1 ed8ae55dbf2445df29648694eeeda8b8763fc495 )
+	name "Carlos (Europe) (En,Fr,De)"
+	rom ( name "Carlos_v1.2_2229.lha" size 690588 crc B98A0B82 sha1 6bae33a92816e797727499e9712dba47f5dfd257 )
+)
+
+game (
+	name "Carnage (Europe) (Zeppelin Platinum)"
+	rom ( name "Carnage_v2.0.lha" size 355297 crc F073FD33 sha1 4d842efd80a81c4e43a73d06d6d549007b3f2126 )
 )
 
 game (
 	name "Carrier Command (Europe)"
-	rom ( name "CarrierCommand_v1.3_0813.lha" size 550591 crc 870C8390 sha1 66b7d313bb163cfec5e1515745c67c1e4f4070bd )
-)
-
-game (
-	name "Carrier Command (No Music) (Europe)"
-	rom ( name "CarrierCommand_v1.3_NoMusic.lha" size 208119 crc 1DD62889 sha1 748a7de696fa6a6ac83ddde8219af89d70a85ffb )
+	rom ( name "CarrierCommand_v1.5_0813.lha" size 585588 crc 7B27C1D2 sha1 ab348826525a12ad3f7ec044594bcfe1901c435d )
 )
 
 game (
 	name "Carthage (Europe)"
-	rom ( name "Carthage_v1.1_2328.lha" size 918865 crc F7073F8B sha1 c979f8bbc566922e9f08852e7e618c1806853a79 )
+	rom ( name "Carthage_v1.2_2328.lha" size 919225 crc E00692E3 sha1 19a9bce6f28dea0d2251699daeb9bdca93a9690c )
 )
 
 game (
 	name "Carthage (USA)"
-	rom ( name "Carthage_v1.1_NTSC_2329.lha" size 918512 crc FC19BE5B sha1 c911d7d1d58fa77ff322801a6ad6e0475aeb3200 )
+	rom ( name "Carthage_v1.2_NTSC_2329.lha" size 918356 crc EE69E1F7 sha1 65f0fd27f744ba242ba5bc7677238aa1d3200ee0 )
 )
 
 game (
-	name "Carton Rouge (France)"
-	rom ( name "CartonRouge_v1.2_Fr.lha" size 2295401 crc 615BFE50 sha1 3eadca7b1df95ded5eb9065b2f57239104a3e63b )
+	name "Carton Rouge - League Edition (France)"
+	rom ( name "CartonRougeLeagueEdition_v2.0_Fr.lha" size 2296796 crc 6879BAF7 sha1 93112e0e418706f69a8cca42699a9e0d6a49a6a1 )
+)
+
+game (
+	name "Carton Rouge - League Edition (France) (AGA)"
+	rom ( name "CartonRougeLeagueEdition_v2.0_AGA_Fr.lha" size 3063248 crc C510E63D sha1 f9e24a23441a5a690e3dc4684b10a6dd9e6420d1 )
 )
 
 game (
 	name "Cartoons, The (Europe)"
-	rom ( name "Cartoons_v1.1.lha" size 1507477 crc 1F5E0B5A sha1 95064293ac797de1002979cf28bbf8245dab2b97 )
+	rom ( name "Cartoons_v1.2.lha" size 1507783 crc 69B0410B sha1 aeb98fd654b5a42e8b6a676ee418ca06e150cb14 )
 )
 
 game (
@@ -2556,13 +2946,18 @@ game (
 )
 
 game (
-	name "Castle Master II - The Crypt (Europe)"
-	rom ( name "CastleMaster2_v1.11_0612.lha" size 665559 crc C309A299 sha1 4ce8d435027c2e39def963165af2d53c24dc8bc2 )
+	name "Castle Master & Castle Master II - The Crypt (Europe)"
+	rom ( name "CastleMaster&TheCrypt_v2.0_0612.lha" size 567275 crc 40260C37 sha1 40328c33efb34709d4f149caf97b7e11cd3c64b0 )
 )
 
 game (
-	name "Castle Master (Europe)"
-	rom ( name "CastleMaster_v1.20.1.lha" size 334595 crc C24B0C30 sha1 edf2dc03dbb3eb17b5bd12a36286d945cbdbaf34 )
+	name "Castle Master II - The Crypt (Europe)"
+	rom ( name "CastleMaster2_v2.0b_0612.lha" size 240947 crc 6B6B1BA4 sha1 ca95feb75df824757ee1e6940191e5608ea19419 )
+)
+
+game (
+	name "Castle Master (Europe) (En,Fr,De)"
+	rom ( name "CastleMaster_v2.0_0447.lha" size 342910 crc B1CFD189 sha1 a519f8bbf05b7d85109471377eae399d96e9a42e )
 )
 
 game (
@@ -2571,7 +2966,7 @@ game (
 )
 
 game (
-	name "Castle of Dr. Brain (MT32) (Germany)"
+	name "Castle of Dr. Brain (Germany) (MT32)"
 	rom ( name "CastleOfDrBrain_v1.1_De_MT32_0304.lha" size 2351680 crc 54B79645 sha1 4799ab40eb4888878af002e27b58df39d98c1415 )
 )
 
@@ -2607,7 +3002,12 @@ game (
 
 game (
 	name "Castle Warrior (Europe)"
-	rom ( name "CastleWarrior_v1.0b.lha" size 703579 crc E9BAED58 sha1 2e8a628d853cccf6207a493973de715b0174c9de )
+	rom ( name "CastleWarrior_v1.1_2289.lha" size 703032 crc 6048A3F7 sha1 80e188866177546826e733c2b9e3aa7cdbb42bfc )
+)
+
+game (
+	name "Castors Juniors Dans La Forêt, Les (France)"
+	rom ( name "CastorsJuniorsDansLaForet_v1.0_Fr.lha" size 428597 crc 62C69A14 sha1 c9443e3635fe66ea504d3bbbea59acfb9d0b7a22 )
 )
 
 game (
@@ -2626,38 +3026,58 @@ game (
 )
 
 game (
+	name "Cave Runner (Europe)"
+	rom ( name "CaveRunner_v1.0.lha" size 75526 crc A47D4EA9 sha1 44fbf7b25d54612c27bf43c245f229dd74016786 )
+)
+
+game (
 	name "Cavitas (Europe)"
 	rom ( name "Cavitas_v1.1_2251.lha" size 736636 crc DA47575E sha1 a0791916292ced68fc923875ba0ccd1845c47e1b )
 )
 
 game (
 	name "Cedric and the Lost Sceptre (Europe)"
-	rom ( name "Cedric_v1.1.lha" size 2612663 crc 83F5E7C3 sha1 d3dff0263dd630118f059fb6290b2a9fdf83c0d9 )
+	rom ( name "Cedric_v2.3.lha" size 2764059 crc 1EDE7F08 sha1 88f1e992fe308ef87338147d12fa76e948760738 )
 )
 
 game (
 	name "Cedric and the Lost Sceptre (Europe) (CD32)"
-	rom ( name "Cedric_v1.1_CD32.lha" size 2755615 crc 9F296BFF sha1 e9ce3e9459f0df86d422a11f6761feefc00d56bc )
+	rom ( name "Cedric_v2.3_CD32.lha" size 2763936 crc F87F5E02 sha1 02122d776099409c79e84e7ee74920c97c2d3b2a )
 )
 
 game (
-	name "Cedric and the Lost Sceptre (Fast) (Europe) (CD32)"
-	rom ( name "Cedric_v1.1_CD32_Fast.lha" size 2755842 crc F86297C9 sha1 5dc7a5aec7dbe0d2f13cc4fbae93dcfc7079c96e )
+	name "Celtic Heart (Europe)"
+	rom ( name "CelticHeart_v1.0.lha" size 664155 crc A0C725AC sha1 7c07b5d01946b2984f71929b0993d7eaf5520009 )
 )
 
 game (
-	name "Cedric and the Lost Sceptre (Fast) (Europe)"
-	rom ( name "Cedric_v1.1_Fast.lha" size 2612883 crc C0847F44 sha1 f83162cc3b1564cacefb6ef4508aed3c85670fe8 )
-)
-
-game (
-	name "Celtic Legends (Europe)"
+	name "Celtic Legends (Europe) (En,Fr,De,It)"
 	rom ( name "CelticLegends_v1.4_1281.lha" size 695599 crc 73A16BE7 sha1 8b7805388459e17bcb1377ed1645d700f8f451ba )
 )
 
 game (
+	name "Centerbase - Science-Fiction Simulation (Europe) (En,De)"
+	rom ( name "Centerbase_v1.1_2785.lha" size 556749 crc D77F2A7B sha1 38c91503ee48940661b46922e9c6b114de75a8be )
+)
+
+game (
+	name "Center Court 2 (Europe) (AGA)"
+	rom ( name "CenterCourt2_v1.1_AGA.lha" size 2716353 crc 99F768D6 sha1 3024f4f85d62c0ed9f9cccecd8077ccca9e71c5b )
+)
+
+game (
+	name "Center Court (Europe)"
+	rom ( name "CenterCourt_v1.0_2765.lha" size 1152319 crc 709EFCAE sha1 22af30beff772fed939427cee36127300eb9f676 )
+)
+
+game (
+	name "Center Court (Europe) (AGA)"
+	rom ( name "CenterCourt_v1.0_AGA_2765.lha" size 1152570 crc F0603CE9 sha1 eb5cb11ff78236a7391871fe7cb8f551a2c3bf5b )
+)
+
+game (
 	name "Centerfold Squares (Europe)"
-	rom ( name "CentrefoldSquares_v1.0_0467.lha" size 657764 crc 3ECFBDA6 sha1 56277fa6a7e87fb0e3529bb1f0f8fd18208152df )
+	rom ( name "CenterfoldSquares_v1.1_0467.lha" size 663907 crc 80CB7D1C sha1 a08089c11a27f0e7fab017c93a9ca10e688a8568 )
 )
 
 game (
@@ -2666,18 +3086,43 @@ game (
 )
 
 game (
-	name "Century (Europe)"
+	name "Century (Europe) (En,De)"
 	rom ( name "Century_v1.0_0640.lha" size 256901 crc CA57BE10 sha1 4cf112679e3b275e5f973baffc5d40a99dd78b3f )
 )
 
 game (
+	name "Challenge Foot Senior (France)"
+	rom ( name "ChallengeFoot_v1.0_Fr.lha" size 285233 crc D859642C sha1 84acf21ece954d18a5b755459b88f3df64b5393b )
+)
+
+game (
+	name "Challenge Golf (Europe)"
+	rom ( name "ChallengeGolf_v1.0_1015.lha" size 285348 crc 0220C9DD sha1 16c2e9b68d8a2ef512a539885316a77474f1bf72 )
+)
+
+game (
+	name "Challenger (Europe)"
+	rom ( name "Challenger_v1.0.1_2704.lha" size 213222 crc 969F4C87 sha1 2ea7d096742957b25d1dc3705610889f4074d07b )
+)
+
+game (
 	name "Chamber of the Sci-Mutant Priestess (USA)"
-	rom ( name "ChamberOfTheSciMutantPriestess_v1.1b_NTSC_3037.lha" size 507867 crc 45EC1926 sha1 177c4b394c1ed1ceb7a22a8bd2459aaae8675a0d )
+	rom ( name "ChamberOfTheSciMutantPriestess_v1.2_NTSC_3037.lha" size 528153 crc FD7EF59C sha1 b68eeee22eb3a96c181b41415efc3ce01844e372 )
 )
 
 game (
 	name "Chambers of Shaolin (Europe)"
-	rom ( name "ChambersOfShaolin_v1.2_3049.lha" size 703942 crc 5D8D45AA sha1 b0361b7c27659780f253598e8d6b8375693f9b96 )
+	rom ( name "ChambersOfShaolin_v2.0_3049.lha" size 704799 crc 158F6FAA sha1 b3a8cbda30e84668fb2e2961cf9fdccb1ad5e33c )
+)
+
+game (
+	name "Chambers of Shaolin (Europe) (CD32)"
+	rom ( name "ChambersOfShaolin_v2.0_CD32.lha" size 726109 crc FB85401E sha1 b214f8f5b33cd27a20c47d0da555b3264fbcf026 )
+)
+
+game (
+	name "Chamonix Challenge (Europe)"
+	rom ( name "ChamonixChallenge_v1.2_2281.lha" size 418571 crc 2DB18C1F sha1 c09298561439449dfdb0a716b64e726db3f7fa0b )
 )
 
 game (
@@ -2711,6 +3156,11 @@ game (
 )
 
 game (
+	name "Chaos Engine 2, The (Europe) (1 MB)"
+	rom ( name "ChaosEngine2_v2.6_1MB_0172.lha" size 2604083 crc CEDD28F4 sha1 03561f67bb97729e308371f633cd9469138d7fc6 )
+)
+
+game (
 	name "Chaos Engine 2, The (Europe) (AGA)"
 	rom ( name "ChaosEngine2_v2.6_AGA_0173.lha" size 2468981 crc 9D798779 sha1 14ad81d3628f2068f282989192fcd9598b51450f )
 )
@@ -2737,12 +3187,12 @@ game (
 
 game (
 	name "Chaos in Andromeda - Eyes of the Eagle (Europe)"
-	rom ( name "ChaosInAndromeda_v1.0.lha" size 533462 crc 427091BC sha1 b4460556e5e43a100258183e0f2744941a058c50 )
+	rom ( name "ChaosInAndromeda_v1.1_1210.lha" size 553336 crc AE2C6676 sha1 d70d58c4be67dfdf32dad774613d83f72b02c486 )
 )
 
 game (
 	name "Chaos in Andromeda - Eyes of the Eagle (Europe) (CDTV)"
-	rom ( name "ChaosInAndromeda_v1.0_CDTV.lha" size 33300505 crc 5F926E56 sha1 c2404736dd031a160d1ce0ba7e3a198e11bdde1d )
+	rom ( name "ChaosInAndromeda_v1.1.1_CDTV.lha" size 33445768 crc BF1141A7 sha1 2b1f6497edc336055428cddcc45f7c2f09e7ada5 )
 )
 
 game (
@@ -2761,6 +3211,11 @@ game (
 )
 
 game (
+	name "Chariots of Wrath (Europe)"
+	rom ( name "ChariotsOfWrath_v1.0_2804.lha" size 477729 crc 8C46774F sha1 cb5e89247495351665d0b73316c62241325da9c1 )
+)
+
+game (
 	name "Charlie J. Cool (Europe)"
 	rom ( name "CharlieJCool_v1.2.lha" size 1410248 crc BC472578 sha1 88b311c953e1b3111dfc53aa4cf995b993a7c016 )
 )
@@ -2771,8 +3226,18 @@ game (
 )
 
 game (
+	name "Charly (Europe)"
+	rom ( name "Charly_v1.0.lha" size 177807 crc 4D7F1468 sha1 ad1087e750ff894fa847109b753cd93eb60902da )
+)
+
+game (
+	name "Charon 5 (Europe)"
+	rom ( name "Charon5_v1.0_2685.lha" size 107119 crc 542043D7 sha1 08ae5b9961242596069d3fb40367161f92b926cc )
+)
+
+game (
 	name "Chase H.Q. II - Special Criminal Investigation (Europe)"
-	rom ( name "ChaseHQ2_v1.4_1246.lha" size 826747 crc 567DC6BA sha1 ce553bbae1a4cb76b74c0ba8aee6abc4c4bfe552 )
+	rom ( name "ChaseHQ2_v1.4_1246.lha" size 826184 crc F1129CEF sha1 883e7ed12cc167ab2ffeabc6d44b037f58e436db )
 )
 
 game (
@@ -2782,16 +3247,16 @@ game (
 
 game (
 	name "Chessmaster 2000, The (Europe)"
-	rom ( name "Chessmaster2000_v1.0_2055.lha" size 286791 crc 69258580 sha1 9c04700e502b3e04bfcc34832544b0da11e0ae37 )
+	rom ( name "Chessmaster2000_v1.1_2055.lha" size 287388 crc B5E26EC2 sha1 42bf6be1f935e6f4fc8c041506ffaa983cbfada7 )
 )
 
 game (
-	name "Fidelity Chessmaster 2100, The (USA)"
+	name "Chessmaster 2100, The (USA)"
 	rom ( name "Chessmaster2100_v1.0_NTSC_1988.lha" size 495893 crc CD4A9847 sha1 ec7e0fccfec79eee5cabafb091b6f930715a087e )
 )
 
 game (
-	name "Chess Player 2150 (Europe)"
+	name "Chess Player 2150 (Europe) (En,Fr,De)"
 	rom ( name "ChessPlayer2150_v1.1_2493.lha" size 302385 crc 8513C200 sha1 0f43b871946fd249d6f846415e2fcd2fe4327f50 )
 )
 
@@ -2811,7 +3276,7 @@ game (
 )
 
 game (
-	name "Chess Simulator (Europe)"
+	name "Chess Simulator (Europe) (En,Fr)"
 	rom ( name "ChessSimulator_v1.0_2054.lha" size 252373 crc 58FD03E8 sha1 74912ef529feec287abdb6e2ce027b48a02bee90 )
 )
 
@@ -2823,6 +3288,11 @@ game (
 game (
 	name "Chichén Itzá (Spain)"
 	rom ( name "ChichenItza_v1.0_Es.lha" size 702566 crc CDFB5523 sha1 de7cfefb61311807160496dcb5d30cee89da4d49 )
+)
+
+game (
+	name "Chinese Karate (Europe)"
+	rom ( name "ChineseKarate_v1.0.lha" size 346551 crc 9EC53D7B sha1 9648f87239912a140d6513c2d349a5eaa3680c71 )
 )
 
 game (
@@ -2872,7 +3342,7 @@ game (
 
 game (
 	name "Chubby Gristle (Europe)"
-	rom ( name "ChubbyGristle_v1.1.lha" size 310686 crc 10FEB3AF sha1 e53327b878f3ab52c844a8bef513e7400ecfed0f )
+	rom ( name "ChubbyGristle_v1.2.lha" size 305409 crc 8FAE8DD3 sha1 de3d73d706f83d400b53f349057ca54e4520dd07 )
 )
 
 game (
@@ -2887,37 +3357,32 @@ game (
 
 game (
 	name "Chuck Rock 2 - Son of Chuck (Europe)"
-	rom ( name "ChuckRock2_v3.0_0282.lha" size 1346249 crc 09365D0B sha1 aa84ff9fd88c58138f756fe760d618c28d2b45ec )
+	rom ( name "ChuckRock2_v3.1_0282.lha" size 1346327 crc 420AACC1 sha1 788e7e9435f0eeddd06b854ce3dd82ea8c0be93b )
 )
 
 game (
 	name "Chuck Rock 2 - Son of Chuck (Europe) (CD32)"
-	rom ( name "ChuckRock2_v3.0_CD32.lha" size 1346412 crc 7AB95433 sha1 22ee3f26bec260a9ba0d789f4583e9e9b450b8cc )
+	rom ( name "ChuckRock2_v3.1_CD32.lha" size 1346490 crc DF833449 sha1 c708477ba0fb4cf10337c7b8be49bf804fa46001 )
 )
 
 game (
 	name "Chuck Rock (Europe)"
-	rom ( name "ChuckRock_v1.1_0767.lha" size 1130000 crc A2646ADD sha1 2d03b1bae2c34d5a8254c862a72e710bda29eaeb )
+	rom ( name "ChuckRock_v1.2_0767.lha" size 1133785 crc B6C22CB6 sha1 a47dde75b4d70154abf7dc2682a7c668d5b91edf )
 )
 
 game (
 	name "Chuck Rock (Europe) (CD32)"
-	rom ( name "ChuckRock_v1.1_CD32.lha" size 1313028 crc 8AA48895 sha1 2ae6d758d22fa0ae89f0322665869854aa44ed77 )
+	rom ( name "ChuckRock_v1.2_CD32.lha" size 1316810 crc F3134929 sha1 96f8c718bdfddcd62b83f76566aa96b69b0eb2b0 )
 )
 
 game (
-	name "Chuck Yeager's Advanced Flight Trainer 2.0 (Europe)"
-	rom ( name "ChuckYeagersAdvancedFlightTrainer2_v1.0_0670.lha" size 553267 crc 83FE8309 sha1 c5fb451522495ae3005c09aced506652cf9926a3 )
-)
-
-game (
-	name "Circus Attractions (Europe) (Compilation - Milestones).zip"
-	rom ( name "CircusAttractions_v1.0_1Disk_1689.lha" size 715759 crc 3AA66B1E sha1 174508dbf05946efa6d4c0675621d2e49db4c1ff )
+	name "Chuck Yeager's Advanced Flight Trainer 2.0 (Europe) (En,Fr,De,It)"
+	rom ( name "ChuckYeagersAdvancedFlightTrainer2_v2.0_0670.lha" size 581026 crc 6E41A471 sha1 e4e3a7318f79f85b89e19bdc176e93736072a262 )
 )
 
 game (
 	name "Circus Attractions (Europe)"
-	rom ( name "CircusAttractions_v1.0_2Disk_0450.lha" size 637213 crc 4A4A189C sha1 4639d46e6ffa49d956aa0b3a034d810cfef54bff )
+	rom ( name "CircusAttractions_v1.1a_0450.lha" size 640529 crc 3A10BF8B sha1 689effffc794f96ec8bf113469bad0e1fe3f150c )
 )
 
 game (
@@ -2946,12 +3411,12 @@ game (
 )
 
 game (
-	name "Civilization (Europe) (v855e.01) (AGA)"
+	name "Civilization (Europe) (AGA)"
 	rom ( name "Civilization_v1.1_AGA_1633.lha" size 2512747 crc 6C2C4269 sha1 f232c1b53964b21cbdbab864173ccaf814a778b0 )
 )
 
 game (
-	name "Civilization (CD) (Europe) (AGA)"
+	name "Civilization (Europe) (AGA) (CD)"
 	rom ( name "Civilization_v1.1_AGA_CD.lha" size 2583773 crc F3B9F24A sha1 dfd6e325e9d25a9db562aa837568c96da6076d29 )
 )
 
@@ -2961,7 +3426,7 @@ game (
 )
 
 game (
-	name "Civilization (CD) (Europe)"
+	name "Civilization (Europe) (CD)"
 	rom ( name "Civilization_v1.1_CD.lha" size 1501621 crc 29006138 sha1 f0df36f65c9c924e206a3fb7d63c364ae3ef4a4b )
 )
 
@@ -3047,7 +3512,7 @@ game (
 
 game (
 	name "Clown-O-Mania (Europe)"
-	rom ( name "ClownOMania_v1.3_2807.lha" size 317021 crc 5B0C3F73 sha1 389ee00849080dca004e2b8480e0d83ee0587b85 )
+	rom ( name "ClownOMania_v2.1_2807.lha" size 317355 crc 7F7DA2AC sha1 d5c7f2553e4e9ddb77c89479b6896d800f3ffd5c )
 )
 
 game (
@@ -3081,6 +3546,11 @@ game (
 )
 
 game (
+	name "Cobra (Europe)"
+	rom ( name "Cobra_v1.1.lha" size 909923 crc 58DC3531 sha1 05d09625c65ec61ecacf987642ea545931122684 )
+)
+
+game (
 	name "Codename - Iceman (Europe)"
 	rom ( name "CodeNameIceman_v1.5_0468.lha" size 2860598 crc BACE2DAD sha1 7a29c435806e9aee8882fa97bd2815905e9abdb8 )
 )
@@ -3096,12 +3566,12 @@ game (
 )
 
 game (
-	name "Colonization (Europe)"
-	rom ( name "Colonization_v1.0_0452.lha" size 1756857 crc 260511F8 sha1 463bd146c38d70e14853737cbf28c857a6fe9a67 )
+	name "Colonization (Europe) (En,Fr,De)"
+	rom ( name "Colonization_v1.1_0452.lha" size 1784560 crc 777A99E8 sha1 353bd736e87eb4a4c91b8d6dfddbbd0605da94d3 )
 )
 
 game (
-	name "Colonization (Europe) (AGA)"
+	name "Colonization (Europe) (En,Fr,De) (AGA)"
 	rom ( name "Colonization_v1.1_AGA_0452.lha" size 1785575 crc 5AB88B6A sha1 154a6c91bc5a5cd00c9ef77601624472a774ecf6 )
 )
 
@@ -3111,28 +3581,23 @@ game (
 )
 
 game (
-	name "Colorado (Europe)"
-	rom ( name "Colorado_v1.4_1743.lha" size 515030 crc 831DA0DD sha1 1cc770b84ddd89aa080e6e6330c58a35c6827cbe )
-)
-
-game (
-	name "Colorado (Fast) (Europe)"
-	rom ( name "Colorado_v1.4_Fast_1743.lha" size 515267 crc B366B396 sha1 1e39cbffc86fea37f640d96fbb05bc00a338660c )
+	name "Colorado (Europe) (En,De)"
+	rom ( name "Colorado_v1.5_1743.lha" size 516099 crc 66035F20 sha1 fbcd90562723143652daeb4df78dec461732ba2f )
 )
 
 game (
 	name "Colorado (France)"
-	rom ( name "Colorado_v1.4_Fr.lha" size 514470 crc 6F0AB620 sha1 e11b1083b58fd802bf970298bd4611ee03457878 )
+	rom ( name "Colorado_v1.5_Fr.lha" size 515522 crc 4DE77FBD sha1 3dee0e608bd6939a0ce8cefe4c7e34d98c03b0c5 )
 )
 
 game (
-	name "Colorado (Fast) (France)"
-	rom ( name "Colorado_v1.4_Fr_Fast.lha" size 514710 crc 9D58D64D sha1 799c41933cc1ffa44846fe6f2db056d6b828d93f )
+	name "Colorado (Spain)"
+	rom ( name "Colorado_v1.5_Es.lha" size 515876 crc 1A446F75 sha1 a29bcbb315b138fd041309e7ac9b8389928b9dd8 )
 )
 
 game (
 	name "Color Buster (Europe)"
-	rom ( name "ColorBuster_v1.0.lha" size 164102 crc 5EF3F22C sha1 e1c47a07db8acbeadaee5885f5df75dd81e04ae9 )
+	rom ( name "ColorBuster_v1.1.lha" size 165051 crc AB46645A sha1 a18e85b2e8d37f240052020f484b3d460c61ac18 )
 )
 
 game (
@@ -3141,13 +3606,18 @@ game (
 )
 
 game (
-	name "Colossus Chess X - The Ultimate Chess Program (Europe)"
+	name "Colossus Chess X - The Ultimate Chess Program (Europe) (En,Fr,De,Es,It)"
 	rom ( name "ColossusChessX_v1.2_1510.lha" size 402112 crc C088D190 sha1 6e7c4625003f7d4eababf6354297c12793c17cf0 )
 )
 
 game (
-	name "Combat Air Patrol (Europe)"
-	rom ( name "CombatAirPatrol_v1.2_0674.lha" size 1324288 crc B3D45CB8 sha1 d4459674ddd14d698eadd1c627dad9784c98e4ce )
+	name "Combat Air Patrol (Europe) (En,Fr,De,Es,It)"
+	rom ( name "CombatAirPatrol_v1.3_0674.lha" size 1325578 crc 31025831 sha1 c66fa70d5458b6e89b1c1f7fc04b763e021f074f )
+)
+
+game (
+	name "Combat Course (USA)"
+	rom ( name "CombatCourse_v1.0_NTSC_2316.lha" size 270941 crc F8C74715 sha1 23c5fa2907977b4bf7659746c29895ba9077b12c )
 )
 
 game (
@@ -3157,7 +3627,7 @@ game (
 
 game (
 	name "Commando (Europe)"
-	rom ( name "Commando_v1.2_0002.lha" size 255176 crc C6E9139C sha1 9c81f49849aaabe87143554d3ae2ceeb24f762ee )
+	rom ( name "Commando_v1.4_0002.lha" size 255915 crc BE8D2E87 sha1 8bbdc36b1f4c30d4f027d7284c68fc73778174b4 )
 )
 
 game (
@@ -3172,7 +3642,7 @@ game (
 
 game (
 	name "Conan - The Cimmerian (Europe)"
-	rom ( name "ConanTheCimmerian_v1.0.lha" size 2830344 crc E90C1168 sha1 b583bab920975abce2cfac5883e753a2a9e99d52 )
+	rom ( name "ConanTheCimmerian_v1.1_2657.lha" size 2834585 crc 46D0FA41 sha1 ec3f0047337777b03902e9869c921b74c1d6a514 )
 )
 
 game (
@@ -3187,26 +3657,26 @@ game (
 
 game (
 	name "Conflict - The Middle East Simulation (Europe)"
-	rom ( name "ConflictMiddleEastPoliticalSimulator_v1.0.lha" size 193138 crc 31B3A1B4 sha1 7088e328eb0c4ebbfe9684103920afcb17e0bd01 )
+	rom ( name "ConflictMiddleEastPoliticalSimulator_v1.01.lha" size 216980 crc 9BB28F8A sha1 becd7fbf00ce0ee24f86b63d60972dfd5d2dccb7 )
 )
 
 game (
-	name "Conqueror (Europe)"
+	name "Conqueror (Europe) (En,De)"
 	rom ( name "Conqueror_v1.1_1275.lha" size 313862 crc DDDE4AAB sha1 4e3a1c52ef817f544d0b509d4fa85c0b1a623dab )
 )
 
 game (
 	name "Conquests of Camelot - The Search for the Grail (Europe)"
-	rom ( name "ConquestsOfCamelot_v1.2_1112.lha" size 3518483 crc 598BB24E sha1 af16d701ebb961c439f098079e166cd3a676e56c )
+	rom ( name "ConquestsOfCamelot_v1.3_1112.lha" size 3528590 crc BE4E5D55 sha1 77d98915e60940d05a1933c4b54df882f0eb8f34 )
 )
 
 game (
-	name "Legend of Robin Hood, The - Conquests of the Longbow (Europe)"
+	name "Conquests of the Longbow (Europe)"
 	rom ( name "ConquestsOfTheLongbow_v1.1-B.lha" size 5900161 crc 35E2DB43 sha1 cf8cc55e43e3fa1dba24073bbf32c2d7fdadadfa )
 )
 
 game (
-	name "Legend of Robin Hood, The - Conquests of the Longbow (MT32) (Europe)"
+	name "Conquests of the Longbow (Europe) (MT32)"
 	rom ( name "ConquestsOfTheLongbow_v1.1-B_MT32.lha" size 5905027 crc E55F8059 sha1 0d83126b5a4d7dcb049c27f4cc8a2acdc1e8c48c )
 )
 
@@ -3227,21 +3697,21 @@ game (
 
 game (
 	name "Cool World (Europe)"
-	rom ( name "CoolWorld_v1.0_1826.lha" size 1129502 crc 043F899B sha1 f3b17595e7bad89ef42f62c55527c50e5516b6bb )
+	rom ( name "CoolWorld_v2.2_1826.lha" size 1130836 crc 55225F72 sha1 a9dd4a75e018262e14eaf478d779907d8d857793 )
 )
 
 game (
-	name "Corporation & Mission Disk (2 Disk) (Europe)"
+	name "Corporation & Mission Disk (Europe) (2 Disk)"
 	rom ( name "Corporation&Missions_v1.4_2Disk_0107&0266.lha" size 816872 crc D6D2A0B0 sha1 4e9e6a6d26a3ddd539aa0df382b78d07c5f82581 )
 )
 
 game (
-	name "Corporation & Mission Disk (3 Disk) (Europe)"
+	name "Corporation & Mission Disk (Europe) (3 Disk)"
 	rom ( name "Corporation&Missions_v1.4_3Disk_0107&0266.lha" size 1145504 crc 7E18804A sha1 3f588c4c617b199aa599ccd4b9f5d2f2e2257caf )
 )
 
 game (
-	name "Corporation (1 Disk) (Europe)"
+	name "Corporation (Europe) (1 Disk)"
 	rom ( name "Corporation_v1.4_1Disk_0107.lha" size 437506 crc 5D44C1C5 sha1 a208eafd4b8d8f70591097fce8888ab6d2bd523c )
 )
 
@@ -3281,8 +3751,18 @@ game (
 )
 
 game (
-	name "Cosmic Spacehead (Europe)"
+	name "Cosmic Spacehead (Europe) (En,Fr,De,Es)"
 	rom ( name "CosmicSpacehead_v1.3.lha" size 943048 crc 328CE02E sha1 63dd3375f13b42ac0a1fdd874b688c0b06cf91f8 )
+)
+
+game (
+	name "Cosmo Ranger - S.O.L. AD 2000 (Europe)"
+	rom ( name "CosmoRanger_v1.1.lha" size 367743 crc 78D0454E sha1 40f59a85d0bb33e2595825f2bb02f6c5791075ad )
+)
+
+game (
+	name "Cosmo Ranger - S.O.L. AD 2000 (USA)"
+	rom ( name "CosmoRanger_v1.1_NTSC.lha" size 373903 crc 9628E972 sha1 69e647ccf1f5062162b5b5f1143b02dce0d8557c )
 )
 
 game (
@@ -3291,12 +3771,17 @@ game (
 )
 
 game (
+	name "Count Duckula II (Europe)"
+	rom ( name "CountDuckula2_v1.0_1712.lha" size 148731 crc 29946A46 sha1 55d9f9af78b92f240cd4483dad8ba9819b7c193a )
+)
+
+game (
 	name "Count Duckula in No Sax Please - We're Egyptian (Europe)"
 	rom ( name "CountDuckula_v1.2.1.lha" size 177946 crc F726FDB9 sha1 c14dc1efb4ef01b3f8ce60a441e072029b2e2556 )
 )
 
 game (
-	name "Cover Girl Poker (Europe)"
+	name "Cover Girl Poker (Europe) (En,Fr,De,It)"
 	rom ( name "CoverGirlStripPoker_v1.1.lha" size 1735636 crc F160477F sha1 8ec9d16d5ec50864fa7f10eb82ca4dc1233c812d )
 )
 
@@ -3312,7 +3797,7 @@ game (
 
 game (
 	name "Crack (Europe)"
-	rom ( name "Crack_v1.0_0057.lha" size 598953 crc D4224CCA sha1 3c224e3327de3d8d33544d9ca1443e2a99941532 )
+	rom ( name "Crack_v1.1_0057.lha" size 599780 crc B1AB73B7 sha1 73d6bf120dbb434cddc4432102c8dd686649450a )
 )
 
 game (
@@ -3322,7 +3807,12 @@ game (
 
 game (
 	name "Crash Garrett (USA)"
-	rom ( name "CrashGarrett_v1.0_NTSC_1373.lha" size 293274 crc EBB722C9 sha1 d0484522ca2762a2ea12e6e58447abaa25a250e8 )
+	rom ( name "CrashGarrett_v1.1.lha" size 293144 crc EEC14961 sha1 aa1d607251915109e1a540bfdcc3d961aac6274a )
+)
+
+game (
+	name "Crash Garrett (USA)"
+	rom ( name "CrashGarrett_v1.1_NTSC_1373.lha" size 293502 crc FA8B7702 sha1 b07b3d3cc9d29d61ccb48e871df058caccbdb0bc )
 )
 
 game (
@@ -3333,11 +3823,6 @@ game (
 game (
 	name "Crazy Cars 3 (Europe)"
 	rom ( name "CrazyCars3_v2.2_3068.lha" size 922365 crc D3767A56 sha1 088563b49cbbb479d287f52596ca6372266f6fcc )
-)
-
-game (
-	name "Crazy Cars 3 (No Intro) (Europe)"
-	rom ( name "CrazyCars3_v2.1_NoIntro.lha" size 658538 crc C847C0E3 sha1 132313e32646104fa5dfd67d2f62342ff7a88ba8 )
 )
 
 game (
@@ -3352,7 +3837,7 @@ game (
 
 game (
 	name "Crazy Shot (Europe)"
-	rom ( name "CrazyShot_v1.1_2404.lha" size 372261 crc 441E77D4 sha1 6f7367d888696668e80680b316fcae15603dfca1 )
+	rom ( name "CrazyShot_v1.2_2404.lha" size 313189 crc B5EE5737 sha1 85a7d182cd8a899295ba2e320014195e5a817483 )
 )
 
 game (
@@ -3367,12 +3852,17 @@ game (
 
 game (
 	name "Creature (Europe)"
-	rom ( name "Creature_v1.1_0846.lha" size 800810 crc 177008A8 sha1 9e3b670c36305273edd6e80f580c2d512c491198 )
+	rom ( name "Creature_v1.2_0846.lha" size 801162 crc 9DB5E3C8 sha1 bb965d19064ce18e561a6653a567096fa236bcd6 )
 )
 
 game (
 	name "Creatures (Europe)"
 	rom ( name "Creatures_v1.1.lha" size 1562184 crc 246B54CB sha1 63328c74fb120a869254f138178ce9d61f31abb0 )
+)
+
+game (
+	name "Cricket Captain (Europe)"
+	rom ( name "CricketCaptain_v1.0_1244.lha" size 222412 crc D6FCBE23 sha1 31ae5b8660f36c77b3ce94318438ae4bbdfaeb62 )
 )
 
 game (
@@ -3386,13 +3876,13 @@ game (
 )
 
 game (
-	name "Crime Does Not Pay (Europe)"
+	name "Crime Does Not Pay (Europe) (En,Fr,De,Es,It)"
 	rom ( name "CrimeDoesNotPay_v1.0_0364.lha" size 418276 crc 8E3AB01B sha1 45c6e5c63cb4531c55001b0ca915b42053c188e7 )
 )
 
 game (
 	name "Crime Wave (Europe)"
-	rom ( name "CrimeWave_v1.1.lha" size 923524 crc FB8AC184 sha1 18f20a1e517a9107c9e521a6dd9d642010dad3cd )
+	rom ( name "CrimeWave_v1.2_2942.lha" size 927886 crc C003B517 sha1 8d69fe7b3b394d19416a44150bfb12e1d1475e7c )
 )
 
 game (
@@ -3407,7 +3897,7 @@ game (
 
 game (
 	name "Croisiere pour un Cadavre (France)"
-	rom ( name "CroisierePourUnCadavre_v2.1-B_Fr_1827.lha" size 3697055 crc 011C0BA5 sha1 3cbab6bf3e6b63e106db8de83c2b9896a45350ee )
+	rom ( name "CroisierePourUnCadavre_v2.3_Fr_1827.lha" size 3697542 crc 6C41FA18 sha1 69a9bc485aea0cab07cc17b7e49e5edb85c7fbe9 )
 )
 
 game (
@@ -3421,28 +3911,38 @@ game (
 )
 
 game (
+	name "Crown (Europe)"
+	rom ( name "Crown_v1.0_1090.lha" size 857395 crc B869746C sha1 4e6d20a6ace6972e6f540d27343090d561bd3695 )
+)
+
+game (
 	name "Cruise for a Corpse (Europe)"
-	rom ( name "CruiseForACorpse_v2.1-B_0108.lha" size 3687407 crc 7E58465D sha1 009b2e46a30023c2d0d8b55a23bdf2919ca674b2 )
+	rom ( name "CruiseForACorpse_v2.3_0108.lha" size 3687894 crc 6A007D0C sha1 ca868ad1bc32223e53e456bb6438b8df1aaea988 )
 )
 
 game (
 	name "Cruise for a Corpse (Germany)"
-	rom ( name "CruiseForACorpse_v2.1-B_De_0676.lha" size 3699509 crc 2E45EE2C sha1 0954ce6a813d51e9f78cafd2e825fad0a85098c7 )
+	rom ( name "CruiseForACorpse_v2.3_De_0676.lha" size 3699996 crc 12049D56 sha1 b3f7b8eaa94dfc48ff5b29e364f8ac58f138af1c )
 )
 
 game (
 	name "Cruise for a Corpse (Spain)"
-	rom ( name "CruiseForACorpse_v2.1-B_Es.lha" size 3689086 crc FF400225 sha1 c58a297ae8364f71925cac2dad245ced87d8a0a2 )
+	rom ( name "CruiseForACorpse_v2.3_Es.lha" size 3689573 crc B238F058 sha1 7f45950c2afaf1676eea0c774260d411676b73a4 )
 )
 
 game (
 	name "Cruise for a Corpse (Italy)"
-	rom ( name "CruiseForACorpse_v2.1-B_It.lha" size 3688107 crc C96BE4A9 sha1 81621f3b7a56437d4701ee983a873f25ce18e21f )
+	rom ( name "CruiseForACorpse_v2.3_It.lha" size 3689146 crc 810C6107 sha1 2fd7e6a2cc719226ed21922c685dac56e2805cd0 )
+)
+
+game (
+	name "Cruise for a Corpse (USA)"
+	rom ( name "CruiseForACorpse_v2.3_NTSC.lha" size 3688670 crc 8692A546 sha1 4ba83e867df72ac84231e3f23d88899961a3f2aa )
 )
 
 game (
 	name "Cruncher Factory (Europe)"
-	rom ( name "CruncherFactory_v1.1.lha" size 136460 crc 97C9AFEB sha1 94d24cb18bc342959491715cd51187a1ef7e3cc0 )
+	rom ( name "CruncherFactory_v1.1.lha" size 153433 crc BBD17811 sha1 98fd2187e9716ff5598da935b203488550dbaf3a )
 )
 
 game (
@@ -3467,7 +3967,7 @@ game (
 
 game (
 	name "Crystal Kingdom Dizzy (Europe)"
-	rom ( name "CrystalKingdomDizzy_v1.0.lha" size 800172 crc A349AE64 sha1 c5eaf5f2b191c29fbb5ddce708ee8fa88191e13f )
+	rom ( name "CrystalKingdomDizzy_v2.0a_0109.lha" size 602898 crc 0DC060E2 sha1 dde74375b215a88d27b941dcca46246a2aa47f79 )
 )
 
 game (
@@ -3486,12 +3986,12 @@ game (
 )
 
 game (
-	name "Crystals of Arborea (Fast) (Germany)"
+	name "Crystals of Arborea (Germany) (Fast)"
 	rom ( name "CrystalsOfArborea_v1.3_De_Fast.lha" size 483484 crc F4E45A69 sha1 8ffe935679ef9c61ef066890e7f9752a56630bdc )
 )
 
 game (
-	name "Crystals of Arborea (Fast) (Europe)"
+	name "Crystals of Arborea (Europe) (Fast)"
 	rom ( name "CrystalsOfArborea_v1.3_Fast.lha" size 483512 crc 6727CBCB sha1 2fca7916916b420f1b132560ec16306a41028964 )
 )
 
@@ -3501,7 +4001,7 @@ game (
 )
 
 game (
-	name "Crystals of Arborea (Fast) (France)"
+	name "Crystals of Arborea (France) (Fast)"
 	rom ( name "CrystalsOfArborea_v1.3_Fr_Fast_2386.lha" size 404031 crc 36F00FF8 sha1 2900aa5a22f01b70361d64e400ab4e76212269f2 )
 )
 
@@ -3517,17 +4017,22 @@ game (
 
 game (
 	name "Curse of Enchantia (Europe)"
-	rom ( name "CurseOfEnchantia_v1.4_0283.lha" size 3627444 crc E3BA65DA sha1 30a3e59e556a6370528d12293a00cc664e2393ef )
+	rom ( name "CurseOfEnchantia_v1.5_0283.lha" size 3631593 crc E22413A0 sha1 791a172e771b9d20139dcc06f3e1d4ee4bb9d795 )
+)
+
+game (
+	name "Curse of Enchantia (Europe) (Fast)"
+	rom ( name "CurseOfEnchantia_v1.5_Fast_0283.lha" size 3632533 crc F41723E7 sha1 ea15024ce7e62a54067d8a6a2ef2ccd70c24cb4e )
 )
 
 game (
 	name "RA (Europe)"
-	rom ( name "CurseOfRa_v1.2.lha" size 601693 crc E394A1CA sha1 7519a337551af21a552c781e57c78053f372720c )
+	rom ( name "CurseOfRa_v1.3b_1277.lha" size 572984 crc 398C2D70 sha1 178e3ce1123de46357608c9ba7511d5bdecfa9e9 )
 )
 
 game (
 	name "RA (Europe) (CDTV)"
-	rom ( name "CurseOfRa_v1.2_CDTV.lha" size 582525 crc D8E8B71E sha1 96bfa2f1d55b15c37c851a71bd0b26a40ffb2754 )
+	rom ( name "CurseOfRa_v1.3b_CDTV.lha" size 572257 crc F8E7874F sha1 ae289b304445312b6f4c597630b8a9fa758df407 )
 )
 
 game (
@@ -3542,7 +4047,7 @@ game (
 
 game (
 	name "Cyber Assault (Europe)"
-	rom ( name "CyberAssault_v1.1.lha" size 621759 crc 83A38C9F sha1 92a13a67d4477e46506c88b45fdf8d84d85fca6e )
+	rom ( name "CyberAssault_v2.0.lha" size 622364 crc 9B025722 sha1 a90c54906d109cd0bba1c14c73b0f11b0e88c1e1 )
 )
 
 game (
@@ -3552,7 +4057,7 @@ game (
 
 game (
 	name "Cyberblast (Europe)"
-	rom ( name "Cyberblast_v0.9_1383.lha" size 532280 crc 43B8F7D5 sha1 a9716ea2406dd70dd65d13b030ad7d27a371222d )
+	rom ( name "Cyberblast_v1.1_1383.lha" size 545858 crc 4BA6EE56 sha1 d728f2ca931dd8dcb91ee0eda23c12bd493acc8f )
 )
 
 game (
@@ -3561,8 +4066,13 @@ game (
 )
 
 game (
-	name "Cyber Empires (Europe)"
-	rom ( name "CyberEmpires_v1.1.lha" size 1288706 crc FA75C890 sha1 f3ea049a14bde0befe0743ff080b09f7077572ff )
+	name "Cyber Cop (Europe)"
+	rom ( name "CyberCop_v1.0.lha" size 354085 crc 2B00D38B sha1 bde1457eea6f4326ff39e625097c3036686b3721 )
+)
+
+game (
+	name "Cyber Empires (USA)"
+	rom ( name "CyberEmpires_v1.1_NTSC.lha" size 1283737 crc 1D319304 sha1 0f3aec6f1efd8ccebaedbe63df471b3b26c834b6 )
 )
 
 game (
@@ -3586,8 +4096,28 @@ game (
 )
 
 game (
+	name "Cybernoid - The Fighting Machine (Old Tiles Set) (Europe)"
+	rom ( name "Cybernoid_v1.3_OldTileSet.lha" size 298382 crc 8944DD35 sha1 1a6c331d496dfee5645e3c474d1f98605e56e709 )
+)
+
+game (
+	name "Cyberpunks 2 (Europe) (AGA) (Demo)"
+	rom ( name "CyberPunks2Demo_v1.1_AGA.lha" size 824200 crc 2966A6B2 sha1 d752bda7e5018adc52c0ee2caba5b3128e65194d )
+)
+
+game (
 	name "Cyberpunks (Europe)"
-	rom ( name "Cyberpunks_v1.2_0365.lha" size 592338 crc 26117DF8 sha1 acfccc2f4752d871baa4a9ad7402cac2e9e0c35e )
+	rom ( name "Cyberpunks_v1.3_0365.lha" size 593456 crc A6D9C97E sha1 dd8753e7bf526f9b2ab99ab7435c87ff9fb2b929 )
+)
+
+game (
+	name "Cybersphere (Europe)"
+	rom ( name "Cybersphere_v1.0.lha" size 187816 crc 2881193B sha1 8c656697396007396742caa1ff923a8863a781c8 )
+)
+
+game (
+	name "Cybersphere Plus (Europe)"
+	rom ( name "CyberspherePlus_v1.0.lha" size 197170 crc 5A42E1E5 sha1 30f2a42cfc0d98832d71930a246459b0c9129d0f )
 )
 
 game (
@@ -3617,12 +4147,12 @@ game (
 
 game (
 	name "Cytron (Europe)"
-	rom ( name "Cytron_v1.02_0110.lha" size 1622234 crc E7062E43 sha1 39b7c4514f3febb2ce4819b5b32dfa500e8336be )
+	rom ( name "Cytron_v1.1_0110.lha" size 1631215 crc A9A4E6A7 sha1 08d3796468505a3c3e5d70c46bfb138c7915b92a )
 )
 
 game (
 	name "Cytron (USA)"
-	rom ( name "Cytron_v1.02_NTSC.lha" size 1622417 crc 89B04A6B sha1 289cf62c56964913e03411fbb7f78d999254f4a3 )
+	rom ( name "Cytron_v1.1_NTSC.lha" size 1631062 crc F2D710E9 sha1 bf53627e48474e1622fc12e0670715ad22f3dd24 )
 )
 
 game (
@@ -3641,12 +4171,17 @@ game (
 )
 
 game (
+	name "Dal'X (France)"
+	rom ( name "DalX_v1.0_Fr.lha" size 742655 crc C3536418 sha1 b3316666b664504921aee6f61d5017053a8a2d85 )
+)
+
+game (
 	name "Damage - The Sadistic Butchering of Humanity (Europe)"
 	rom ( name "Damage_v1.2.lha" size 1353039 crc 80AFB6BC sha1 e54e182043a78a6266798dbe57e615c66850346a )
 )
 
 game (
-	name "Damage (Preview) (Europe)"
+	name "Damage (Europe) (Preview)"
 	rom ( name "DamagePreview_v1.0.lha" size 359991 crc 06E421A2 sha1 9d9236b4c67141f49459bf0ca62cff27d32730ca )
 )
 
@@ -3662,27 +4197,52 @@ game (
 
 game (
 	name "Dan Dare III - The Escape (Europe)"
-	rom ( name "DanDare3_v1.1_2257.lha" size 388516 crc 7D2BF68C sha1 22f20c442356ae73bff6ff200aaf491d55400059 )
+	rom ( name "DanDare3_v1.2_2257.lha" size 395488 crc F5FE638A sha1 5db119a9a22e77dfc9c84c8a34aa239182cd18b3 )
+)
+
+game (
+	name "Danger Freak (Europe)"
+	rom ( name "DangerFreak_v1.0_0975.lha" size 643891 crc 3E1DBFA4 sha1 d6e18edf2a00c47b532e92ea264c9242b81d8692 )
+)
+
+game (
+	name "Danger Freak (Europe)"
+	rom ( name "DangerFreak_v1.1_0975.lha" size 644343 crc 9A8EE9C9 sha1 f2823fac3328600096ff291bba1ba2ddf5549a44 )
+)
+
+game (
+	name "Dangerous Streets (Europe)"
+	rom ( name "DangerousStreets_v1.3_1019.lha" size 881294 crc 665653C5 sha1 270e5ff83e354429116779bc6b75db8db61e1fbb )
 )
 
 game (
 	name "Dangerous Streets (Europe) (AGA)"
-	rom ( name "DangerousStreets_v1.2_AGA_1020.lha" size 2441627 crc 82273F7A sha1 91f8272ec3a69c234beb4b1fda68217c611fbe80 )
+	rom ( name "DangerousStreets_v1.3_AGA_1020.lha" size 2442805 crc 95AF21F3 sha1 6c0942ba3c7146af99b4e31a92a7334b4847c48b )
+)
+
+game (
+	name "Dangerous Streets (Europe) (CD32)"
+	rom ( name "DangerousStreets_v1.3_CD32.lha" size 1979698 crc 4EF6C15E sha1 87b108926ca0a9aa69db9816c32f13d525b551ab )
 )
 
 game (
 	name "Darius+ (Europe)"
-	rom ( name "Darius+_v1.0.lha" size 463231 crc 3A471490 sha1 934d34635cddf1268e8d63d7a6623e41000c38d4 )
+	rom ( name "Darius+_v1.1_2303.lha" size 419123 crc 0A61C179 sha1 75d3d1087771a5b914de57ab6060f0ab175d00c8 )
+)
+
+game (
+	name "Dark Castle (Europe)"
+	rom ( name "DarkCastle_v1.03.lha" size 705072 crc 1682565A sha1 f3dd470a56d9db939d1ace6844c5de56f91bc659 )
 )
 
 game (
 	name "Dark Castle (USA)"
-	rom ( name "DarkCastle_v1.01_NTSC_1459.lha" size 708570 crc DE9828D5 sha1 8006d53af73068d54b46b2879d333bef1461dbc0 )
+	rom ( name "DarkCastle_v1.03_NTSC_1459.lha" size 712159 crc CF2B0E91 sha1 7df45b3f1d408d8c7f354c7ea9426b0eda5955d1 )
 )
 
 game (
 	name "Dark Century (Europe)"
-	rom ( name "DarkCentury_v1.0_0244.lha" size 708476 crc 6ACA4F5F sha1 3fdf200871786adc5de639069c9c7e58f60add30 )
+	rom ( name "DarkCentury_v1.1_0244.lha" size 708833 crc 42CA7AD5 sha1 2fdbe55dfec7d7e1912e6027e2567b387f375368 )
 )
 
 game (
@@ -3692,12 +4252,12 @@ game (
 
 game (
 	name "Darkman (Europe)"
-	rom ( name "Darkman_v1.0_1564.lha" size 698384 crc C58930C4 sha1 9cb9825a7758a36d249433451f5d7b1075661efc )
+	rom ( name "Darkman_v1.2_1564.lha" size 694112 crc 453F3A39 sha1 00fba4b4996fbb6bdb4d0b8e905ae0bad66f5d3d )
 )
 
 game (
-	name "Darkmere (Europe)"
-	rom ( name "Darkmere_v1.2_0453.lha" size 4287005 crc 9A78EAEE sha1 6148bf673d60251e1b8eb33f60759885a02d8973 )
+	name "Darkmere (Europe) (En,Fr,De,It)"
+	rom ( name "Darkmere_v2.0_0453.lha" size 4289620 crc 808A1790 sha1 b2a3ea2aaab719630e36ff093daa6ea35cdfd312 )
 )
 
 game (
@@ -3706,38 +4266,38 @@ game (
 )
 
 game (
-	name "Darkseed (Europe) (CD32)"
-	rom ( name "DarkSeed_v1.03_CD32.lha" size 16193962 crc 8E7E49F0 sha1 8f42ab6133387e8f7a426d1dcc1b039d7c1f879b )
-)
-
-game (
 	name "Darkseed (Europe)"
-	rom ( name "DarkSeed_v1.4_2141.lha" size 4851775 crc D9EF19D4 sha1 cfbbed5effbead21bcbb56d0fcd0313c4ebf81b6 )
+	rom ( name "DarkSeed_v1.5_2141.lha" size 4852565 crc B7A210DE sha1 6114e46ffdc8c02e85906da361ca8258e836166d )
 )
 
 game (
 	name "Darkseed (Germany)"
-	rom ( name "DarkSeed_v1.4_De.lha" size 4966283 crc 21EE3EDD sha1 f3ad03a44d73fa92f4edb9b01cf540ad4ead92ad )
+	rom ( name "DarkSeed_v1.5_De.lha" size 4967073 crc 1222D704 sha1 14529d994a5429e7a2093df6a6cd4d6f1969d70e )
 )
 
 game (
 	name "Darkseed (Spain)"
-	rom ( name "DarkSeed_v1.4_Es.lha" size 4935996 crc 55C13942 sha1 f628424a2d7c4eed0d4b388a322b0665baa71044 )
+	rom ( name "DarkSeed_v1.5_Es.lha" size 4936786 crc 4B17F5F2 sha1 2ecaa5e91d9d039f880b54f2a76a7cfbb6dceaf7 )
 )
 
 game (
 	name "Darkseed (France)"
-	rom ( name "DarkSeed_v1.4_Fr.lha" size 4888032 crc C543E8A3 sha1 6a79709cfdd731f54167aeec631321a5cbf0ecba )
+	rom ( name "DarkSeed_v1.5_Fr.lha" size 4888822 crc 21AB3D11 sha1 b8e6ec7e229cc32d67b65d7c37d12372009d58c7 )
+)
+
+game (
+	name "Darkseed (Europe) (CD32)"
+	rom ( name "DarkSeed_v2.0_CD32.lha" size 16179654 crc 72B1694A sha1 3ba03e22fb32b09c25eea6fbd73fade153f9a4e0 )
 )
 
 game (
 	name "Dark Side (Europe)"
-	rom ( name "DarkSide_v1.1_1099.lha" size 378850 crc 396B7BF6 sha1 c9da73d12ee269af26c76476b6d0007e363cac8c )
+	rom ( name "DarkSide_v2.0_1099.lha" size 383489 crc C9881393 sha1 4a4bdc0fe8d083cbccb9aa116c547f8ea00f15f6 )
 )
 
 game (
 	name "Dark Side (USA)"
-	rom ( name "DarkSide_v1.1_NTSC_1424.lha" size 341739 crc CDBE4563 sha1 fc9b89a04db680d64c113e68fb6c3c7e7efd4e6f )
+	rom ( name "DarkSide_v2.0_NTSC_1424.lha" size 343215 crc 16FEF68A sha1 ad9b7d2e0b07ccd540ec728db8d31668ddc04bc1 )
 )
 
 game (
@@ -3747,7 +4307,7 @@ game (
 
 game (
 	name "Datastorm (Europe)"
-	rom ( name "Datastorm_v1.2_1555.lha" size 809866 crc DE791313 sha1 dcaf46ae3571a44930523a293283687dd806e74a )
+	rom ( name "Datastorm_v2.0_1555.lha" size 814599 crc 27BD927E sha1 4c890addbfbf8b30e819fae0d8dc35f009efe9ab )
 )
 
 game (
@@ -3772,12 +4332,12 @@ game (
 
 game (
 	name "Day of the Viper (Europe)"
-	rom ( name "DayOfTheViper_v1.0_0454.lha" size 349637 crc BCD8EAF6 sha1 2ae9cdbf10c945b5d180df4e6692c55dc64dfebc )
+	rom ( name "DayOfTheViper_v1.01_0454.lha" size 364985 crc FFA52771 sha1 bfab1f78cd1c25850dfecde64782f839b1fedd58 )
 )
 
 game (
 	name "Days of Thunder (Europe)"
-	rom ( name "DaysOfThunder_v1.1_0285.lha" size 279354 crc F72F0CAC sha1 9af390e4d64d735f237cd85af4e5e745097f39d6 )
+	rom ( name "DaysOfThunder_v2.0_0285.lha" size 293532 crc 42A753D6 sha1 e9eb9ee0db8b37868506dffbfc53c8b6d4ed3326 )
 )
 
 game (
@@ -3812,12 +4372,17 @@ game (
 
 game (
 	name "Death Mask (Europe)"
-	rom ( name "DeathMask_v1.1_1326.lha" size 1596728 crc 33513BFF sha1 988b41bd0cd457ec84902cb06b079cafc9fd1b0d )
+	rom ( name "DeathMask_v1.2_1326.lha" size 1597881 crc 3A22CD91 sha1 97157ada3865e789f3c1e10a77195e93a860a4a6 )
 )
 
 game (
 	name "Death Mask (Europe) (AGA)"
-	rom ( name "DeathMask_v1.1_AGA_1326.lha" size 1596759 crc 1BF377E0 sha1 c568c9fdc7dc285dea4e738c7747bb53dc8fa175 )
+	rom ( name "DeathMask_v1.2_AGA_1326.lha" size 1597909 crc 575DECD9 sha1 02ed6501f13a818802ef85ce2f2f3d8a11052f55 )
+)
+
+game (
+	name "Death Mask (Europe) (CD32)"
+	rom ( name "DeathMask_v1.1_CD32.lha" size 1483268 crc D8CA245B sha1 b0ceaf805fdba59cd761a157050bf94bb66fe2f9 )
 )
 
 game (
@@ -3837,7 +4402,7 @@ game (
 
 game (
 	name "Début - Planet Simulation (Europe)"
-	rom ( name "DebutPlanetSimulation_v1.1.lha" size 443695 crc 372B6D49 sha1 717fb4d92699f35dd88f6e24ae087e6889a0900e )
+	rom ( name "DebutPlanetSimulation_v1.2.lha" size 445846 crc 5D4A455B sha1 cb5c6f6bdf3ee5a62252b1c4adf7a6d5d7172399 )
 )
 
 game (
@@ -3847,7 +4412,7 @@ game (
 
 game (
 	name "Deconstruction (Europe) (AGA)"
-	rom ( name "Deconstruction_v1.0_AGA.lha" size 1859032 crc AE5B8EBF sha1 8f51095c2757f05d7a5b865ec8a40df60e4b2699 )
+	rom ( name "Deconstruction_v1.2_AGA.lha" size 1855462 crc 622E20AF sha1 f2c5f73b60b5e43f40aed50751eff0f8f63776bc )
 )
 
 game (
@@ -3857,7 +4422,12 @@ game (
 
 game (
 	name "Deep Core (Europe)"
-	rom ( name "DeepCore_v1.1.lha" size 1914890 crc 30B64DE6 sha1 e61aeca661ea102421e8c91e9c98401a20d6e82a )
+	rom ( name "DeepCore_v2.0.lha" size 1920794 crc 21CC5766 sha1 b7c83c9f5d3a8444b8e7ccc2b65eb12033b0a8ed )
+)
+
+game (
+	name "Deep Core (Europe) (CD32)"
+	rom ( name "DeepCore_v2.0_CD32.lha" size 1701607 crc D0A65CFC sha1 8eb87bbaa58092f4493c46265e453a88133fa258 )
 )
 
 game (
@@ -3871,13 +4441,18 @@ game (
 )
 
 game (
+	name "Defender (Acid) (Europe)"
+	rom ( name "Defender_v1.0_Acid.lha" size 108819 crc E308431B sha1 c2d6e30029158c11c6403fb23e653fd2f3ce0d92 )
+)
+
+game (
 	name "Defender (Ratsoft) (Europe)"
 	rom ( name "Defender_v1.0_Ratsoft.lha" size 176338 crc 64B4F849 sha1 e985011fda2393f76b5a5427b6b8eaabd77bc1da )
 )
 
 game (
 	name "Defender of the Crown II (Europe) (CD32)"
-	rom ( name "DefenderOfTheCrown2_v1.1_CD32.lha" size 7017814 crc 62AB974A sha1 f4b4a37d7f629ec3216d9054e388ad9eb16f70d8 )
+	rom ( name "DefenderOfTheCrown2_v1.2_CD32.lha" size 7018108 crc 4AB2F3FF sha1 b1d1d88c3051026a3d1ce855980b2ce455922e46 )
 )
 
 game (
@@ -3902,12 +4477,12 @@ game (
 
 game (
 	name "Défenseur De La Couronne II (France) (CD32)"
-	rom ( name "DefenseurDeLaCouronne2_v1.1_CD32_Fr.lha" size 7819071 crc DFB3C887 sha1 247be7a5cc02f4ee0aa34c057657aa50cc389c4e )
+	rom ( name "DefenseurDeLaCouronne2_v1.2_CD32_Fr.lha" size 7819365 crc D7E42200 sha1 c51d5915e3a8e3311546a11a6153848cda47170e )
 )
 
 game (
 	name "Defensor De La Corona II, El (Spain) (CD32)"
-	rom ( name "DefensorDeLaCorona2_v1.1_CD32_Es.lha" size 7044995 crc F1D4A6E3 sha1 3e84234b50e0ac3fc05c77938394e33846fb413b )
+	rom ( name "DefensorDeLaCorona2_v1.2_CD32_Es.lha" size 7045289 crc 90A86604 sha1 d58701aba93971403e7c79403f16d33e0c10fc70 )
 )
 
 game (
@@ -3917,32 +4492,37 @@ game (
 
 game (
 	name "Deja Vu II - Lost In Las Vegas! (Europe)"
-	rom ( name "DejaVu2LostInLasVegas_v1.0.lha" size 525260 crc FF3ACA5D sha1 5e94cb83e27a219edc4a5c58fa60654d31cacfd4 )
+	rom ( name "DejaVu2LostInLasVegas_v1.1.lha" size 548318 crc 7CF6C784 sha1 39f60a3fe462c594099f61081a171d99d02bcda8 )
 )
 
 game (
 	name "Deja Vu - A Nightmare Comes True! (USA)"
-	rom ( name "DejaVu_v1.0_NTSC_1832.lha" size 470416 crc 00A4E963 sha1 9136e726cb4031307b1ad670bca59e1848150cb9 )
+	rom ( name "DejaVu_v1.2_NTSC_1832.lha" size 484304 crc 97EE0E75 sha1 67cc29903afee01ba79298ea762ae6e5c115e6e2 )
 )
 
 game (
 	name "Deliverance (Europe)"
-	rom ( name "Deliverance_v1.5_1500.lha" size 1829553 crc 1A63D912 sha1 da3ec607703bd7d5a1320d3e7e9717522062584a )
+	rom ( name "Deliverance_v2.0_1500.lha" size 1830368 crc E175970F sha1 46eb29d81e68ef29b5ad55471a1767e397b0b167 )
+)
+
+game (
+	name "Deliverance (Europe) (512 kB)"
+	rom ( name "Deliverance_v2.0_512k_1500.lha" size 1830575 crc 8764238C sha1 0737aa899d30214f104af46fe783569da90efac7 )
 )
 
 game (
 	name "Delta Command (Arcadia) (Europe)"
-	rom ( name "DeltaCommand_v0.2_Arcadia.lha" size 814960 crc ABE6AA58 sha1 ced5e8df55f77ccebf1acc3d4ca1de8ad786e0d8 )
+	rom ( name "DeltaCommand_v1.0_Arcadia.lha" size 820921 crc EA7CCF4A sha1 aebfdd9be4a26d7743d0d15a6ed188969059ebb3 )
 )
 
 game (
 	name "DeLuxe Galaga (Europe)"
-	rom ( name "DeluxeGalaga_v1.2.lha" size 872390 crc B3DA0E0E sha1 74c5ea72dbd377418467c16a488dbe6a17f0ad94 )
+	rom ( name "DeluxeGalaga_v1.3.lha" size 872318 crc D4EAA641 sha1 de7bf072e2cd9f9e47764c4b3883b6c8c5eaf92a )
 )
 
 game (
 	name "DeLuxe Galaga (Europe) (AGA)"
-	rom ( name "DeluxeGalaga_v1.2_AGA.lha" size 1041171 crc C733B7A2 sha1 c83ef1d9c01b678bf69b1795ddf174024cda696c )
+	rom ( name "DeluxeGalaga_v1.3_AGA.lha" size 1041289 crc D2EB0DFD sha1 b037671d758eab3d4c7aec98b9ff43630bd078dc )
 )
 
 game (
@@ -3966,6 +4546,11 @@ game (
 )
 
 game (
+	name "Demolition (Europe)"
+	rom ( name "Demolition_v1.0_2712.lha" size 263898 crc 0FCFCAE1 sha1 b2064f758eeb9105f35d70c666a12d7bac60f33a )
+)
+
+game (
 	name "Demon Blue (Europe)"
 	rom ( name "DemonBlue_v1.2.lha" size 545505 crc 28683670 sha1 1c4ff310128d5ade067c169ba820bcaccdebeebe )
 )
@@ -3982,12 +4567,17 @@ game (
 
 game (
 	name "Denaris (Europe) (Compilation - 5th Anniversary)"
-	rom ( name "Denaris_v1.1a_1Disk_2166.lha" size 721181 crc 2F7715BD sha1 0ccee4637fa13bb2dd5e8617eba64c23856c75d2 )
+	rom ( name "Denaris_v2.0_1Disk_2166.lha" size 721548 crc 2B18EA06 sha1 e2fb8bb1a95016d521c59997c9c78c9764a56195 )
 )
 
 game (
 	name "Denaris (Europe)"
-	rom ( name "Denaris_v1.1a_2Disk_0049.lha" size 855575 crc 0868ACEF sha1 9c87c10c2c4d4b84256ed67d11cb96d0252b7628 )
+	rom ( name "Denaris_v2.0_2Disk_0049.lha" size 855932 crc 2FAB099A sha1 18a979e8d7a9ca68548e673fa6485cf928895808 )
+)
+
+game (
+	name "Denaris (USA)"
+	rom ( name "Denaris_v2.0_NTSC.lha" size 858499 crc E6ABAC84 sha1 3691e4262014a4bf3147ba19ddaa7ca2ef45be6c )
 )
 
 game (
@@ -4031,28 +4621,43 @@ game (
 )
 
 game (
+	name "Detector (Europe)"
+	rom ( name "Detector_v1.0.lha" size 771789 crc 7AAD272D sha1 885a90c5a59dc90175014a9135ed69f1ba538f39 )
+)
+
+game (
 	name "Detonator (Europe)"
 	rom ( name "Detonator_v1.0.lha" size 411792 crc 19DB5D88 sha1 9090ccbd4ae9db9cbdb1b2ba7e8e92165df9d0f8 )
 )
 
 game (
 	name "Detroit (Europe)"
-	rom ( name "Detroit_v1.0_1861.lha" size 1122859 crc 685E3530 sha1 37153cd53f89af5d24eb222eb654547dcb406234 )
+	rom ( name "Detroit_v1.1_1861.lha" size 1126305 crc 1245FA33 sha1 3cbaf17a126daeab5c2b0f5693151bca0e592bed )
+)
+
+game (
+	name "Detroit (France)"
+	rom ( name "Detroit_v1.1_Fr.lha" size 1125542 crc 1B408D8D sha1 b6045393a876c91053e41e23655ff3f173864897 )
 )
 
 game (
 	name "Detroit (Europe) (AGA)"
-	rom ( name "Detroit_v1.0_AGA.lha" size 1186909 crc EF362DA6 sha1 2b1fb4641e66a4caa4666409d88a0609ebadc65c )
+	rom ( name "Detroit_v1.1_AGA.lha" size 1190294 crc 1C9B224C sha1 c7fa32bf656e887962e1fa0bc535d953ecd8f349 )
 )
 
 game (
 	name "Detroit (France) (AGA)"
-	rom ( name "Detroit_v1.0_AGA_Fr.lha" size 1185434 crc 8670FCF3 sha1 6fe006083bce9245d2f25fa74d813ef6e6c0f24e )
+	rom ( name "Detroit_v1.1_AGA_Fr.lha" size 1188798 crc 3523E592 sha1 5cfed28682de7dfb186ab022c740d66bf8b7332c )
 )
 
 game (
-	name "Deuteros - The Next Millennium (Europe)"
+	name "Deuteros - The Next Millennium (Europe) (En,Fr,De)"
 	rom ( name "Deuteros_v1.10_0958.lha" size 967771 crc 919EF60C sha1 dd23d52f1f398973999fedf7dbd0eb12a36a3018 )
+)
+
+game (
+	name "Devil's Temple (Europe) (Demo)"
+	rom ( name "DevilsTempleDemo_v1.0.lha" size 458570 crc B55747D3 sha1 380b25fd2f58ba9e30329451794cc5eeb243d1b1 )
 )
 
 game (
@@ -4076,7 +4681,7 @@ game (
 )
 
 game (
-	name "Dick Tracy (Europe)"
+	name "Dick Tracy (Europe) (En,Fr,De,Es,It)"
 	rom ( name "DickTracy_v1.0.lha" size 392621 crc 87F4B8CF sha1 ba0240d74df5388f274910819537db2b09b6c3b6 )
 )
 
@@ -4092,11 +4697,11 @@ game (
 
 game (
 	name "Difensore Della Corona II (Italy) (CD32)"
-	rom ( name "DifensoreDellaCorona2_v1.1_CD32_It.lha" size 8385968 crc 7694996B sha1 8a32bc232d8d6483c25e3f9aa70335412a4377cd )
+	rom ( name "DifensoreDellaCorona2_v1.2_CD32_It.lha" size 8386262 crc 8B70745C sha1 ca1506fd98f7a703933f218d55a259624d076021 )
 )
 
 game (
-	name "Digger (Europe)"
+	name "Digger (Europe) (En,Fr,De,It)"
 	rom ( name "Digger_v1.0.lha" size 47617 crc 2FBFE506 sha1 426dcd5e854345709236c07d1395cfc50d7f0f37 )
 )
 
@@ -4106,13 +4711,13 @@ game (
 )
 
 game (
-	name "Diggers (Europe) (CD32)"
+	name "Diggers (Europe) (En,Fr,De,It) (CD32)"
 	rom ( name "Diggers_v1.0_CD32.lha" size 10607288 crc A2565E75 sha1 5f08259197f72fea261c11c2b9fa1f1d62c19313 )
 )
 
 game (
 	name "Dimo's Quest (Europe)"
-	rom ( name "DimosQuest_v1.1a_1216.lha" size 667050 crc 7D1441AE sha1 82f269ae66a2b802ae3c5a3565a0b63403367971 )
+	rom ( name "DimosQuest_v1.3_1216.lha" size 664706 crc BC451C5F sha1 04215bc6fac323db60ae4b916ae4890d4ed88fca )
 )
 
 game (
@@ -4132,16 +4737,16 @@ game (
 
 game (
 	name "Diosa De Cozumel, La (Spain)"
-	rom ( name "DiosaDeCozumel_v1.0_Es.lha" size 752286 crc E00DAC2C sha1 efe745d01bae815de36c35d6552d361d495b2a09 )
+	rom ( name "DiosaDeCozumel_v1.0_Es.lha" size 1273685 crc E1BA3F56 sha1 126456e87c27f997ce3a611d81662e25e76d6942 )
 )
 
 game (
 	name "Disc (Europe)"
-	rom ( name "Disc_v1.1_1503.lha" size 610279 crc 5522F37B sha1 1fc0cb02bf8b857a44ea49d24f409132116173e4 )
+	rom ( name "Disc_v2.0_1503.lha" size 610685 crc BD26509B sha1 437346a70410ccf49bfc4db688e8fca8bb5926ee )
 )
 
 game (
-	name "Discovery - In the Steps of Columbus (Europe)"
+	name "Discovery - In the Steps of Columbus (Europe) (En,Fr,De,Es,It)"
 	rom ( name "Discovery_v1.0_2175.lha" size 576914 crc 040D3479 sha1 13297e2c3ea2b5ad4c8ebd885e0985389098af45 )
 )
 
@@ -4152,17 +4757,17 @@ game (
 
 game (
 	name "Disposable Hero (Europe)"
-	rom ( name "DisposableHero_v1.5_1367.lha" size 1885104 crc 6C24FB5F sha1 e0e767039d13eca07932d222805d0882fefec8a9 )
+	rom ( name "DisposableHero_v1.7_1367.lha" size 1885558 crc AC0D59B8 sha1 324a7c4c5277981985cca43137394e800589d11c )
 )
 
 game (
 	name "Disposable Hero (Europe) (CD32)"
-	rom ( name "DisposableHero_v1.5_CD32.lha" size 2352280 crc 1C963248 sha1 62f099f450c76b6a62e02cfff68b83e53775365d )
+	rom ( name "DisposableHero_v1.7_CD32.lha" size 2340272 crc 3B8290BA sha1 b59264e09ab8d73b16912b051e82d43e8dd0452d )
 )
 
 game (
-	name "Disposable Hero (Fast) (Europe)"
-	rom ( name "DisposableHero_v1.5_Fast_1367.lha" size 1885115 crc 809AF2BF sha1 f1dfca77871c82d9cf2be7c762f28e74188af9d5 )
+	name "Disposable Hero (Europe) (Fast)"
+	rom ( name "DisposableHero_v1.7_Fast_1367.lha" size 1885609 crc 5D22AB11 sha1 08b9b72af50b3cc47241afd40b357940f218fa42 )
 )
 
 game (
@@ -4177,7 +4782,7 @@ game (
 
 game (
 	name "Dizzy Collection - 5 Game Pack (Europe)"
-	rom ( name "DizzyCollection_v1.2.lha" size 1172442 crc 55C0D6DA sha1 60d28701ba4611cbcb366d69195a734b7eca2204 )
+	rom ( name "DizzyCollection_v2.0_1348.lha" size 1174356 crc ABCD3845 sha1 8480805e395f5ca936671f9f709d03cdf8ca2b79 )
 )
 
 game (
@@ -4192,7 +4797,7 @@ game (
 
 game (
 	name "Dizzy - Prince of the Yolkfolk (Europe)"
-	rom ( name "DizzyPrinceOfTheYolkfolk_v1.4_1146.lha" size 228001 crc 866FEC88 sha1 558f429f560418e4d459320a12c5a9b711e5edde )
+	rom ( name "DizzyPrinceOfTheYolkfolk_v2.0_1146.lha" size 229887 crc 7B1965A7 sha1 ba5fb1541b23c8cfd917aee22b2c970f51ee6b3d )
 )
 
 game (
@@ -4201,13 +4806,13 @@ game (
 )
 
 game (
-	name "Dogfight - 80 Years of Aerial Warfare (Europe)"
+	name "Dogfight - 80 Years of Aerial Warfare (Europe) (En,Fr,De,It)"
 	rom ( name "Dogfight_v1.02_1293.lha" size 1720463 crc A63343E6 sha1 da8ea3b53dad9666098340f3f431d65cb77b7b50 )
 )
 
 game (
 	name "Dogs of War (Europe)"
-	rom ( name "DogsOfWar_v1.3_3008.lha" size 394330 crc 350D3838 sha1 701d81d85496aaa00d7943d3d87a74156fed516f )
+	rom ( name "DogsOfWar_v2.1_3008.lha" size 397144 crc 0348A58D sha1 37a7ae9906ce8d19c7f313d335492368c6844549 )
 )
 
 game (
@@ -4226,7 +4831,7 @@ game (
 )
 
 game (
-	name "Dominium (Europe)"
+	name "Dominium (Europe) (En,Fr,De)"
 	rom ( name "Dominium_v1.0.lha" size 2111282 crc 9173534A sha1 3bf6f15bb126719909b12f46fb9bd1bb99c258c0 )
 )
 
@@ -4236,13 +4841,18 @@ game (
 )
 
 game (
-	name "Donald's Alphabet Chase (Europe)"
+	name "Donald's Alphabet Chase (Europe) (En,Fr,De,Es,It)"
 	rom ( name "DonaldsAlphabetChase_v1.0_2067.lha" size 329013 crc 961524D8 sha1 1e4abceb2b75799d5214348150e4e771262e0332 )
 )
 
 game (
-	name "Donkey Kong (Europe)"
-	rom ( name "DonkeyKong_v1.0.lha" size 200350 crc E168FEF2 sha1 4e1645ec05f2b383da07585d8d60fef2b3c7e383 )
+	name "¿Dónde Está Carmen Sandiego? ¡Búscala Por Todo El Mundo! (Spain)"
+	rom ( name "DondeEstaCarmenSandiegoBuscalaPorTodoElMundo_v0.1_Es.lha" size 458284 crc 7E1BBD74 sha1 6b2d21ef9addcf5087d0697d37d40923ca1887c5 )
+)
+
+game (
+	name "Donkey Kong (Bignonia) (Europe)"
+	rom ( name "DonkeyKong_v1.0_Bignonia.lha" size 201824 crc 668E7094 sha1 804a72c33e29139dcb992e2d2a13472f540d0aff )
 )
 
 game (
@@ -4257,7 +4867,12 @@ game (
 
 game (
 	name "Doodlebug (Europe)"
-	rom ( name "Doodlebug_v1.2.lha" size 519015 crc F9263ADB sha1 4ec3dfcc1855ba4da3e7eec3063f2caadbdf8a56 )
+	rom ( name "Doodlebug_v1.3_1862.lha" size 528494 crc 866890EA sha1 07daf2f507422b96569d35900d58a0b2f00321ff )
+)
+
+game (
+	name "Doody (Europe)"
+	rom ( name "Doody_v1.1.lha" size 106293 crc A2AC83C5 sha1 da7009ba008cf4a82feb566a222c6eeeeed8f552 )
 )
 
 game (
@@ -4296,6 +4911,11 @@ game (
 )
 
 game (
+	name "Down at the Trolls (Europe)"
+	rom ( name "DownAtTheTrolls_v1.2_3009.lha"size 366212 crc 001A196F sha1 4cbc6feef16c0c7c0614ea71dab01613f70eb7b6 )
+)
+
+game (
 	name "Downhill Challenge (USA)"
 	rom ( name "DownhillChallenge_v1.2_NTSC.lha" size 320159 crc 4F7C0DC7 sha1 9ab251f70886c7bf8b914bf030b0e7e3204ff052 )
 )
@@ -4307,12 +4927,12 @@ game (
 
 game (
 	name "Dragon Breed (Europe)"
-	rom ( name "DragonBreed_v1.1_0441.lha" size 408264 crc 4D8AB15E sha1 c4fbb5bbfedb2bc49aa5d09aba3bd359df0e32ed )
+	rom ( name "DragonBreed_v1.2_0441.lha" size 408546 crc 1390724F sha1 bd81be685a912be0da88691a5b75c8f66d3b902c )
 )
 
 game (
 	name "Dragon Fighter (Europe)"
-	rom ( name "DragonFighter_v1.1_1023.lha" size 957275 crc C56752E0 sha1 3968459ac5bd0e2aa15ffa17de4b6bd52a45fe15 )
+	rom ( name "DragonFighter_v1.2_1023.lha" size 957722 crc 2FC89416 sha1 7558ba26792919b9de3f35d47f263577c49ffabe )
 )
 
 game (
@@ -4331,23 +4951,28 @@ game (
 )
 
 game (
+	name "Dragon Lord (USA)"
+	rom ( name "DragonLord_v2.1_NTSC_3070.lha" size 1320502 crc 30AAE591 sha1 f11305b5de053c924088a1725c53c921ceae2832 )
+)
+
+game (
 	name "Dragons Breath (Europe)"
-	rom ( name "DragonsBreath_v1.6_0072.lha" size 1309161 crc C4D68E4F sha1 ce04fa01fc4e63f31a47ccdf4d1cb4f692046d58 )
+	rom ( name "DragonsBreath_v2.1_0072.lha" size 1309556 crc 648A8829 sha1 36df3e4372e8175da88deda22611e929a496556e )
 )
 
 game (
 	name "Dragons Breath (Germany)"
-	rom ( name "DragonsBreath_v1.6_De_0821.lha" size 1310181 crc 374C407A sha1 b4707e7cc60f26bc52bfec6e64cc67eeafe9e382 )
+	rom ( name "DragonsBreath_v2.1_De_0821.lha" size 1310576 crc B3316922 sha1 6abd7a6dc60989fcdba132f15610138d4b95447c )
 )
 
 game (
 	name "Dragons Breath (France)"
-	rom ( name "DragonsBreath_v1.6_Fr_2388.lha" size 1313777 crc EEE8DFB5 sha1 7e89e65849512107ba7886ebeb36296ab1b82cff )
+	rom ( name "DragonsBreath_v2.1_Fr_2388.lha" size 1314173 crc D1CB5AE5 sha1 5fe9fa5d180c345aa34d247fbb6061368c94dfb7 )
 )
 
 game (
 	name "Dragons Breath (Italy)"
-	rom ( name "DragonsBreath_v1.6_It.lha" size 1310578 crc 86E4F453 sha1 39cf39c3672b0160a7ec2549eec0be9fce3ffd11 )
+	rom ( name "DragonsBreath_v2.1_It.lha" size 1310968 crc 8E8DA859 sha1 bb3b4536b0563a2221637e09669c1cfb91511cba )
 )
 
 game (
@@ -4366,8 +4991,18 @@ game (
 )
 
 game (
-	name "Dragon's Lair - Escape from Singe's Castle (Slow) (Europe)"
+	name "Dragon's Lair - Escape from Singe's Castle (USA)"
+	rom ( name "DragonsLair&EscapeFromSingesCastle_v1.2a_Fast_NTSC.lha" size 8637535 crc 1A9A1E7D sha1 f6d61f4bed20dd62cd9a0de555c280a9e0b1437c )
+)
+
+game (
+	name "Dragon's Lair - Escape from Singe's Castle (Europe) (Slow)"
 	rom ( name "DragonsLair&EscapeFromSingesCastle_v1.2a_Slow_1360&0980.lha" size 8635030 crc A97CB0E1 sha1 43673a68e1eb81ec9ea9359aafebee70369b101a )
+)
+
+game (
+	name "Dragon's Lair - Escape from Singe's Castle (USA) (Slow)"
+	rom ( name "DragonsLair&EscapeFromSingesCastle_v1.2a_Slow_NTSC.lha" size 8637509 crc 976249A1 sha1 c36860c6c26e9b66931fecf9523e99c898ef14ba )
 )
 
 game (
@@ -4391,7 +5026,7 @@ game (
 )
 
 game (
-	name "Dragon's Lair - Escape from Singe's Castle (Slow) (Europe)"
+	name "Dragon's Lair - Escape from Singe's Castle (Europe) (Slow)"
 	rom ( name "DragonsLairEscapeFromSingesCastle_v1.2a_Slow_0980.lha" size 3632956 crc 66216D49 sha1 07c5e1f6e35f43b3550763e8ab3306cafd211e26 )
 )
 
@@ -4401,23 +5036,28 @@ game (
 )
 
 game (
-	name "Dragon Spirit (Europe)"
-	rom ( name "DragonSpirit_v1.1_1545.lha" size 572207 crc 482121C9 sha1 721e5ad690cdc0c03bc15dd47ebb8fc25eb58c3e )
+	name "Dragons of Flame (Europe)"
+	rom ( name "DragonsOfFlame_v1.0_0985.lha" size 388727 crc 9A3D793B sha1 50cdcebe2971401f09d5b05da927dd8775da033a )
 )
 
 game (
-	name "Dragonstone (Europe) (CD32)"
+	name "Dragon Spirit (Europe)"
+	rom ( name "DragonSpirit_v1.3_1545.lha" size 572609 crc 3BDAC2F8 sha1 794d44a42d4edd664e774c7e7d4b6abd73f73289 )
+)
+
+game (
+	name "Dragonstone (Europe) (En,Fr,De) (CD32)"
 	rom ( name "Dragonstone_V1.0_CD32.lha" size 2672170 crc A273BB6D sha1 7a4ccf3a302afdea11cd09d46d5450bff064ada4 )
 )
 
 game (
-	name "Dragonstone (Europe)"
+	name "Dragonstone (Europe) (En,Fr,De)"
 	rom ( name "Dragonstone_v1.2_0471.lha" size 3287539 crc 600767CB sha1 660d2964a39fa3367364396aeba9f78ec6cce62b )
 )
 
 game (
 	name "Advanced Dungeons & Dragons - DragonStrike - DragonLance Dragon Combat Simulator (USA) (v1.0) (Europe)"
-	rom ( name "DragonStrike_v1.1_NTSC_1479.lha" size 1168565 crc 7C2F63A7 sha1 aa199f253fd4dc5fcbb3dd47a4dc72db75306f9b )
+	rom ( name "DragonStrike_v1.2_NTSC_1479.lha" size 1170396 crc F3CADE99 sha1 7ef7efc05adb763804248cbb47a1eb5da6fb5ad4 )
 )
 
 game (
@@ -4447,42 +5087,47 @@ game (
 
 game (
 	name "Drakkhen (Germany)"
-	rom ( name "Drakkhen_v1.3_De_Files_0458.lha" size 1182161 crc D99ED2E2 sha1 58f37bc494a8d01348b6de32540bbee1a490f364 )
+	rom ( name "Drakkhen_v1.4_De_Files_0458.lha" size 1186120 crc 3926B494 sha1 7eec0d3fa7217fd26d2c233ea32f14ca5ee830a0 )
 )
 
 game (
-	name "Drakkhen (Image) (Germany)"
-	rom ( name "Drakkhen_v1.3_De_Image_0458.lha" size 1377668 crc DDF4E5EA sha1 ffb69750e7d752c8a0348ed8a1ddba0038f8c253 )
+	name "Drakkhen (Germany) (Image)"
+	rom ( name "Drakkhen_v1.4_De_Image_0458.lha" size 1380638 crc 1A0CF2BF sha1 c5f0d932cb524917200430085245bd2e663802e4 )
 )
 
 game (
 	name "Drakkhen (Europe)"
-	rom ( name "Drakkhen_v1.3_Files_0769.lha" size 1184532 crc F38C9456 sha1 e858b54d16ed24aca272c5ead8af17983c8b0427 )
+	rom ( name "Drakkhen_v1.4_Files_0769.lha" size 1187514 crc 5E1BB10A sha1 405eda7ec6a4c409707e36a55ecc75d434dd8202 )
 )
 
 game (
 	name "Drakkhen (France)"
-	rom ( name "Drakkhen_v1.3_Fr_Files_2558.lha" size 1179769 crc 15837932 sha1 3e6a89c8a1b86412715029ab123f46dea8098b93 )
+	rom ( name "Drakkhen_v1.4_Fr_Files_2558.lha" size 1182736 crc 93D76D33 sha1 46c7da880d25e40ddceea0275fd92974da5375d4 )
 )
 
 game (
-	name "Drakkhen (Image) (France)"
-	rom ( name "Drakkhen_v1.3_Fr_Image_2558.lha" size 1207403 crc 0D8248C4 sha1 6e4d5e756725342bc6cec3f2fae9ec63ce05d132 )
+	name "Drakkhen (France) (Image)"
+	rom ( name "Drakkhen_v1.4_Fr_Image_2558.lha" size 1210359 crc 3112952E sha1 8a65d04166ff44a2e870ac34bc291913cb2fa00a )
 )
 
 game (
-	name "Drakkhen (Image) (Europe)"
-	rom ( name "Drakkhen_v1.3_Image_0769.lha" size 1253836 crc 29478F74 sha1 673619d10d6cfdc7df0343d2a19be2b32420955d )
+	name "Drakkhen (Europe) (Image)"
+	rom ( name "Drakkhen_v1.4_Image_0769.lha" size 1256818 crc 7D37048B sha1 6dac833391ed8d04d6540c819425cb2ca9016b47 )
 )
 
 game (
 	name "Drakkhen (USA)"
-	rom ( name "Drakkhen_v1.3_NTSC_Files_1843.lha" size 1182197 crc 51C330FE sha1 a98c9a73dc0927c940f034bebe94b0efa428c650 )
+	rom ( name "Drakkhen_v1.4_NTSC_Files_1843.lha" size 1185168 crc ADE9DD48 sha1 7ed26c64939cded76edc4ae2bfda7803227c479b )
 )
 
 game (
 	name "Drakkhen (USA) (Image)"
-	rom ( name "Drakkhen_v1.3_NTSC_Image_1843.lha" size 1232556 crc 6744C4E2 sha1 b6005ea5fa23ba6d7f6330e436cf984c672c7980 )
+	rom ( name "Drakkhen_v1.4_NTSC_Image_1843.lha" size 1235540 crc 92A2025E sha1 a1931caf46c9f3225e492ab3f2c84b134223112c )
+)
+
+game (
+	name "Dr. Cube's Magic Lands (Europe)"
+	rom ( name "DrCubesMagicLands_v1.1.lha" size 1339649 crc 77CA4A8C sha1 9fc1157aa9a2fa0dceb606e1c22c3484f9664f8b )
 )
 
 game (
@@ -4526,13 +5171,13 @@ game (
 )
 
 game (
-	name "Driller (Europe)"
-	rom ( name "Driller_v1.0_2256.lha" size 279225 crc 7F493170 sha1 d3df36062047f6ab612dd6fd7fa24c9c0690a103 )
+	name "Driller (Europe) (En,Fr,De,It)"
+	rom ( name "Driller_v2.2_2256.lha" size 280768 crc 5C9B0B93 sha1 4b688a96a9076ecf5d67bf110966649e759da149 )
 )
 
 game (
 	name "Drip (Europe)"
-	rom ( name "Drip_v1.0.lha" size 246038 crc 0632A67F sha1 1d508bd05c3a43c6abea8ed8b6551d43f3b0c4ab )
+	rom ( name "Drip_v1.1.lha" size 250033 crc 2BB00EAB sha1 c407bdd4ce6bb4921ff68e2b9f25d25dce199936 )
 )
 
 game (
@@ -4556,43 +5201,63 @@ game (
 )
 
 game (
-	name "Dune II - Battle for Arrakis (Europe)"
+	name "Dune II - Battle for Arrakis (Europe) (En,Fr,De)"
 	rom ( name "Dune2_v1.1_1548.lha" size 2525592 crc BE830DF4 sha1 fdca74c3c2f8ff7191f487c4d40712d849497a07 )
 )
 
 game (
+	name "Dune II - Battle for Arrakis (Italy)"
+	rom ( name "Dune2_v1.1_It.lha" size 2038805 crc 3A8406E6 sha1 c17b4c90bb8a18dac0de4950891655727ce1d3d9 )
+)
+
+game (
+	name "Dune II - Battle for Arrakis (USA)"
+	rom ( name "Dune2_v1.1_NTSC.lha" size 2527830 crc D2431720 sha1 589b6b9c95778ce4395517e667f34f0d18312d32 )
+)
+
+game (
 	name "Dune (Europe)"
-	rom ( name "Dune_v3.0_1156.lha" size 1769660 crc BCCE8E7D sha1 9837bbae21a39d15bea6f21ed4e5556cacaa7487 )
+	rom ( name "Dune_v3.1_1156.lha" size 1769963 crc B5289985 sha1 20394cacb2a8628c82ebbf7d6776dfcb6d89fc49 )
 )
 
 game (
 	name "Dune (Germany)"
-	rom ( name "Dune_v3.0_De_0459.lha" size 1774295 crc 94347593 sha1 c9afef6af3e4b0492629e60d557b634ecf55295d )
+	rom ( name "Dune_v3.1_De_0459.lha" size 1774455 crc 056E56DF sha1 dd79639a31796d7cc982ea5144a7d734ae5634b6 )
 )
 
 game (
 	name "Dune (Spain)"
-	rom ( name "Dune_v3.0_Es.lha" size 1772468 crc E6BD9F44 sha1 393ba3f38f23ca0c5afa13b0912837e5cce9aa48 )
+	rom ( name "Dune_v3.1_Es.lha" size 1772628 crc 8BAF95F5 sha1 e876960f4625be6b320997f437d15fea62340eea )
 )
 
 game (
 	name "Dune (France)"
-	rom ( name "Dune_v3.0_Fr_2393.lha" size 1773360 crc 6D5BF3E3 sha1 11ba4c03e1d16ca0a312b735052111bd4dc967f5 )
+	rom ( name "Dune_v3.1_Fr_2393.lha" size 1773520 crc FCF1C7A1 sha1 8d29ae106413b5eb70226caa4e73325d3ad1b393 )
+)
+
+game (
+	name "Dune (Greece)"
+	rom ( name "Dune_v3.1_Gr.lha" size 1772087 crc BC3FBBFC sha1 658b87c051e55f7edf81fbffa6fe219c166ae446 )
 )
 
 game (
 	name "Dune (Italy)"
-	rom ( name "Dune_v3.0_It_2594.lha" size 1771461 crc B7EE842E sha1 3465357287ed54b0204834ccf2fcef115ef8c70a )
+	rom ( name "Dune_v3.1_It_2594.lha" size 1771621 crc 00780334 sha1 6dd374032144c7422dde91d0280a97fcb75c8429 )
+)
+
+game (
+	name "Dungeonette (Europe) (AGA) (Demo)"
+	rom ( name "DungeonetteDemo_v1.1_AGA.lha" size 744078 crc 4C9235B3 sha1 b1a3fbd90820768cb1a3d8dd202cda2c24251116 )
 )
 
 game (
 	name "Dungeon Master II - The Legend of Skullkeep (Europe)"
-	rom ( name "DungeonMaster2_v1.0_AGA_0899.lha" size 4416263 crc 6EDB0154 sha1 79ec51a32180004f00919e153c43ba45ba6999f4 )
+	rom ( name "DungeonMaster2_v1.1_0899.lha" size 4429143 crc 1D3AF899 sha1 f228108cae3d56fdc2e8e4e59f24d6d8fcf79442 )
 )
 
 game (
-	name "Dungeon Master (Europe)"
-	rom ( name "DungeonMaster_v1.2_0833.lha" size 614937 crc F2D17973 sha1 64fe90194025cbe189949216450c00cacf400c71 )
+	name "Dungeon Master (Europe) (En,Fr,De)"
+	rom ( name "DungeonMaster_v2.0_0833.lha" size 596102 crc A2BAD38E sha1 e1c5682a576e10f56425fc9f89d5ef5c83342867 )
 )
 
 game (
@@ -4602,12 +5267,12 @@ game (
 
 game (
 	name "Dungeons of Avalon II - The Island of Darkness (Europe)"
-	rom ( name "DungeonsOfAvalon2_v1.0_1957.lha" size 484672 crc 93330912 sha1 bd1a30843847cffc8b38b08a08f4baaa74cbbab1 )
+	rom ( name "DungeonsOfAvalon2_v1.1_1957.lha" size 484456 crc D583E088 sha1 e5073eea2d26497c2ab3bf77707a91a7b2e2ac94 )
 )
 
 game (
 	name "Dungeons of Avalon (Europe)"
-	rom ( name "DungeonsOfAvalon_v1.0_1956.lha" size 505044 crc 7BB9388E sha1 7aeafa46474ae524e7925631bc085f4518f5e04f )
+	rom ( name "DungeonsOfAvalon_v1.1_1956.lha" size 504831 crc 10CC6937 sha1 b65f6dd1d35e4182ac4f429466ab48dc6c6c8dd8 )
 )
 
 game (
@@ -4617,7 +5282,7 @@ game (
 
 game (
 	name "Dylan Dog - The Murderers (Europe)"
-	rom ( name "DylanDogTheMurderers_v1.3.lha" size 1491778 crc 18DF7DB4 sha1 c72002eacd633adc46a3ddd18d6ce8791f5f1cba )
+	rom ( name "DylanDogTheMurderers_v2.0.lha" size 1492034 crc 6389E20D sha1 ae50d1c569c96ef4c4ef21012604af629890bcc3 )
 )
 
 game (
@@ -4627,7 +5292,7 @@ game (
 
 game (
 	name "Dynamite Dux (Europe)"
-	rom ( name "DynamiteDux_v1.0_1183.lha" size 525988 crc 5260C862 sha1 7ed5731942d9a567b5067288baef47921a8de389 )
+	rom ( name "DynamiteDux_v2.0_1183.lha" size 528234 crc B0CE5CDF sha1 0452150f53cce874641fc7248953670ce646c5ae )
 )
 
 game (
@@ -4646,8 +5311,13 @@ game (
 )
 
 game (
-	name "Eagle's Rider (Europe)"
+	name "Eagle's Rider (Europe) (En,Fr,De)"
 	rom ( name "EaglesRider_v1.0.lha" size 628523 crc CC8FCFEE sha1 6b03c57d8093e09fc744965e26cd21a4cc49f4f8 )
+)
+
+game (
+	name "Earl Weaver Baseball (Europe)"
+	rom ( name "EarlWeaverBaseball_v1.0_0323.lha" size 535936 crc 4B20D48E sha1 e007debefc087263b5564115035a8b77c97c175a )
 )
 
 game (
@@ -4662,17 +5332,17 @@ game (
 
 game (
 	name "Eco Phantoms (Europe)"
-	rom ( name "EcoPhantoms_v1.0_2471.lha" size 691371 crc 9C752B79 sha1 590ba2e3a9fe96e4e5f7c899d4251e876095406a )
+	rom ( name "EcoPhantoms_v1.1_2471.lha" size 691551 crc D8C670A3 sha1 4b47697d3440efc6f19bdd7ce439044e9f55a6c6 )
 )
 
 game (
 	name "Edd the Duck 2 - Back with a Quack! (Europe)"
-	rom ( name "EddTheDuck2_v1.1.lha" size 280029 crc DAF164A8 sha1 d7d5d67a58fadc3ef065dd65860b3120c8e8982a )
+	rom ( name "EddTheDuck2_v1.3_1726.lha" size 281987 crc 53909B39 sha1 290cec6c72e74ba66afbbe8248077c5a36f037c8 )
 )
 
 game (
 	name "Edd the Duck! (Europe)"
-	rom ( name "EddTheDuck_v1.1_0650.lha" size 373406 crc 328765CE sha1 406e37b71a2c5aea565a1e6894a9a78b723323b3 )
+	rom ( name "EddTheDuck_v1.2_0650.lha" size 374402 crc D857197A sha1 ee90a6174c32982ec5ce8a87c3f1fac1aac4b1f0 )
 )
 
 game (
@@ -4697,27 +5367,32 @@ game (
 
 game (
 	name "Elf (Europe) (En,Fr,De) (Ocean)"
-	rom ( name "Elf_v1.2_Ocean_0473.lha" size 1581878 crc D2094622 sha1 bc860b83543f79021dc6945915b403b3aff3e7ed )
+	rom ( name "Elf_v1.3_Ocean_EnFrDe_0473.lha" size 1582358 crc BD8E1F31 sha1 a6b6c7f65b71076ba33f0dce6bc9d816b5325b7d )
 )
 
 game (
-	name "Elf (USA) (Ocean)"
-	rom ( name "Elf_v1.2_Ocean_NTSC.lha" size 1555456 crc 2EBB5E76 sha1 9e2ac742663eef28ce5f72273aafb9311367e5c7 )
+	name "Elf (USA) (En,Fr,De) (Ocean)"
+	rom ( name "Elf_v1.3_Ocean_EnFrDe_NTSC.lha" size 1555945 crc 42AA9C2C sha1 f1119a95fad9d194af487bf8bd50aa31f438d162 )
 )
 
 game (
 	name "Elfmania (Europe)"
-	rom ( name "Elfmania_v1.2b_0114.lha" size 1835226 crc 45D94F6F sha1 75311a0cc079d77004e5cf5cb2c5f98abe555b5c )
+	rom ( name "Elfmania_v2.0_0114.lha" size 1833358 crc A632B420 sha1 271cafbbf493dcd708c0488c89fc3c4edb552c2e )
+)
+
+game (
+	name "Elfmania (Europe) (512 kB)"
+	rom ( name "Elfmania_v2.0_512k_0114.lha" size 1833437 crc 26A8954B sha1 492c16f2f9b49c70f876669578669c41a4c14d21 )
 )
 
 game (
 	name "Eliminator (Europe)"
-	rom ( name "Eliminator_v1.1_0770.lha" size 522648 crc 173AC2B2 sha1 853e78b3752903261fad5ba6a206cc8017d41c32 )
+	rom ( name "Eliminator_v1.3_0770.lha" size 523515 crc C3200872 sha1 cb3ec163537bfe1f93d473387523ad385e0c5e12 )
 )
 
 game (
 	name "Elite (Europe)"
-	rom ( name "Elite_v2.0_1572.lha" size 428733 crc A72942DF sha1 8e1cd92e7d82650038d5404c875265be31657cbb )
+	rom ( name "Elite_v2.1_1572.lha" size 429180 crc 4B14F171 sha1 def85e7695124e2bbb5e8c598732cac62fafc4e8 )
 )
 
 game (
@@ -4727,42 +5402,47 @@ game (
 
 game (
 	name "Elvira II - The Jaws of Cerberus (Europe)"
-	rom ( name "Elvira2_v1.4_2242.lha" size 4718677 crc CC195066 sha1 78180323f7e9d001efe78c4cf19d942c932e04ef )
+	rom ( name "Elvira2_v1.5_2242.lha" size 4719135 crc 0C5BE8BC sha1 d26c2e8f3518eabc74d96dc811282c316277bfeb )
 )
 
 game (
 	name "Elvira II - The Jaws of Cerberus (Germany)"
-	rom ( name "Elvira2_v1.4_De.lha" size 4721919 crc 116FEDB1 sha1 9ae44b2af326f912dcd191283e2fbfe82391c1c4 )
+	rom ( name "Elvira2_v1.5_De.lha" size 4724771 crc 1649393E sha1 ddc4dfc5e3f4d57c126559f770a35d5f453b08d4 )
 )
 
 game (
 	name "Elvira II - The Jaws of Cerberus (Spain)"
-	rom ( name "Elvira2_v1.4_Es.lha" size 4721513 crc A7ABA0A6 sha1 d1bc9ea917392dc940bcd20604dceea8911c752d )
+	rom ( name "Elvira2_v1.5_Es.lha" size 4721961 crc 6D619477 sha1 77569201a588a0fb3409cfc6f30a763bdf860ee7 )
 )
 
 game (
 	name "Elvira II - The Jaws of Cerberus (France)"
-	rom ( name "Elvira2_v1.4_Fr_2663.lha" size 4723160 crc 21C9074B sha1 243634d60d644e7adb8e840e2f613ade5231be77 )
+	rom ( name "Elvira2_v1.5_Fr_2663.lha" size 4723610 crc 8FF552AE sha1 fa08e59f3bc42b53f1215adb7f488699c1db04f3 )
 )
 
 game (
 	name "Elvira II - The Jaws of Cerberus (Italy)"
-	rom ( name "Elvira2_v1.4_It.lha" size 4711728 crc 244A7C12 sha1 719c8717c6166115dcbab299ddcabd83ca68a4fa )
+	rom ( name "Elvira2_v1.5_It.lha" size 4712175 crc E5F09458 sha1 e3334ecd44a335ef1fca2cc150f1184aa69dbf4e )
 )
 
 game (
 	name "Elvira - Mistress of the Dark (Europe)"
-	rom ( name "Elvira_v1.2_0267.lha" size 3203004 crc A76FF3CF sha1 c604fab0a1930954f8de3d482f1a46c88fba9b8b )
+	rom ( name "Elvira_v1.4_0267.lha" size 3203854 crc 3BF8E502 sha1 1fd48dfa73df07edd79f284a17aaf408289dd0a6 )
 )
 
 game (
 	name "Elvira - Mistress of the Dark (Germany)"
-	rom ( name "Elvira_v1.2_De_0474.lha" size 3220774 crc B44CDB0E sha1 ce43631854a929ccec4f23dcd286841fd0eb92c1 )
+	rom ( name "Elvira_v1.4_De_0474.lha" size 3221621 crc 1BD989B0 sha1 e7cbecd96d359543f3e6344df530f5b735b7bb29 )
 )
 
 game (
 	name "Elvira - Mistress of the Dark (France)"
-	rom ( name "Elvira_v1.2_Fr_1751.lha" size 3204737 crc AD476416 sha1 34f8e30b64600bc12e19ed8ba23152e39c962dd5 )
+	rom ( name "Elvira_v1.4_Fr_1751.lha" size 3205584 crc E1A98A80 sha1 5fe96a127eca396c1010d6fb505d30931e82ce6e )
+)
+
+game (
+	name "Elvira - Mistress of the Dark (USA)"
+	rom ( name "Elvira_v1.4_NTSC.lha" size 3192697 crc 65657352 sha1 ce462c6f9acef4bbedabeefbfdf58628c08f0727 )
 )
 
 game (
@@ -4771,13 +5451,23 @@ game (
 )
 
 game (
-	name "Embryo (Europe)"
-	rom ( name "Embryo_v1.0_2265.lha" size 3686312 crc 91D63F79 sha1 a2a1910a470f94310522cf5c8b7eddb855e02b08 )
+	name "Embryo (Europe) (En,Fr,Hr)"
+	rom ( name "Embryo_v1.0_2265.lha" size 3695188 crc 0C267F7A sha1 ece5fc7218e45aadf9224e03941f190ac5bc4fce )
 )
 
 game (
 	name "Embryo (Germany)"
-	rom ( name "Embryo_v1.0_De.lha" size 3699455 crc 95E176D4 sha1 caa154018e96091f460f85a2aade59a598a985b2 )
+	rom ( name "Embryo_v1.0_De.lha" size 3700021 crc 68237526 sha1 72738d95fd57021d02cc859b84a759316e18891d )
+)
+
+game (
+	name "Embryo (France)"
+	rom ( name "Embryo_v1.0_Fr_2265.lha" size 3695525 crc CDDCAA60 sha1 555a18033ae89ab6b6bb7f01f18b62d6dde2da9d )
+)
+
+game (
+	name "Embryo (Croatia)"
+	rom ( name "Embryo_v1.0_Hr_2265.lha" size 3695524 crc DA714D31 sha1 5e68b959ab17fb41e214028e01e861adf6e8f475 )
 )
 
 game (
@@ -4796,8 +5486,13 @@ game (
 )
 
 game (
-	name "Emerald Mines (CD) (Europe)"
+	name "Emerald Mines (Europe) (CD)"
 	rom ( name "EmeraldMines_v1.0_CD.lha" size 10698482 crc 6C8D3274 sha1 0b0bcc9feae056ae2b2ee4aefffdf2ca45567439 )
+)
+
+game (
+	name "Emetic Skimmer (Europe)"
+	rom ( name "EmeticSkimmer_v1.0a.lha" size 591392 crc C0E90959 sha1 97ac39f3b267f64ef02dfe87e993fa6fb612eb50 )
 )
 
 game (
@@ -4807,22 +5502,22 @@ game (
 
 game (
 	name "Emmanuelle (Europe)"
-	rom ( name "Emmanuelle_v1.1a.lha" size 482369 crc 94616A39 sha1 902ab4c02f6a214270159c2d2ab266be9b2ec19f )
+	rom ( name "Emmanuelle_v1.2.lha" size 446950 crc 4C5C290D sha1 4f01e8fe4ea8a7f4da8765b3d5db3e9ef23ce13c )
 )
 
 game (
 	name "Emmanuelle (Germany)"
-	rom ( name "Emmanuelle_v1.1a_De_0324.lha" size 508040 crc 7B3DA5C0 sha1 624f5a86a7ee69e8f0f948525463b14c1102dd7d )
+	rom ( name "Emmanuelle_v1.2_De_0324.lha" size 433257 crc 38F835E3 sha1 5e5f23dce86de8b9b340054f23a89727583c7381 )
 )
 
 game (
 	name "Emmanuelle (Spain)"
-	rom ( name "Emmanuelle_v1.1a_Es.lha" size 478871 crc 88905812 sha1 f057840d28fb413ad5f801c8fb66b36227daccd4 )
+	rom ( name "Emmanuelle_v1.2_Es.lha" size 446158 crc 168308C1 sha1 4b000078898b70a43fd457f8ab40af53bd2e1212 )
 )
 
 game (
 	name "Emmanuelle (France)"
-	rom ( name "Emmanuelle_v1.1a_Fr.lha" size 498720 crc 09EDC659 sha1 fd5ec0622d950f8a9f645cd09edcb7108f94f25d )
+	rom ( name "Emmanuelle_v1.2_Fr_2693.lha" size 432785 crc C23F0FA2 sha1 aa0d0e55eb3f1f391df94072c6c9280676a4b535 )
 )
 
 game (
@@ -4842,7 +5537,7 @@ game (
 
 game (
 	name "Enchanted Land (Europe)"
-	rom ( name "EnchantedLand_v1.3_3063.lha" size 782295 crc 4299566F sha1 ffed2e06e9d7e962f30ca21aa683f2b8a31cf242 )
+	rom ( name "EnchantedLand_v1.4_3063.lha" size 781516 crc 5A926EE9 sha1 de831aa0eb560978ecc9c85408ee47fadc5bb15e )
 )
 
 game (
@@ -4852,42 +5547,47 @@ game (
 
 game (
 	name "Enemy 2 - Missing In Action (Europe)"
-	rom ( name "Enemy2MissingInAction_v1.1.lha" size 993922 crc 188614C6 sha1 c736f3da4d2830634728006a1bbdbb0d8cce685d )
+	rom ( name "Enemy2MissingInAction_v1.2.lha" size 992626 crc 1377C346 sha1 28a2faea0b417233c66821efdfae59ab904862b3 )
 )
 
 game (
 	name "Enemy 2 - Missing In Action (Germany)"
-	rom ( name "Enemy2MissingInAction_v1.1_De.lha" size 996773 crc 23EC4AB3 sha1 b844b3f7746795d32b4132c8e6e6402726a50a1b )
+	rom ( name "Enemy2MissingInAction_v1.2_De.lha" size 995473 crc 70E2C059 sha1 b48126f8d294816f2bb8a1364a9cf73210b13336 )
 )
 
 game (
 	name "Enemy - Tempest of Violence (Europe)"
-	rom ( name "EnemyTempestOfViolence_v1.1.lha" size 1198385 crc F6A5D6E0 sha1 64f4a7171c7766d1ec8361a1c01a4b2fc5651b72 )
+	rom ( name "EnemyTempestOfViolence_v1.2.lha" size 1198991 crc B75A9190 sha1 92d439fe60fed854052754a97935ad2909e2ba24 )
 )
 
 game (
 	name "Enemy - Tempest of Violence (Germany)"
-	rom ( name "EnemyTempestOfViolence_v1.1_De.lha" size 1206851 crc 074EC4E6 sha1 058ecf102a081d38a1fb7f6d8750918742a05f42 )
+	rom ( name "EnemyTempestOfViolence_v1.2_De.lha" size 1207289 crc 4C8950A1 sha1 d3bbb3ef21309b61fbcca790637842237d29178e )
 )
 
 game (
-	name "Enemy - Tempest of Violence (EasyPlay) (Europe)"
-	rom ( name "EnemyTempestOfViolence_v1.1_EasyPlay.lha" size 1197348 crc FA5D688A sha1 3c9da2f267bc28eed62c615346f7d80578203892 )
+	name "Enemy - Tempest of Violence (Europe) (EasyPlay)"
+	rom ( name "EnemyTempestOfViolence_v1.2_EasyPlay.lha" size 1197786 crc F4196AD7 sha1 2732cc384874619500489b31f4f601659ed69b32 )
 )
 
 game (
-	name "Enemy - Tempest of Violence (EasyPlay) (Germany)"
-	rom ( name "EnemyTempestOfViolence_v1.1_EasyPlay_De.lha" size 1205223 crc C5A97816 sha1 d4794959da91ea1c847a69594329833a948775c1 )
+	name "Enemy - Tempest of Violence (Germany) (EasyPlay)"
+	rom ( name "EnemyTempestOfViolence_v1.2_EasyPlay_De.lha" size 1205661 crc 604CF9B0 sha1 50540c6c42845623033c8da970cc25adf3aa0230 )
 )
 
 game (
 	name "Enforcer, The (Europe)"
-	rom ( name "Enforcer_v1.1.lha" size 376655 crc 63EDA32C sha1 14cfd3ae89857b9ab9fd9f1b045d487a303315db )
+	rom ( name "Enforcer_v2.0_2962.lha" size 264928 crc 0D698F5D sha1 36070aaaaf1598d3d237294d0c061b338e52fa63 )
 )
 
 game (
 	name "England Championship Special (Europe)"
 	rom ( name "EnglandChampionshipSpecial_v1.1_1671.lha" size 258838 crc CB8FF48E sha1 583939bd414cba774a22b647d77546e8096a3397 )
+)
+
+game (
+	name "Enigme a Oxford (Europe)"
+	rom ( name "EnigmeAOxford_v1.1.lha" size 356249 crc 9E5B8219 sha1 4b032fc25e7a564ad6823f1fc819496a3619e23b )
 )
 
 game (
@@ -4901,18 +5601,18 @@ game (
 )
 
 game (
-	name "Entity (No Intro) (Europe)"
+	name "Entity (Europe) (No Intro)"
 	rom ( name "Entity_v1.2_NoIntro_1735.lha" size 2259908 crc BE1D5F17 sha1 6760b27289f0adf6c87dee925593887c65226809 )
 )
 
 game (
-	name "Epic & Epic Extra Missions (Europe)"
-	rom ( name "Epic&MissionDisk_v1.3_1819.lha" size 2765429 crc CFA459BF sha1 3dc435bf465c315dbaab24ee00b6682f1ae23f37 )
+	name "Epic (Europe)"
+	rom ( name "Epic_v2.0_1819.lha" size 2794761 crc 9E76E647 sha1 b6b5c250f87fe5bc1205f77b4a6728b41bc3ec1e )
 )
 
 game (
-	name "Epic (Europe)"
-	rom ( name "Epic_v1.3_1819.lha" size 2506487 crc A2BBA25E sha1 b85df283082a92289f9a0f03fcb42113dd056e13 )
+	name "Epic (Europe) (1 MB)"
+	rom ( name "Epic_v2.0_1MB_1820.lha" size 1912391 crc 1A8AE4E2 sha1 092b21cf626f5a07939f1e2cba8fa870e9357d07 )
 )
 
 game (
@@ -4927,12 +5627,17 @@ game (
 
 game (
 	name "Escape from Colditz (Europe)"
-	rom ( name "EscapeFromColditz_v1.2_0214.lha" size 434626 crc FDC0B31D sha1 df4f9e82c513f7ccb9bf1d59d4b6507eee5b7aa7 )
+	rom ( name "EscapeFromColditz_v1.4a_0214.lha" size 435072 crc 53612DA1 sha1 277fb9c0caed95a9651ef7f173a6eba6ae8320f8 )
 )
 
 game (
 	name "Escape from the Planet of the Robot Monsters (Europe)"
-	rom ( name "EscapeFromThePlanetOfTheRobotMonsters_v1.5_0477.lha" size 513738 crc 54D2FA31 sha1 eae5b5829d1b1d8f588227b91ffd9ea206d67970 )
+	rom ( name "EscapeFromThePlanetOfTheRobotMonsters_v1.7_0477.lha" size 517156 crc 0D0426F1 sha1 909cb1fc0c1af064ef9ef606b8667ddbf940c179 )
+)
+
+game (
+	name "Escape from the Planet of the Robot Monsters (USA)"
+	rom ( name "EscapeFromThePlanetOfTheRobotMonsters_v1.7_NTSC.lha" size 485899 crc C27F3C7F sha1 2188f8427da99735da9b5fb024c15c1703ce0c2b )
 )
 
 game (
@@ -4946,13 +5651,18 @@ game (
 )
 
 game (
-	name "Espana - The Games '92 (Europe)"
+	name "Espana - The Games '92 (Europe) (En,Fr,De,Es,It)"
 	rom ( name "EspanaTheGames92_v1.2_1327.lha" size 1855100 crc B30D87CA sha1 4001eeae888897df2b2adb8675ae5caf4c2193f0 )
 )
 
 game (
 	name "ESWAT (Europe)"
-	rom ( name "ESWAT_v1.0_2577.lha" size 1077674 crc 64C0ADE6 sha1 75c594ba6e292a884fef7c4494d99581f47dc8f4 )
+	rom ( name "ESWAT_v2.0_Files_2577.lha" size 855243 crc 1645BD23 sha1 b210c05de529c153b982691d6e67165dc3e1bbe9 )
+)
+
+game (
+	name "ESWAT (Europe) (Image)"
+	rom ( name "ESWAT_v2.0_Image_2577.lha" size 1076672 crc 7E7E2BD0 sha1 b810e7ecddf360ed175c1d483eeb81187cb6b4d1 )
 )
 
 game (
@@ -4961,18 +5671,34 @@ game (
 )
 
 game (
+	name "Eureka Maths 4ème/3ème (France)"
+	rom ( name "EurekaMaths4Eme3Eme_v1.0_Fr.lha" size 1278836 crc D1B7E79D sha1 b24a886cf190e221142baf29a9fa46f3f6d0bd28 )
+)
+
+game (
+	name "Eureka Maths 6ème/5ème (France)"
+	rom ( name "EurekaMaths6Eme5Eme_v1.0_Fr.lha" size 1286747 crc 41B04F4E sha1 d22706ed1152a06ee7063fc304c7a824190281e5 )
+)
+
+
+game (
 	name "European Champions (Europe)"
 	rom ( name "EuropeanChampions_v1.2_Ocean_2569.lha" size 1055483 crc 6E2D9D4C sha1 e4bd3d19c2ea7f30987420db25b9e35d4cfc0ca2 )
 )
 
 game (
-	name "European Championship 1992 (Europe)"
-	rom ( name "EuropeanChampionship1992_v1.01_0478.lha" size 1447315 crc BB58DC0D sha1 d28d322768e6617b73859dc346c6a64dce8bdc45 )
+	name "European Championship 1992 (Europe) (En,Fr,De,Es,It,Sv)"
+	rom ( name "EuropeanChampionship1992_v1.02_0478.lha" size 1447523 crc 0ACDC1C7 sha1 3a162f02dec7d1356087ceddead5f983b6b9de6b )
 )
 
 game (
 	name "European Football Champ (Europe)"
 	rom ( name "EuropeanFootballChamp_v1.0_1672.lha" size 286176 crc 2BEDBFD7 sha1 f2b66f0daa0f4710797e520a02bb07cb3fc7ff8e )
+)
+
+game (
+	name "European Space Simulator (Europe) (En,Fr,De,Es,It)"
+	rom ( name "EuropeanSpaceSimulator_v1.0_1375.lha" size 420678 crc 59BDD648 sha1 cd175ff965b990b64862892a4499e9776c4c71e3 )
 )
 
 game (
@@ -4982,12 +5708,17 @@ game (
 
 game (
 	name "Evil Dawn (Europe)"
-	rom ( name "EvilDawn_v1.0.lha" size 132623 crc D656512D sha1 16f1a36ec38becab92e39cd2dfe5fc002748178d )
+	rom ( name "EvilDawn_v1.1.lha" size 132630 crc 31CE8A10 sha1 fe76e41d74ee050002f4447c762a43de9958f417 )
 )
 
 game (
-	name "Evil's Doom (Europe) (Demo)"
-	rom ( name "EvilsDoomDemo_v1.0.lha" size 2600170 crc 4AD08CE0 sha1 ac4a2fa5f15ff54b319d540a3ec7efc7566c3d4d )
+	name "Evil's Doom (Europe) (AGA) (Demo)"
+	rom ( name "EvilsDoomDemo_v1.0_AGA.lha" size 2710976 crc 8B888ADF sha1 fc678960c31ad18e53da19dff2a1a75efe87c71a )
+)
+
+game (
+	name "Evolution Cryser (Europe)"
+	rom ( name "EvolutionCryser_v1.0.lha" size 335449 crc 91A92C9E sha1 8c0427e26de8208ede878c35f3f6a8336a1e8c0d )
 )
 
 game (
@@ -5001,8 +5732,28 @@ game (
 )
 
 game (
-	name "Exile (Europe)"
-	rom ( name "Exile_v1.3_0032.lha" size 481338 crc 7D8BA08A sha1 5ff87f1f6f7a9a65677076a8842c158df50138f1 )
+	name "Exile (Europe) (En,Fr,De) (AGA)"
+	rom ( name "Exile_v1.1_AGA_0885.lha" size 972473 crc E074510A sha1 b5ad06c14d55e584711770ae0ac355f6387d19c0 )
+)
+
+game (
+	name "Exile (Europe) (En,Fr,De) (CD32)"
+	rom ( name "Exile_v1.1_CD32.lha" size 807171 crc 78D7207E sha1 a6dff59c0a13e5f1cb1adac228aab6bbff12f1bf )
+)
+
+game (
+	name "Exile (Europe) (En,Fr,De)"
+	rom ( name "Exile_v1.4_0032.lha" size 486812 crc 97D71CD8 sha1 02d29e855c579953fee3171e677665eba86b82c5 )
+)
+
+game (
+	name "Exodus 3010 (Europe)"
+	rom ( name "Exodus3010_v1.1.lha" size 750736 crc 85A6A5FB sha1 eae907ee2b4609ce2d3039df0f8c8e6322770b2e )
+)
+
+game (
+	name "Exodus 3010 (Germany)"
+	rom ( name "Exodus3010_v1.1_De_1605.lha" size 775608 crc 0835F891 sha1 79efb348dd5a525a191735a82c236e69d00d69f5 )
 )
 
 game (
@@ -5032,17 +5783,17 @@ game (
 
 game (
 	name "Exterminator (Europe)"
-	rom ( name "Exterminator_v1.1_1958.lha" size 618863 crc 9C1C4A32 sha1 ba41868f25ba28c2b40e930a81c1b55a8663fd29 )
+	rom ( name "Exterminator_v1.2_1958.lha" size 619889 crc 9AFA393D sha1 14f779779804756b7a781002d56fc72fec4b3b10 )
 )
 
 game (
-	name "Extractors - The Hanging Worlds of Zarg (Unreleased) (Europe) (CD32)"
+	name "Extractors - The Hanging Worlds of Zarg (Europe) (CD32) (Unreleased)"
 	rom ( name "ExtractorPreview_v1.0_CD32.lha" size 1905210 crc 18D5280E sha1 bbf7ca666fe115fe0c25219d9b2e40745c6d2222 )
 )
 
 game (
 	name "Extrial (Europe)"
-	rom ( name "Extrial_v1.0.lha" size 521864 crc A03AD509 sha1 a379546546fcbcd4b17fb3f51ab8b1c00393c04d )
+	rom ( name "Extrial_v1.1.lha" size 549935 crc E60FF689 sha1 44813c0202a5046b0043c40eb195b125b51340ce )
 )
 
 game (
@@ -5057,12 +5808,12 @@ game (
 
 game (
 	name "Advanced Dungeons & Dragons - Eye of the Beholder II - The Legend of Darkmoon - A Legend Series Fantasy Role-Playing Saga, Vol.II (Europe)"
-	rom ( name "EyeOfTheBeholder2_v1.1_0834.lha" size 2650907 crc B38C244B sha1 38a2bc35210beb79a2cdf36c2a845793052e41a1 )
+	rom ( name "EyeOfTheBeholder2_v1.3_0834.lha" size 2755078 crc DF091562 sha1 0848913777ce54085f7a8bb8c18434bb16a93093 )
 )
 
 game (
 	name "Advanced Dungeons & Dragons - Eye of the Beholder II - Legende von Darkmoon - A Legend Series Fantasy Role-Playing Saga, Vol.II (Germany)"
-	rom ( name "EyeOfTheBeholder2_v1.1_De_0681.lha" size 2653512 crc B327A0F0 sha1 270f77b0d24877884a20cfa7123b3f43d71b837e )
+	rom ( name "EyeOfTheBeholder2_v1.3_De_0681.lha" size 2757815 crc 0843A05F sha1 4aa8e6cd424ff0bfb48d091932570b1201e7c2e7 )
 )
 
 game (
@@ -5137,12 +5888,17 @@ game (
 
 game (
 	name "FA-18 Interceptor (Europe)"
-	rom ( name "FA18Interceptor_v1.4_0119.lha" size 409477 crc 410DD0D7 sha1 47c0052c438f88513c61a6daefff4016e83f2568 )
+	rom ( name "FA18Interceptor_v2.0_0119.lha" size 411220 crc 1E1EF7E7 sha1 d398cc0cd187be23512835f556fd11aaa78cfc95 )
 )
 
 game (
-	name "Face-Off Ice Hockey (Europe)"
-	rom ( name "FaceOff_v1.0_1670.lha" size 686332 crc 74DBD621 sha1 808a0ae8d814b6804a97a7b7ebb48714304ec06b )
+	name "Face Off (Europe) (Anco)"
+	rom ( name "FaceOff_v1.0_Anco_2483.lha" size 248762 crc 6F6E58F7 sha1 1fd6f4b42eb135a8bb825bc1be5e472ab80507ed )
+)
+
+game (
+	name "Face-Off (Europe) (En,Fr,De,Es,It) (Krisalis)"
+	rom ( name "FaceOff_v1.0_Krisalis_1670.lha" size 686565 crc 025A641B sha1 abf0b2db8a5c19a319846ba3ec9235f67a5b049c )
 )
 
 game (
@@ -5177,17 +5933,22 @@ game (
 
 game (
 	name "Fallen Angel (Europe)"
-	rom ( name "FallenAngel_v1.1a.lha" size 329436 crc 1B9F4F28 sha1 9af14e4dbe8c81897eb2de9c158d28095d0a3c62 )
+	rom ( name "FallenAngel_v1.2.lha" size 329972 crc A73E1660 sha1 2a7d9c93383edd6665c78e56cfa3c407fc092428 )
 )
 
 game (
-	name "Fantastic Dizzy (Europe)"
-	rom ( name "FantasticDizzy_v2.0_1904.lha" size 884570 crc CEE99BF3 sha1 40c004cc3f23c88c191b42e3d888d77615b65850 )
+	name "Famous Five, The - Five on a Treasure Island (Europe)"
+	rom ( name "FamousFive_v1.0.lha" size 262852 crc 9DFF1DD1 sha1 e8db3bfc6af8ca1365bbe4a48aa9f852692d3cf3 )
 )
 
 game (
-	name "Fantastic Dizzy (Europe) (AGA)"
-	rom ( name "FantasticDizzy_v2.0_AGA.lha" size 928932 crc 897FA5F3 sha1 3101d90f5c46464396d0ecf13a60cdd1f3dd3e6b )
+	name "Fantastic Dizzy (Europe) (En,Ja,Fr,De,Es,It)"
+	rom ( name "FantasticDizzy_v2.2_1904.lha" size 887878 crc DE897C30 sha1 8117ac4de100a3f8a1a41c106d329e179adb2e58 )
+)
+
+game (
+	name "Fantastic Dizzy (Europe) (En,Ja,Fr,De,Es,It) (AGA)"
+	rom ( name "FantasticDizzy_v2.2_AGA.lha" size 930476 crc 1D00F5A9 sha1 d276a7170b0761fa40fb1965d59c1a3d6965257e )
 )
 
 game (
@@ -5217,27 +5978,27 @@ game (
 
 game (
 	name "Fascination (Europe)"
-	rom ( name "Fascination_v1.1.lha" size 1334823 crc C499A814 sha1 83aea5e845923358b52038b4d2d9f2f374ad14ad )
+	rom ( name "Fascination_v1.2.lha" size 1333562 crc 7C2EE619 sha1 cb2a330daa11d8cfcec71a7bf86dfda906aea1d5 )
 )
 
 game (
 	name "Fascination (Germany)"
-	rom ( name "Fascination_v1.1_De.lha" size 1340841 crc F8E2EDC7 sha1 292574d827994d951a00bf9c8d32393fda83b0ba )
+	rom ( name "Fascination_v1.2_De.lha" size 1340093 crc 8E89CF3D sha1 e21159432430b69a73149d285d8af0fa10036463 )
 )
 
 game (
 	name "Fascination (Spain)"
-	rom ( name "Fascination_v1.1_Es.lha" size 1337621 crc EAFEF534 sha1 30460ac0d6e274c0e844a45a9bf85996c92db08c )
+	rom ( name "Fascination_v1.2_Es.lha" size 1336378 crc FE151F1F sha1 9c1fa1047afe6954ac53d8b5779593590d07a587 )
 )
 
 game (
 	name "Fascination (France)"
-	rom ( name "Fascination_v1.1_Fr.lha" size 1338876 crc D88BAA1D sha1 662bd570111f8f1d24cb2ebf39b9dd7607c34b9c )
+	rom ( name "Fascination_v1.2_Fr_2485.lha" size 1337637 crc C091F710 sha1 b3ec0d1dee100bc85cefc28f20bbbdf30dee7333 )
 )
 
 game (
 	name "Fascination (Italy)"
-	rom ( name "Fascination_v1.1_It.lha" size 1339556 crc F1AA7604 sha1 af43110a39d4dc90de54116bf5fc36c889a34fb0 )
+	rom ( name "Fascination_v1.2_It.lha" size 1338316 crc 748157BF sha1 76694754946fc7851a41572b50b7ec8b1ef835b3 )
 )
 
 game (
@@ -5256,7 +6017,7 @@ game (
 )
 
 game (
-	name "Fast Food (Dizzy Collection) (Europe)"
+	name "Fast Food (Europe) (Dizzy Collection)"
 	rom ( name "FastFood_v1.0_DizzyCollection.lha" size 241818 crc AF8DA08C sha1 fc5e39e60295a407ecd7124287e151d91d6aeb4f )
 )
 
@@ -5271,23 +6032,23 @@ game (
 )
 
 game (
-	name "Fatal Mission 2 (Europe)"
+	name "Fatal Mission (Europe)"
 	rom ( name "FatalMission_v1.0.lha" size 273362 crc F9668430 sha1 2b32e67e9bb0626ab9a4d3464d68d0a2063bdb96 )
 )
 
 game (
 	name "Fate - Gates of Dawn (Europe)"
-	rom ( name "FateGatesOfDawn_v1.1_2842.lha" size 1898922 crc 036A1B22 sha1 cc60a210e4d3fe38a0978a5dba7729f40d60de03 )
+	rom ( name "FateGatesOfDawn_v1.2_2842.lha" size 1964554 crc 54819E76 sha1 0433435085e7cba5196bef418089049fa85bdf0f )
 )
 
 game (
 	name "Fate - Gates of Dawn (Germany)"
-	rom ( name "FateGatesOfDawn_v1.1_De_0544.lha" size 1901806 crc FB886BF1 sha1 7a5a478c79f3f542745cc4245b518681abb1d1dc )
+	rom ( name "FateGatesOfDawn_v1.2_De_0544.lha" size 1967445 crc 6CAB0DFA sha1 50e1b6bfdb7aa3343c2f3526cf550057029ad415 )
 )
 
 game (
 	name "Fate - Gates of Dawn (Europe) (Uncensored)"
-	rom ( name "FateGatesOfDawn_v1.1_Uncensored.lha" size 1905743 crc 8FD1CCE4 sha1 4b362be47e9e8b56f75a357656d04b0ecfb278dc )
+	rom ( name "FateGatesOfDawn_v1.2_Uncensored.lha" size 1971130 crc 813997D7 sha1 10e6f9831dbc33ae108f6d02ac866a4ecd6a033c )
 )
 
 game (
@@ -5306,7 +6067,7 @@ game (
 )
 
 game (
-	name "Fears (Europe) (Censored) (AGA)"
+	name "Fears (Europe) (AGA) (Censored)"
 	rom ( name "Fears_v3.4_AGA_Censored.lha" size 1681462 crc 7A206348 sha1 1912488635521510298ed0f1a4d699eb65b11af6 )
 )
 
@@ -5346,18 +6107,23 @@ game (
 )
 
 game (
-	name "Fiendish Freddy's Big Top o' Fun (Europe)"
-	rom ( name "FiendishFreddysBigTopOFun_v1.3_0500.lha" size 1361729 crc 5D64BD93 sha1 e0dd2089486728052630f74646abed84353882ee )
+	name "Feudal Lords (Europe)"
+	rom ( name "FeudalLords_v1.1_2991.lha" size 401874 crc 9CD685BB sha1 62eb722f68cd7bf4420bd729f530f05619bdef2b )
 )
 
 game (
-	name "FIFA International Soccer (Europe)"
+	name "Fiendish Freddy's Big Top o' Fun (Europe)"
+	rom ( name "FiendishFreddysBigTopOFun_v1.4_0500.lha" size 1361813 crc 725AA3F1 sha1 2961bd007ec596da6531ff7409a972b159a7418c )
+)
+
+game (
+	name "FIFA International Soccer (Europe) (En,Fr,De)"
 	rom ( name "FIFAInternationalSoccer_v1.0_0501.lha" size 1831208 crc 4E281767 sha1 be5e0c36f9521b80dc718992342378a9a2a0331e )
 )
 
 game (
-	name "Fighter Bomber (Europe)"
-	rom ( name "FighterBomber_v1.1_1135.lha" size 817689 crc CFCCDC0B sha1 8bd16bb315b9dd1be57a0563679e20b796e35237 )
+	name "Fighter Bomber (Europe) (En,Fr)"
+	rom ( name "FighterBomber_v2.0_1135.lha" size 867523 crc 38013860 sha1 c3de60a02367bb33a18fdbd8513d6c5204d96f5a )
 )
 
 game (
@@ -5392,67 +6158,102 @@ game (
 
 game (
 	name "Final Assault (Europe)"
-	rom ( name "FinalAssault_v1.0.lha" size 412473 crc DE6DD1D7 sha1 8c2fa80c789c2459e359af035693a8dc09880390 )
+	rom ( name "FinalAssault_v1.2.lha" size 413491 crc D60397F5 sha1 bf13b0f977de48e3c34d7c5d75fcf096dc20648a )
+)
+
+game (
+	name "Final Assault (USA)"
+	rom ( name "FinalAssault_v1.2_NTSC_1429.lha" size 447489 crc D347378A sha1 1e1e5c31258365245b9ef6837b04a1e93e78a573 )
 )
 
 game (
 	name "Final Battle, The (Europe)"
-	rom ( name "FinalBattle_v1.1.lha" size 518823 crc 9B51C1E5 sha1 8277d01483cc3f8ac0f925f4b23bbaa46db89462 )
+	rom ( name "FinalBattle_v1.2_0259.lha" size 528273 crc 30CB4970 sha1 ec8d6ab37118c291ed50038d60e2274dbe5db763 )
 )
 
 game (
 	name "Final Battle, The (Germany)"
-	rom ( name "FinalBattle_v1.1_De.lha" size 520901 crc B05B66E6 sha1 32078afa13c3e68d0ac6a1d83e8513c7abdd03f3 )
+	rom ( name "FinalBattle_v1.2_De.lha" size 530215 crc 7FDC2268 sha1 55fe9665ee6470dda691ddef65473806798e822a )
+)
+
+game (
+	name "Final Battle, The (France) (En,Fr)"
+	rom ( name "FinalBattle_v1.2_Fr.lha" size 530357 crc A250360B sha1 cea3089d4023dbcdca51999d6bcd4544ec20efd0 )
 )
 
 game (
 	name "Final Blow (Europe)"
-	rom ( name "FinalBlow_v1.0.lha" size 569502 crc 8D5D4BD8 sha1 3e42d0410c8a6d849aeb25b5d43f3c9eba4ab974 )
+	rom ( name "FinalBlow_v1.1_2457.lha" size 578418 crc 1F7882A6 sha1 da1068725fa07ec2b4234877d6b8cf01b2309093 )
+)
+
+game (
+	name "Final Command (Europe)"
+	rom ( name "FinalCommand_v1.0_1964.lha" size 521996 crc 027BB7AA sha1 17a889d38a63722a49ba9ca9ccf0c08c86564aaf )
+)
+
+game (
+	name "Final Command (France)"
+	rom ( name "FinalCommand_v1.0_Fr_2668.lha" size 520233 crc 7E270313 sha1 f6c71d64030cc32be188bf408baf8c21dc59eb52 )
 )
 
 game (
 	name "Final Countdown (Europe)"
-	rom ( name "FinalCountdown_v1.0.lha" size 639100 crc 8D720F5D sha1 46afa26b380e6dd89009eb5b58023f82f23f6344 )
+	rom ( name "FinalCountdown_v1.3_2691.lha" size 644579 crc D1455866 sha1 5aa250657d4c4dbab6cbce28c4359d149f962bcd )
+)
+
+game (
+	name "Final Countdown (Europe) (Fast)"
+	rom ( name "FinalCountdown_v1.3_Fast_2691.lha" size 645673 crc 98F38F03 sha1 76019a483bd1c3fd10bdb636c98e3d82545f0a37 )
 )
 
 game (
 	name "Final Fight (Europe)"
-	rom ( name "FinalFight_v1.6_1MB_1329.lha" size 1022540 crc 4787A729 sha1 e421fefc2942b865b0b5ca21ffa9bbfa61537eb6 )
+	rom ( name "FinalFight_v1.7_1329.lha" size 1019393 crc EE5ADF17 sha1 85eddd2513d7ed65bf7b48d2b2523b7b95206341 )
 )
 
 game (
-	name "Final Fight (512 KB) (Europe)"
-	rom ( name "FinalFight_v1.6_512k_1329.lha" size 1022576 crc 04B78362 sha1 6babed2a8d8d3c781aea771b72ff97bbc7c81254 )
+	name "Final Fight (Europe) (512 kB)"
+	rom ( name "FinalFight_v1.7_512k_1329.lha" size 1022781 crc 667C215D sha1 c782905b8a34f73d36bc4fd9187357dba10c8236 )
+)
+
+game (
+	name "Final Trip, The (Europe)"
+	rom ( name "FinalTrip_v1.0.lha" size 160111 crc 7D69CDA5 sha1 bf68762b5a11335268d6e2d088ae33acd3247f1f )
+)
+
+game (
+	name "Fire! (Europe)"
+	rom ( name "Fire!_v1.0.lha" size 402057 crc 047C9D1F sha1 7c5d9f8c5021006e735aae0a88a9805a158132e2 )
 )
 
 game (
 	name "Fire & Forget II - The Death Convoy (Europe)"
-	rom ( name "Fire&Forget2_v1.1_0482.lha" size 623368 crc CB0B057B sha1 1bd4f72818f37bfb6985b5278750cc1473bcfcc2 )
+	rom ( name "Fire&Forget2_v1.2_0482.lha" size 505846 crc BF7319A1 sha1 69835c28673ab3fe36ebdea3fef0a5440c9e4fcf )
 )
 
 game (
 	name "Fire and Forget (Europe)"
-	rom ( name "Fire&Forget_v1.0_0924.lha" size 377622 crc 7E5B492A sha1 0e8e7a9a8bfb2fc66e5befd2c23856b029efcebd )
+	rom ( name "Fire&Forget_v1.1_0924.lha" size 334658 crc 67BB4289 sha1 86c49afc66eb3f092231664ebb6b0738ebc78723 )
+)
+
+game (
+	name "Fire and Brimstone (Europe)"
+	rom ( name "FireAndBrimstone_v1.3_3012.lha" size 619007 crc 65233378 sha1 f552924370144d633cdcaea6d6180e8f7d010642 )
 )
 
 game (
 	name "Fire & Ice - The Daring Adventures of Cool Coyote (Europe)"
-	rom ( name "Fire&Ice_v2.2_0502.lha" size 962238 crc FA606F55 sha1 712a3077045118da24c0cea037894710b6785419 )
+	rom ( name "FireAndIce_v3.4_0502.lha" size 963864 crc 9E3F63DF sha1 15472584b6edf485d6c48ce355d5fd40f08658ed )
 )
 
 game (
 	name "Fire & Ice - The Daring Adventures of Cool Coyote (Europe) (CD32)"
-	rom ( name "Fire&Ice_v2.2_CD32.lha" size 1602496 crc 4F8D927A sha1 e3816eef019be858909056f610fb65053ff0ee9f )
+	rom ( name "FireAndIce_v3.4_CD32.lha" size 1604431 crc 4C228C5E sha1 92fbdf20811a16df53dbb52a9c980b7e1f57c814 )
 )
 
 game (
 	name "Fire & Ice - Christmas Special Edition (Europe) (Demo)"
 	rom ( name "Fire&IceXmasDemo_v1.0.lha" size 196770 crc 8B22A34B sha1 fa80126f937525b6902fed98f4773fac0835381b )
-)
-
-game (
-	name "Fire and Brimstone (Europe)"
-	rom ( name "FireAndBrimstone_v1.2_3012.lha" size 617776 crc DF1AD145 sha1 f87842417360aa137a63284c9887982b80a9bc51 )
 )
 
 game (
@@ -5482,22 +6283,22 @@ game (
 
 game (
 	name "Firestar (Europe)"
-	rom ( name "Firestar_v1.1.lha" size 201179 crc C094621B sha1 5480b44f98a74f335c738dda68836e946458b0c4 )
+	rom ( name "Firestar_v2.0_2978.lha" size 201829 crc AC6B8800 sha1 ccb4ed0859a638ddc74ef6cbc47fc5afb31cd609 )
 )
 
 game (
-	name "First Contact (Europe)"
+	name "First Contact (Europe) (En,Fr,De)"
 	rom ( name "FirstContact_v1.1_0923.lha" size 563172 crc 633C1802 sha1 b52116aa4fc19a84da120c5fa03a01f8b08a68b2 )
 )
 
 game (
 	name "First Samurai (Europe)"
-	rom ( name "FirstSamurai_v2.0_1182.lha" size 970261 crc FD784A5D sha1 f41f21fe44ba6a2d38bfb80821bc6c2b6715f79e )
+	rom ( name "FirstSamurai_v2.1_1182.lha" size 970450 crc B67394AF sha1 5ffad4302a6ba667d5670450ee4a3fdaaad82d00 )
 )
 
 game (
-	name "First Samurai (A1200 Version) (NON AGA) (Europe)"
-	rom ( name "FirstSamurai_v2.0_A1200Version_NONAGA.lha" size 888820 crc AE0CDA85 sha1 3ac5310e2939397a7588a219d163eadd830439a9 )
+	name "First Samurai (Europe) (A1200 Version)"
+	rom ( name "FirstSamurai_v2.1_A1200Version_NONAGA.lha" size 889009 crc F0860EF8 sha1 a1df2c2daf5320d2659c7a8326dae99d60597b2c )
 )
 
 game (
@@ -5516,73 +6317,78 @@ game (
 )
 
 game (
-	name "Werner Flaschbier (Europe)"
+	name "Flaschbier (Europe)"
 	rom ( name "Flaschbier_v1.0.lha" size 404663 crc A029C109 sha1 a775a418fdb8691c4e4c2de4dbfc429a55880006 )
 )
 
 game (
-	name "Werner Flaschbier (No Intro) (Europe)"
+	name "Flaschbier (Europe) (No Intro)"
 	rom ( name "Flaschbier_v1.0_NoIntro.lha" size 162293 crc 037BE889 sha1 b8be7359c02eb955b792692864d68a7e70041114 )
 )
 
 game (
 	name "Flashback (Europe)"
-	rom ( name "Flashback_v3.4_1163.lha" size 2267269 crc 252CB0B3 sha1 029529adc644afc20be501326dcd958824e20cdb )
+	rom ( name "Flashback_v3.5_1163.lha" size 2267377 crc 04F184BD sha1 6256389cce4f09b38b087cbe0bf460b8959689a7 )
 )
 
 game (
 	name "Flashback (Czech)"
-	rom ( name "Flashback_v3.4_Cz.lha" size 2264938 crc CA3C6A2A sha1 449bd838164cad3159f333944a26e15755b8942e )
+	rom ( name "Flashback_v3.5_Cz.lha" size 2265043 crc CB4C0305 sha1 8fa4ec8fc176da46f0e372019f050ad514ab9561 )
 )
 
 game (
 	name "Flashback (Germany)"
-	rom ( name "Flashback_v3.4_De_0064.lha" size 2268180 crc 04B5AC21 sha1 7012f76a9ed4d0b7316ed02c2b2f1b4c125503f4 )
+	rom ( name "Flashback_v3.5_De_0064.lha" size 2268289 crc 11F1A10F sha1 b75441d05f703b4d07191525326da508a14af9ac )
 )
 
 game (
 	name "Flashback (France)"
-	rom ( name "Flashback_v3.4_Fr_1736.lha" size 2264864 crc 8BF0B117 sha1 cb3d8eed7bda69c615e9fb068822e1a4172a50dc )
+	rom ( name "Flashback_v3.5_Fr_1736.lha" size 2264972 crc DDA48618 sha1 089b644774b9467aed41bbc709bf7a1c78ce2965 )
 )
 
 game (
 	name "Flashback (Italy)"
-	rom ( name "Flashback_v3.4_It.lha" size 2268402 crc 1CCC157A sha1 01c5919b8273eecefe7a20d909ad9c6eae1dd8cd )
+	rom ( name "Flashback_v3.5_It.lha" size 2268511 crc 4F1CCFE2 sha1 0d91241e86510fcb4cc557a3e9e9800366ee8770 )
 )
 
 game (
-	name "Flashback (Low Mem) (Europe)"
-	rom ( name "Flashback_v3.4_LowMem_1163.lha" size 2268199 crc 385DA121 sha1 581fdabc1587180d51ef558d3bd2e2e50cd1e109 )
+	name "Flashback (Europe) (Low Mem)"
+	rom ( name "Flashback_v3.5_LowMem_1163.lha" size 2268302 crc AAF5DEF2 sha1 15b5f52e2b9bf03d5d331f7d3968a61b92305cd3 )
 )
 
 game (
-	name "Flashback (Low Mem) (Czech)"
-	rom ( name "Flashback_v3.4_LowMem_Cz.lha" size 2265845 crc 7FAFE254 sha1 dfadd237ab7604f1e7353e01a140b40adc267e01 )
+	name "Flashback (Czech) (Low Mem)"
+	rom ( name "Flashback_v3.5_LowMem_Cz.lha" size 2265947 crc 7BE9CF94 sha1 f60df3f8abefecc99d384b29d6da96daf5f74f52 )
 )
 
 game (
-	name "Flashback (Low Mem) (Germany)"
-	rom ( name "Flashback_v3.4_LowMem_De_0064.lha" size 2269108 crc 86322B36 sha1 be8eb4e0f6939300aa17ea7bf43a1689757ce9a3 )
+	name "Flashback (Germany) (Low Mem)"
+	rom ( name "Flashback_v3.5_LowMem_De_0064.lha" size 2269208 crc 7D669599 sha1 a6aae1d666c3af0423c6c999a78074c0f0a138c1 )
 )
 
 game (
-	name "Flashback (Low Mem) (France)"
-	rom ( name "Flashback_v3.4_LowMem_Fr_1736.lha" size 2265790 crc 2116B599 sha1 37194ae02709ef82f48750ee99433eba48f77782 )
+	name "Flashback (France) (Low Mem)"
+	rom ( name "Flashback_v3.5_LowMem_Fr_1736.lha" size 2265891 crc D5509E65 sha1 cbfb6d4e4891a39c5e71a07bcafd33450cfc0c57 )
 )
 
 game (
-	name "Flashback (Low Mem) (Italy)"
-	rom ( name "Flashback_v3.4_LowMem_It.lha" size 2269330 crc 87439109 sha1 f964181d1361e07a69f2719d0e4d619bdcacf70c )
+	name "Flashback (Italy) (Low Mem)"
+	rom ( name "Flashback_v3.5_LowMem_It.lha" size 2269433 crc 7DA6E572 sha1 c73770d040545616ce877f7b1fdd4b9a00fbd11e )
 )
 
 game (
-	name "Flashback (Low Mem) (Poland)"
+	name "Flashback (Poland) (Low Mem)"
 	rom ( name "Flashback_v3.4_LowMem_Pl.lha" size 2266007 crc 328804E5 sha1 69756062ce2802543fb8c09f94bb51ba1d9a91bb )
 )
 
 game (
 	name "Flashback (Poland)"
-	rom ( name "Flashback_v3.4_Pl.lha" size 2265081 crc 41470094 sha1 b1b461f9c486caafafe5237c4b9c7636c4dbd666 )
+	rom ( name "Flashback_v3.5_LowMem_Pl.lha" size 2266110 crc 8EBBF093 sha1 104b9440dbe9bdadcf2cfa4eb77e61636a5f534f )
+)
+
+game (
+	name "Flies - Attack on Earth (Europe)"
+	rom ( name "FliesAttackOnEarth_v1.0.lha" size 2484967 crc 48AE9DBB sha1 bd9d528b7028b1c5b309869ead110383add833b4 )
 )
 
 game (
@@ -5592,7 +6398,7 @@ game (
 
 game (
 	name "Flight of the Amazon Queen (Europe)"
-	rom ( name "FlightOfTheAmazonQueen_v1.0_0971.lha" size 4382038 crc EB700DE9 sha1 a1a5f072593719f6a8d2bebc9bddf84bd5a52f6b )
+	rom ( name "FlightOfTheAmazonQueen_v1.1_0971.lha" size 4382458 crc B4D776E5 sha1 733cf069a2091e6aece564aea845cd99857109bb )
 )
 
 game (
@@ -5647,7 +6453,7 @@ game (
 
 game (
 	name "Flimbo's Quest (Europe)"
-	rom ( name "FlimbosQuest_v2.1a_0121.lha" size 826945 crc D7FDA0BA sha1 203c361a7e49e7f9b0e8a57af437bfba4c747636 )
+	rom ( name "FlimbosQuest_v2.3_0121.lha" size 836163 crc 80C5FFFB sha1 33e2e6bc494dc5352234a68040389b62e2674a90 )
 )
 
 game (
@@ -5681,18 +6487,18 @@ game (
 )
 
 game (
-	name "Escape from Colditz (Germany)"
-	rom ( name "FluchtAusColditz_v1.2_De.lha" size 457502 crc 9F18A495 sha1 d49e9f724a76bceb2c9775df920e1ffcbbf44717 )
+	name "Escape from Colditz (Germany) (Unl)"
+	rom ( name "FluchtAusColditz_v1.4a_De.lha" size 457950 crc A4EC1166 sha1 dab6d83ca77342c9193a46abfbfb81e1fcdba68b )
 )
 
 game (
-	name "Flight of the Amazon Queen (Germany)"
-	rom ( name "FlugDerAmazonQueen_v1.0_De.lha" size 4401447 crc EC72025C sha1 9f7b083e8d9e0f54c310f48ea8ff84276c160a06 )
+	name "Flight of the Amazon Queen (Germany) (Unl)"
+	rom ( name "FlugDerAmazonQueen_v1.1_De.lha" size 4401871 crc 700BDBA8 sha1 f50e5c995e421345165e19c7157a679ca7cb5f67 )
 )
 
 game (
 	name "Fly Fighter (Europe)"
-	rom ( name "FlyFighter_v1.2_1547.lha" size 429896 crc A77D7CDB sha1 da8d1391f2442da59a5d7b9ce36dd2d190ea4c3f )
+	rom ( name "FlyFighter_v1.3_1547.lha" size 430229 crc ED6DCADB sha1 e220a27b58f1a892afaea96983344e3806f71036 )
 )
 
 game (
@@ -5761,12 +6567,17 @@ game (
 )
 
 game (
+	name "Formula 1 3D (Europe)"
+	rom ( name "Formula13D_v1.0_2985.lha" size 696287 crc 60F2D6F2 sha1 0b2ed0a1e6d9fcead8b58f6bbbfcc65e931ff1ad )
+)
+
+game (
 	name "Formula 1 Grand Prix (Europe)"
 	rom ( name "Formula1GrandPrix_v1.0.lha" size 321555 crc AD7B7861 sha1 9f486b53f3f14230146993b5c1292680fec29b51 )
 )
 
 game (
-	name "MicroProse Formula One Grand Prix (3 Disk) (Europe)"
+	name "MicroProse Formula One Grand Prix (Europe) (3 Disk)"
 	rom ( name "FormulaOneGrandPrix_v1.0_3Disk.lha" size 1189760 crc 604AE4FC sha1 2c1e8b91d02317aa2d1ee735d24a28569ab5f055 )
 )
 
@@ -5776,8 +6587,13 @@ game (
 )
 
 game (
+	name "Fortress Underground (Europe)"
+	rom ( name "FortressUnderground_v1.0.lha" size 155086 crc 6A1A03D7 sha1 6ffa5ac77e61ffcc5856b3f6c9ebcd2f6f00acd7 )
+)
+
+game (
 	name "Foundation's Waste (Europe)"
-	rom ( name "FoundationsWaste_v1.1_2759.lha" size 340180 crc D6560C34 sha1 bb86f1a2466a5cfb2fc6726591e45c7b26672a70 )
+	rom ( name "FoundationsWaste_v1.2.lha" size 340669 crc 6A90AD16 sha1 28994f12c3a8b226a4e5d0a11ba34da5db03da73 )
 )
 
 game (
@@ -5787,7 +6603,7 @@ game (
 
 game (
 	name "Fraction Action (Europe)"
-	rom ( name "FractionAction_v1.0.lha" size 122692 crc A9B674BB sha1 b3bec8c922bb57503e29147e216f12400223a9bb )
+	rom ( name "FractionAction_v1.01.lha" size 122712 crc 93C1ECB5 sha1 dfad4cb0e1a49dfdfb8b0beb345a48d1d522f0a5 )
 )
 
 game (
@@ -5801,7 +6617,7 @@ game (
 )
 
 game (
-	name "Franko - The Crazy Revenge! (Censored) (Poland)"
+	name "Franko - The Crazy Revenge! (Poland) (Censored)"
 	rom ( name "Franko_v1.2_Censored_Pl.lha" size 2150363 crc 3F4B34CD sha1 ad6a3278760010aa86af18024c418db95ba8f3ff )
 )
 
@@ -5822,22 +6638,22 @@ game (
 
 game (
 	name "Freedom - Rebels in the Darkness (Europe)"
-	rom ( name "Freedom_v1.0.lha" size 499067 crc 21350ED4 sha1 5d6c2f6a4cd78675eef9d1474de278a4dfd62e02 )
+	rom ( name "Freedom_v1.1.lha" size 499323 crc 63890B27 sha1 4ed84bd50f3986fca4fd62030ca74e33ddfa5643 )
 )
 
 game (
 	name "Freedom - Die Krieger des Schattens (Germany)"
-	rom ( name "Freedom_v1.0_De.lha" size 500522 crc 244393D1 sha1 58151738516e82a1aba8ab78073802e3fe79ca5d )
+	rom ( name "Freedom_v1.1_De_0330.lha" size 457181 crc 0264D3CF sha1 9a38845560c69aa4bae67497eb9d9bd5f168e7e4 )
 )
 
 game (
 	name "Freedom - Los Guerreros de la Noche (Spain)"
-	rom ( name "Freedom_v1.0_Es.lha" size 499149 crc B2511AB2 sha1 8e8bafdc6e3702bb6be043ecd85cc17862818cff )
+	rom ( name "Freedom_v1.1_Es.lha" size 499403 crc 3D53D38F sha1 bf691e7147d41bcca5f9416a21e46f24f157b9e6 )
 )
 
 game (
 	name "Freedom - Les Guerriers de l'Ombre (France)"
-	rom ( name "Freedom_v1.0_Fr_2297.lha" size 464544 crc 6588CA41 sha1 4e4f929f7aadf47355bdb531eedf67ca75a89348 )
+	rom ( name "Freedom_v1.1_Fr_2297.lha" size 464791 crc 61AB485B sha1 a52fbaa952eefac28ddfb778a2b11953f466cea3 )
 )
 
 game (
@@ -5851,33 +6667,33 @@ game (
 )
 
 game (
-	name "Fright Night (512 KB) (Europe)"
+	name "Fright Night (Europe) (512 kB)"
 	rom ( name "FrightNight_v1.1_512k.lha" size 346375 crc A89C98AD sha1 4c891c92a591fc18083344676971e02f060122c3 )
 )
 
 game (
 	name "Frontier - Elite II (Europe)"
-	rom ( name "Frontier_v1.2_1960.lha" size 553052 crc 6F551960 sha1 d9f210e91d4ad03073650fab679ce935e34cd0f7 )
+	rom ( name "Frontier_v1.3_1960.lha" size 553562 crc 587F0F56 sha1 582d1dadeaefbd166c35d34bc8b7a7d04bc5ce1d )
 )
 
 game (
 	name "Frontier - Elite II (Europe) (CD32)"
-	rom ( name "Frontier_v1.2_CD32.lha" size 463691 crc 300D2F34 sha1 c15ae83e06489a5ffd740c2469f6cc3d2e37eb27 )
+	rom ( name "Frontier_v1.3_CD32.lha" size 464405 crc 91C6B752 sha1 b11213b7c681d2169550709e9de41ed19efef4be )
 )
 
 game (
 	name "Frontier - Elite II (Czech)"
-	rom ( name "Frontier_v1.2_Cz.lha" size 554434 crc B7D5C7A2 sha1 b3ea0adbcbe0ca898f1984207a6d2f54e5e4bd1f )
+	rom ( name "Frontier_v1.3_Cz.lha" size 554941 crc B68964B0 sha1 7458114ce4aebdc214295e1989bfbecd6714600f )
 )
 
 game (
 	name "Frontier - Elite II (Germany)"
-	rom ( name "Frontier_v1.2_De_0505.lha" size 554559 crc 6016833B sha1 c7bd946565362cdb299291cb35686d1c8ea0d193 )
+	rom ( name "Frontier_v1.3_De_0505.lha" size 555066 crc D9965E3A sha1 6dfab13a0febe116b3ba69dc2584b766929334e0 )
 )
 
 game (
 	name "Frontier - Elite II (France)"
-	rom ( name "Frontier_v1.2_Fr_2745.lha" size 554308 crc 90FC745E sha1 48b4728cfe168a66839436319912ccd4a106a244 )
+	rom ( name "Frontier_v1.3_Fr_2745.lha" size 554815 crc 6C26BE8C sha1 65f96febee598c3db5713d4a3b2e34ac7238ff6a )
 )
 
 game (
@@ -5887,27 +6703,32 @@ game (
 
 game (
 	name "Full Contact (Europe)"
-	rom ( name "FullContact_v1.6_2246.lha" size 1489105 crc 0FDD3761 sha1 33dc25c8128365ed6c04b0c587388810cde854d5 )
+	rom ( name "FullContact_v1.7_2246.lha" size 1493240 crc 79D81F6F sha1 5193b7eba44bf9e659b7fd193028110a6be4e910 )
+)
+
+game (
+	name "Full Contact (Europe) (Pre-release)"
+	rom ( name "FullContact_v1.7_PreRelease.lha" size 1517989 crc 15E92BD7 sha1 2c2171abd1dba324a2725519ea8b7804ebc0f5e4 )
 )
 
 game (
 	name "Full Metal Planete (Europe)"
-	rom ( name "FullMetalPlanete_v1.6_Files_0656.lha" size 550150 crc 8E0E5904 sha1 ba6315c1b5e3daa6c64cf2a779c02c4b0c06f326 )
+	rom ( name "FullMetalPlanete_v1.7_Files_0656.lha" size 551520 crc DB173E7A sha1 1912308f6b9f7158b198a9393817c45090a98ec8 )
 )
 
 game (
 	name "Full Metal Planete (USA)"
-	rom ( name "FullMetalPlanete_v1.6_Files_NTSC_1204.lha" size 565201 crc 71A3EEFE sha1 bf3399a010f933710ca2f034a86cfdd6cc9f2474 )
+	rom ( name "FullMetalPlanete_v1.7_Files_NTSC_1204.lha" size 563580 crc 4BC9730A sha1 2fbfe9bee8f4a0e42824008474f33f94b6f20f44 )
 )
 
 game (
-	name "Full Metal Planete (Image) (Europe)"
-	rom ( name "FullMetalPlanete_v1.6_Image_0656.lha" size 519962 crc 687CD2F8 sha1 ae83136c78cd37589bd591c719b5f8a730815724 )
+	name "Full Metal Planete (Europe) (Image)"
+	rom ( name "FullMetalPlanete_v1.7_Image_0656.lha" size 521338 crc A16F5828 sha1 e668aa20d6188baf3e4318302615ce608194293b )
 )
 
 game (
-	name "Full Metal Planete (Image) (USA)"
-	rom ( name "FullMetalPlanete_v1.6_Image_NTSC_1204.lha" size 531731 crc 6C3F260A sha1 3ff12ac0d46dfc7d0a99e33e0daf80f1af3572f9 )
+	name "Full Metal Planete (USA) (Image)"
+	rom ( name "FullMetalPlanete_v1.7_Image_NTSC_1204.lha" size 530114 crc 82834B83 sha1 bcfe3df1bb26fd97eb4bd2eb5224d1ed22b6673e )
 )
 
 game (
@@ -5916,18 +6737,18 @@ game (
 )
 
 game (
-	name "Fury of the Furries (Europe)"
+	name "Fury of the Furries (Europe) (En,Fr,De,Es,It)"
 	rom ( name "FuryOfTheFurries_v1.0_1347.lha" size 2549181 crc D8662D5E sha1 246036337c6e6ecb3353b4c7daf832b2b1e52fb3 )
 )
 
 game (
-	name "Fury of the Furries (Europe) (CD32)"
+	name "Fury of the Furries (Europe) (En,Fr,De,Es,It) (CD32)"
 	rom ( name "FuryOfTheFurries_v1.0_CD32.lha" size 3328851 crc 2FD377F1 sha1 3d24cf68c89b60e2a4e114a2b60acd16a729db75 )
 )
 
 game (
 	name "Fusion (Europe)"
-	rom ( name "Fusion_v1.0_0331.lha" size 217067 crc C659D289 sha1 5efdd00bccf96e0adb629d9ac0c74b3dcf8951c4 )
+	rom ( name "Fusion_v1.2_0331.lha" size 217958 crc 4818F557 sha1 ba99a12decafbee7753d631fbbe74a35590aeab8 )
 )
 
 game (
@@ -5953,6 +6774,11 @@ game (
 game (
 	name "Future Shock (Europe)"
 	rom ( name "FutureShock_v1.1.lha" size 793001 crc 9AE57BEB sha1 2a9bbaae279f3606a0c2c8a362f04546404b31d3 )
+)
+
+game (
+	name "Future Sport (Europe)"
+	rom ( name "FutureSport_v1.0.lha" size 298470 crc 545EE4F7 sha1 ba6baf471398671865a6b1a84ddb4ac5ece3d157 )
 )
 
 game (
@@ -5991,7 +6817,7 @@ game (
 )
 
 game (
-	name "Fuzzball (No Intro) (Europe)"
+	name "Fuzzball (Europe) (No Intro)"
 	rom ( name "Fuzzball_v1.0_NoIntro_1940.lha" size 342610 crc 28B0AABA sha1 59b8affceffe7f2427d85001eb1312622a0b44ad )
 )
 
@@ -6011,7 +6837,7 @@ game (
 )
 
 game (
-	name "Galactic Empire (Europe)"
+	name "Galactic Empire (Europe) (En,Fr,De,Es,It)"
 	rom ( name "GalacticEmpire_v1.0_2012.lha" size 633470 crc 3FDBD7FE sha1 c099bc58c98fa79408107beebe9a360c9cb6fa69 )
 )
 
@@ -6021,13 +6847,13 @@ game (
 )
 
 game (
-	name "Galactic - The Xmas Edition (2 MB) (Europe)"
+	name "Galactic - The Xmas Edition (Europe) (2 MB)"
 	rom ( name "GalacticTheXmasEdition_v1.0_2MB.lha" size 205408 crc F4CF0096 sha1 5432425ab417b32b8b0374d8dfc9f4939d0b0049 )
 )
 
 game (
 	name "Galactic Warrior Rats (Europe)"
-	rom ( name "GalacticWarriorRats_v1.2_1942.lha" size 479251 crc 5C4E64A4 sha1 c587fc252d3d6eca9f8c2f99dcf7c7970ee3f222 )
+	rom ( name "GalacticWarriorRats_v1.2a_1942.lha" size 479459 crc FCD7B406 sha1 df5e626adb7c6f04d903323e04f774d25bfebc60 )
 )
 
 game (
@@ -6047,7 +6873,7 @@ game (
 
 game (
 	name "Galaxy Force II (Europe)"
-	rom ( name "GalaxyForce2_v1.2_0485.lha" size 449139 crc 368BEDFF sha1 36ddc3b9a66c476b8c1c12fc1812a999f356e72f )
+	rom ( name "GalaxyForce2_v1.4_0485.lha" size 450633 crc FBCF5A96 sha1 bc7f61413325456eb1a76ad2f33557ce44a77e59 )
 )
 
 game (
@@ -6082,7 +6908,7 @@ game (
 
 game (
 	name "Garfield - Big, Fat, Hairy Deal (Europe)"
-	rom ( name "GarfieldBigFatHairyDeal_v1.0_0933.lha" size 178118 crc 3F076AB4 sha1 22e33b7d970eb6066e6b1116f04df723b6897a29 )
+	rom ( name "GarfieldBigFatHairyDeal_v1.1_0933.lha" size 178851 crc 90C166E9 sha1 d91c523b6cedebe7b1fe150f3fc742a157889acc )
 )
 
 game (
@@ -6107,7 +6933,7 @@ game (
 
 game (
 	name "Gauntlet II (Europe)"
-	rom ( name "Gauntlet2_v1.2.lha" size 521779 crc DE86DBC2 sha1 607e133cb571b48811d31a9d27ecdf23742f8de4 )
+	rom ( name "Gauntlet2_v2.0_0182.lha" size 527617 crc F694467D sha1 25b3db718ba40da18071450c142f70dba35d8004 )
 )
 
 game (
@@ -6116,7 +6942,7 @@ game (
 )
 
 game (
-	name "Gazza II (Europe)"
+	name "Gazza II (Europe) (En,Fr,De,It)"
 	rom ( name "Gazza2_v1.0.lha" size 206086 crc BF0FE496 sha1 f51dd06d04e8a09a2f21f91ed76412241d75bcc0 )
 )
 
@@ -6126,8 +6952,8 @@ game (
 )
 
 game (
-	name "Gear Works (Europe)"
-	rom ( name "GearWorks_v1.0.lha" size 495516 crc 777AC637 sha1 6ee196629b934e5b6d0a9103f402d05dd3090bd1 )
+	name "Gear Works (USA)"
+	rom ( name "GearWorks_v1.0_NTSC_1028.lha" size 496116 crc 78E52E00 sha1 e0afc6403047a69d1a0f82c96c6302ac99e7a79b )
 )
 
 game (
@@ -6137,37 +6963,37 @@ game (
 
 game (
 	name "Geisha (Europe)"
-	rom ( name "Geisha_v1.3.lha" size 651758 crc 1757D74D sha1 aa0066a5c31dab9b6a0dd603b02ed352d1bc2d18 )
+	rom ( name "Geisha_v1.4.lha" size 655226 crc 3F57DA36 sha1 94fc180259fc8c759f5eae9ef9e2e5da8a1f70ea )
 )
 
 game (
 	name "Geisha (Germany)"
-	rom ( name "Geisha_v1.3_De.lha" size 655837 crc 0BED9177 sha1 3dc97d1b8bd51e8896f2ff9931aaa7c737427e60 )
+	rom ( name "Geisha_v1.4_De.lha" size 659313 crc 202A4845 sha1 c7b5b67e7536f235396566bcb764cdc8859f244f )
 )
 
 game (
 	name "Geisha (Spain)"
-	rom ( name "Geisha_v1.3_Es.lha" size 647804 crc 5E755922 sha1 a2d8b46ead9e79004a30c69313c5ce056d42643d )
+	rom ( name "Geisha_v1.4_Es.lha" size 651275 crc B673C0A3 sha1 0d29198820a58e915c6510bfbfa340cc57abdf7c )
 )
 
 game (
 	name "Geisha (France)"
-	rom ( name "Geisha_v1.3_Fr.lha" size 645136 crc 6EB07F8D sha1 5d9d1b5cefe5646df225ad00e86d9aea8ce9227d )
+	rom ( name "Geisha_v1.4_Fr.lha" size 648612 crc 170DA4F4 sha1 7dc73fae4fa4cd2f86d40e0db8e8e54a6fc24af4 )
 )
 
 game (
 	name "Gemini Wing (Europe)"
-	rom ( name "GeminiWing_v1.0_0486.lha" size 369438 crc 4BB76081 sha1 b01fdbb1c80925553cd3335992cad2456065e2c9 )
+	rom ( name "GeminiWing_v1.1_0486.lha" size 365251 crc BD4027AB sha1 5101804f016233a6fce0b46da21785bcfef835a4 )
 )
 
 game (
 	name "Gem Stone Legend (Europe)"
-	rom ( name "GemStoneLegend_v1.0.lha" size 912049 crc BB07AC38 sha1 9d25f34c66c7fc919293a859229aa33e216d8a5a )
+	rom ( name "GemStoneLegend_v1.1.lha" size 912109 crc 56513C21 sha1 9b7ec12223054980718a1e36ae7bb00fa6577e9c )
 )
 
 game (
 	name "Gem'X (Europe)"
-	rom ( name "GemX_v1.5a_1181.lha" size 483386 crc 5DFF16ED sha1 5315c7f9ebaee8369f570ad4efd01e7840d0f87c )
+	rom ( name "GemX_v1.6_1181.lha" size 483418 crc A285AA39 sha1 c27863eaa79834e8fd9c57d75e7c7cdd2af60073 )
 )
 
 game (
@@ -6181,13 +7007,18 @@ game (
 )
 
 game (
+	name "Germ Crazy (Germany)"
+	rom ( name "GermCrazy_v1.0_De_0507.lha" size 481907 crc A82086BA sha1 d782bc160c8f4d1952088decb11121e2652bf1cd )
+)
+
+game (
 	name "Gettysburg (Europe)"
-	rom ( name "Gettysburg_v1.0_1937.lha" size 147055 crc 29AC9B70 sha1 152ff5ac2708beffa5ae41084ab1a5850a91398a )
+	rom ( name "Gettysburg_v1.01_1937.lha" size 147795 crc 3FE43AF4 sha1 175a29461c7caf4a6f3c5876417cd9f02f6fe525 )
 )
 
 game (
 	name "Ghost Battle (Europe)"
-	rom ( name "GhostBattle_v1.2.lha" size 968756 crc 0ACB21A5 sha1 2300ad290111e9d59c6b6476530e58b26ba0f645 )
+	rom ( name "GhostBattle_v1.5.lha" size 977901 crc B25B1173 sha1 248f61089b81813fa56faec10a14f6f42c88bafe )
 )
 
 game (
@@ -6207,12 +7038,17 @@ game (
 
 game (
 	name "Ghosts'n Goblins (Europe)"
-	rom ( name "GhostsNGoblins_v1.2.lha" size 580427 crc 0EC00DAE sha1 919b912852eb27c41319a8a40b5f1ec8965c0af4 )
+	rom ( name "GhostsNGoblins_v1.4.lha" size 583118 crc B325C25D sha1 3478f4f694b7445900bc983a5d9693e1e685178e )
+)
+
+game (
+	name "Ghouls 'n' Ghosts (Europe) (Budget - Kixx)"
+	rom ( name "GhoulsNGhosts_v1.3_1Disk_1985.lha" size 638318 crc 415FC08B sha1 17ecb7360ad8da2e319b2c52d34990e196a3e902 )
 )
 
 game (
 	name "Ghouls 'n' Ghosts (Europe)"
-	rom ( name "GhoulsNGhosts_v1.0_2252.lha" size 591131 crc D80635D4 sha1 db295821b578d5a2c9dcaf28a52b42ce15ca22fe )
+	rom ( name "GhoulsNGhosts_v1.3_2Disk_2252.lha" size 599261 crc 6B07A302 sha1 27b1aeb4649b9ba5b7a27942be10724742a24cd1 )
 )
 
 game (
@@ -6226,33 +7062,43 @@ game (
 )
 
 game (
+	name "Gilbert - Escape From Drill (Europe)"
+	rom ( name "GilbertEscapeFromDrill_v1.0_2969.lha" size 320839 crc 34BA6D73 sha1 9cd285cc4f9cd0d2407e8698fb01eb45dfaf2646 )
+)
+
+game (
 	name "Gladiators (Europe)"
 	rom ( name "Gladiators_v1.0.lha" size 452389 crc 2A96A9CD sha1 b81a37ca541b253238b87c176c95e14496878745 )
 )
 
 game (
 	name "Global Gladiators (Europe)"
-	rom ( name "GlobalGladiators_v1.4_0657.lha" size 960144 crc 61399ABA sha1 e480e4d38ae8e7938ffbf0afd120aa82af7630b8 )
+	rom ( name "GlobalGladiators_v1.5_0657.lha" size 961581 crc 6AFB1C5E sha1 c96b7a0a09e0051453b0a01e267c8bd39e4abbd4 )
 )
 
 game (
 	name "Global Trek (Europe)"
-	rom ( name "GlobalTrek_v1.0.lha" size 80098 crc 18194B00 sha1 1154d27156484862434e5f5c00353a3a0b1aa7ef )
+	rom ( name "GlobalTrek_v1.1.lha" size 80085 crc 37D3BD4E sha1 bbd2d0e9f78dce6c7aea5d9666c65eca717ed458 )
 )
 
 game (
 	name "Globdule (Europe)"
-	rom ( name "Globdule_v1.1b_0183.lha" size 1547188 crc 157B157D sha1 317d4f9eaee2713af1f5e3e12c26d963055bab72 )
+	rom ( name "Globdule_v2.2_0183.lha" size 1548596 crc 95931785 sha1 9882412294556e18180023723a2031c4ebed6214 )
 )
 
 game (
 	name "Globdule (USA)"
-	rom ( name "Globdule_v1.1b_NTSC.lha" size 1545656 crc A8F2403A sha1 8c778a06e43a9b6ad1a676083085f2132cdb61fb )
+	rom ( name "Globdule_v2.2_NTSC.lha" size 1547068 crc E4D46BDC sha1 433defbe779fc4b57c28adcb27d5bef9736e641e )
 )
 
 game (
 	name "Globulus (Europe)"
-	rom ( name "Globulus_v1.1.lha" size 202772 crc 57A197D4 sha1 d561eacf7f01d723ba6dc31c4e1215d1d3c9aeba )
+	rom ( name "Globulus_v2.1a.lha" size 213850 crc 27BD9C06 sha1 14034713b090dc9dc5136ca7ba3f440e885b1c99 )
+)
+
+game (
+	name "Globulus (Europe) (Pre-release)"
+	rom ( name "Globulus_v2.1a_PreRelease.lha" size 217289 crc B15F128A sha1 413b33261c99082ba05346b67884acf06b90145e )
 )
 
 game (
@@ -6261,18 +7107,28 @@ game (
 )
 
 game (
+	name "Gloom (Europe)"
+	rom ( name "Gloom_v1.4_1330.lha" size 1165114 crc B638AE29 sha1 f43612ebb9ac75c90851c130921953f2b6cb1542 )
+)
+
+game (
 	name "Gloom (Europe) (AGA)"
-	rom ( name "Gloom_v1.2_AGA_0124.lha" size 1210065 crc 1C8401D5 sha1 328d26023b5186f90b64156b9d60d56a80e4e31a )
+	rom ( name "Gloom_v1.4_AGA_0124.lha" size 1210596 crc 5BFF5EDA sha1 20d8f71c882860a4bc5151de436391cda6e2258d )
 )
 
 game (
 	name "Gloom (Europe) (CD32)"
-	rom ( name "Gloom_v1.2_CD32.lha" size 1210144 crc A5F17BE8 sha1 d2c882521a7dc53bba05f2fe3f03d69e264a79a3 )
+	rom ( name "Gloom_v1.4_CD32.lha" size 1210749 crc B8C83D82 sha1 ceea224acfd881d5c338a7729bad38f583e1ccac )
 )
 
 game (
 	name "Gloom (Europe) (AGA) (Demo)"
 	rom ( name "GloomDemo_v1.1_AGA.lha" size 449474 crc ACB51342 sha1 8270317dfe0820d286990b89ba68dac96588bdfb )
+)
+
+game (
+	name "Glubble (Europe)"
+	rom ( name "Glubble_v1.0.lha" size 564348 crc E7AAA37C sha1 34baaf59d975f304912a773a7f02661ea649e681 )
 )
 
 game (
@@ -6296,58 +7152,58 @@ game (
 )
 
 game (
-	name "Goal! (Europe)"
+	name "Goal! (Europe) (En,Fr,De,Es,It,No)"
 	rom ( name "Goal_v1.01_1817.lha" size 969208 crc B338A3E9 sha1 9d12813e486a4d749c74eeb50e57234d2f24c4e4 )
 )
 
 game (
-	name "Gobliiins (Europe)"
-	rom ( name "Gobliiins_v1.3_0065.lha" size 1405902 crc ECFAE6B3 sha1 dbc941dc98fac908f3080277e043a9fe8922bc6f )
+	name "Gobliiins (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Gobliiins_v1.4_0065.lha" size 1406141 crc A78B3976 sha1 5ae3f33dcee3b49319d8889ab64c66a335251653 )
 )
 
 game (
 	name "Gobliins 2 - The Prince Buffoon (Europe)"
-	rom ( name "Gobliins2_v1.4_0185.lha" size 1950203 crc 89F5E4D6 sha1 009bba68241f2c29f02781c3e425e792b9c97e5c )
+	rom ( name "Gobliins2_v2.0_0185.lha" size 1950588 crc 03A5E5A6 sha1 8ae11a5b342b34a3c8f5bd02e287eb2e0e66120d )
 )
 
 game (
 	name "Gobliins 2 - The Prince Buffoon (Germany)"
-	rom ( name "Gobliins2_v1.4_De_0332.lha" size 1953927 crc E2928772 sha1 b87abe89875dda671a9fd9439f26fe37c00a857b )
+	rom ( name "Gobliins2_v2.0_De_0332.lha" size 1954308 crc DB69E947 sha1 c7c8717f30019e1b8187cf8b1a79c48866307159 )
 )
 
 game (
 	name "Gobliins 2 - The Prince Buffoon (Spain)"
-	rom ( name "Gobliins2_v1.4_Es.lha" size 1952210 crc A63F4108 sha1 e8ab21d8e7415f369210b3b717c7e93240014ad4 )
+	rom ( name "Gobliins2_v2.0_Es.lha" size 1952596 crc E50DD891 sha1 3099aea5acd4000ea2f76bb0eb4eea107bce0d67 )
 )
 
 game (
 	name "Gobliins 2 - The Prince Buffoon (France)"
-	rom ( name "Gobliins2_v1.4_Fr_2866.lha" size 1949926 crc 1DB4FD40 sha1 4b6c3e1ae2837334eb966fd58b640eb942ed53ee )
+	rom ( name "Gobliins2_v2.0_Fr_2866.lha" size 1950301 crc 7DF75840 sha1 b1bca21ceab56c2a526e2ace4cb6ac2d7c5b0596 )
 )
 
 game (
 	name "Gobliins 2 - The Prince Buffoon (Italy)"
-	rom ( name "Gobliins2_v1.4_It.lha" size 1950888 crc 64D81539 sha1 cf9bb8a7602149a6d21ee3ced678286a163750e4 )
+	rom ( name "Gobliins2_v2.0_It.lha" size 1951272 crc 6A15E1EE sha1 c682c933fc1d9e3bbcd5066d6adad8c45a80a863 )
 )
 
 game (
 	name "Goblins 3 (Europe)"
-	rom ( name "Goblins3_v2.3.lha" size 3312232 crc 55B255FF sha1 b15d7a5417813f75cc80c93bb29e9e95ec794994 )
+	rom ( name "Goblins3_v3.1.lha" size 3313552 crc 5C3282C1 sha1 92314028bcedf53a16f0fb54dea39f5edeeaa107 )
 )
 
 game (
 	name "Godfather, The (Europe)"
-	rom ( name "Godfather_v1.1a_1331.lha" size 2978509 crc B6F82261 sha1 7ddbd6ae7e21e0c57b86e6d4bd5c051d1d1379dc )
+	rom ( name "Godfather_v2.0_1331.lha" size 2979072 crc 7F51FD30 sha1 92545ee207fe2bb43b56156bb68d8a128ea7f3d9 )
 )
 
 game (
 	name "Gods (Europe)"
-	rom ( name "Gods_v2.3.1_0666.lha" size 1235525 crc 7C89535F sha1 8eaa3aa257417c2b8dd4b56b65ed63d5cdf19c76 )
+	rom ( name "Gods_v3.2_0666.lha" size 1237230 crc 3B3899E6 sha1 52f4f425355195656e49e8d15d1a8bbfde09f758 )
 )
 
 game (
 	name "Gods (USA)"
-	rom ( name "Gods_v2.3.1_NTSC.lha" size 1183540 crc E9447A72 sha1 96b04ebd37e4b1850ee4f6d57b19394e47164a1b )
+	rom ( name "Gods_v3.2_NTSC.lha" size 1185247 crc DE2B3E0B sha1 2c7a1769c4c5602436a9f325a7ebdebbe301ee92 )
 )
 
 game (
@@ -6357,17 +7213,22 @@ game (
 
 game (
 	name "Golden Axe (Europe)"
-	rom ( name "GoldenAxe_v1.5_0017.lha" size 591927 crc BA562776 sha1 40e32a07111f8ebd9c6a62c85c4a169c1dcae824 )
+	rom ( name "GoldenAxe_v1.7_0017.lha" size 592632 crc 76328DBB sha1 d4e094f1d7fa0a856394b6149ef961e5d3fc01c4 )
 )
 
 game (
 	name "Golden Axe (USA)"
-	rom ( name "GoldenAxe_v1.5_NTSC.lha" size 594189 crc D5D846A9 sha1 4c28ee1e987e7ab13638aa580eff7a8420186d59 )
+	rom ( name "GoldenAxe_v1.7_NTSC.lha" size 594728 crc 719FF80B sha1 687ac82eeafd64e5ea23a078a7361cfe44c4e2bf )
 )
 
 game (
 	name "Golden Eagle (Europe)"
-	rom ( name "GoldenEagle_v1.1.lha" size 1571452 crc 427CA73B sha1 50535991a06c26efdaba4424eada5554d94edf2c )
+	rom ( name "GoldenEagle_v1.2.lha" size 1548876 crc 2A4F5E23 sha1 a85b0621fe3714f2702df1598bdfc25ec59d233f )
+)
+
+game (
+	name "Golden Eagle (Europe) (512 kB)"
+	rom ( name "GoldenEagle_v1.2_512k.lha" size 1549426 crc 9AFFC2DA sha1 16c55bd6356d0d789a33b476a0e34e2cb02850a7 )
 )
 
 game (
@@ -6381,7 +7242,7 @@ game (
 )
 
 game (
-	name "Gold of the Aztecs, The (Kernal Version 1.1) (Europe)"
+	name "Gold of the Aztecs, The (Europe) (Kernal Version 1.1)"
 	rom ( name "GoldOfTheAztecs_v1.1_Kernal_Version_1.1.lha" size 1456337 crc DBDDF2AF sha1 8b407e0228296acc2d9e0a7d423715db02f555fa )
 )
 
@@ -6406,8 +7267,18 @@ game (
 )
 
 game (
-	name "Goofy's Railway Express (Europe)"
+	name "Goofy's Railway Express (Europe) (En,Fr,De,Es,It)"
 	rom ( name "GoofysRailwayExpress_v1.0_2473.lha" size 260812 crc 6895B0BF sha1 3b56b4482399abc49702b5e3e8a3f1ecdb3e16f6 )
+)
+
+game (
+	name "Gordian Tomb (Europe)"
+	rom ( name "GordianTomb_v1.0.lha" size 216890 crc 16A3B30F sha1 e6a093400b6420f535f0ae4163218e932e5d3e5b )
+)
+
+game (
+	name "Gotcha (Europe)"
+	rom ( name "Gotcha_v1.0_Prestige.lha" size 423829 crc C117E150 sha1 00c67dbc3e433eadc7d29d7cd1f9d27d262db48c )
 )
 
 game (
@@ -6421,13 +7292,18 @@ game (
 )
 
 game (
+	name "Graffiti Man (Europe)"
+	rom ( name "GraffitiMan_v1.0_2168.lha" size 393405 crc 51D968F8 sha1 24ce98c6de4b99027c970c6cbe41b0c1a380737a )
+)
+
+game (
 	name "Graham Gooch's Second Innings (Europe)"
 	rom ( name "GrahamGoochSecondInnings_v1.0.lha" size 579975 crc E33DCD01 sha1 d39057fd95d283b78b272dde452a117ea5f33dc6 )
 )
 
 game (
 	name "Graham Gooch World Class Cricket (Europe)"
-	rom ( name "GrahamGoochWorldClassCricket_v1.0.lha" size 553026 crc 737BADAC sha1 d658755bc4a13da434c8f1c1b204d71692304ebc )
+	rom ( name "GrahamGoochWorldClassCricket_v1.1.lha" size 553800 crc CCD36171 sha1 fc640b44a0572d9722c918faa8afe6770ea633eb )
 )
 
 game (
@@ -6436,13 +7312,23 @@ game (
 )
 
 game (
-	name "Graham Taylor's Soccer Challenge (Europe)"
+	name "Graham Taylor's Soccer Challenge (Europe) (En,Fr,De,Es,It)"
 	rom ( name "GrahamTaylorsSoccerChallenge_v1.0_0125.lha" size 828179 crc 43C96A24 sha1 7d4cb60d826456f19ba50d52475a0894a418a883 )
 )
 
 game (
+	name "Grand Monster Slam (Europe) (1 Disk)"
+	rom ( name "GrandMonsterSlam_v2.1_1Disk_1688.lha" size 673095 crc DD05A7A6 sha1 c220ae2b2d61d59c3c66e293b830ef716d1b318f )
+)
+
+game (
 	name "Grand Monster Slam (Europe)"
-	rom ( name "GrandMonsterSlam_v1.3.lha" size 665365 crc 904DDED3 sha1 74b01858810b8379c24fee5b7c36771fd7a2ada9 )
+	rom ( name "GrandMonsterSlam_v2.1_2Disk_1917.lha" size 733043 crc 8A5562D6 sha1 792c4a1696e7d804940b91c16c17a05e2e429ee2 )
+)
+
+game (
+	name "Grand National (Europe)"
+	rom ( name "GrandNational_v1.0_2361.lha" size 791173 crc 0D127C7C sha1 8217051ab2049365f931ec6c00345455cc7ad285 )
 )
 
 game (
@@ -6481,7 +7367,7 @@ game (
 )
 
 game (
-	name "Great Courts 2 (512 KB) (Europe)"
+	name "Great Courts 2 (Europe) (512 kB)"
 	rom ( name "GreatCourts2_v1.5_512KB_0333.lha" size 646669 crc 74946113 sha1 32a19a326d8c3143075b2c1ce2e1ff67097eaa46 )
 )
 
@@ -6496,6 +7382,11 @@ game (
 )
 
 game (
+	name "Green Beret (Europe) (PD/Freeware)"
+	rom ( name "GreenBeret_v1.0.lha" size 358268 crc 6A4C6F21 sha1 7ed81c28dd748b883067f1e30875a6f9f990a20f )
+)
+
+game (
 	name "Gremlins 2 - The New Batch (Europe)"
 	rom ( name "Gremlins2_v1.2_0489.lha" size 394441 crc 59E2B0A0 sha1 f53c1ba74c1109a4972249f8b57938a6c9ecf7e3 )
 )
@@ -6507,17 +7398,26 @@ game (
 
 game (
 	name "Grid Start (Europe)"
-	rom ( name "GridStart_v1.0.lha" size 377338 crc 6A03F473 sha1 036289a67370c05c9c2511ab1ad9af1a8210bde1 )
+	rom ( name "GridStart_v1.1_1470.lha" size 380685 crc 8DC5C2D9 sha1 5190c339b085c3dd6627e315c61d5d7c4e1b8f1b )
+)
+game (
+	name "Grid Start (Europe) (Alt)"
+	rom ( name "GridStart_v1.1_AltVersion.lha" size 380765 crc B9046FD8 sha1 9cc3dbfe2b3d63d216ea495abb7c822d718e01ad )
+)
+
+game (
+	name "Grimblood (Europe)"
+	rom ( name "Grimblood_v1.0_2088.lha" size 338534 crc D3ECB97F sha1 3cca2d903a8e9dd87d9b60ee61056431d94e011d )
 )
 
 game (
 	name "Guardian (Europe) (AGA)"
-	rom ( name "Guardian_v1.0_AGA_0835.lha" size 1221066 crc 4684304D sha1 eeac4eb6d5a78cd2cc5f324d8367ef62dd96d5ff )
+	rom ( name "Guardian_v2.0_AGA_0835.lha" size 1224126 crc 2555DCC5 sha1 4e6c079d724f62bbf8a0a50e3242f1f491141884 )
 )
 
 game (
 	name "Guardian (Europe) (CD32)"
-	rom ( name "Guardian_v1.0_CD32.lha" size 975362 crc 3B924583 sha1 3767ae1c491a5cc7a5e2927b84c87ca3eadb5fe0 )
+	rom ( name "Guardian_v2.0_CD32.lha" size 960860 crc 86A2CEAB sha1 edaef771b6421bb2847f43988da6e7d8e5dcf0c5 )
 )
 
 game (
@@ -6536,8 +7436,18 @@ game (
 )
 
 game (
-	name "Guldkorn Expressen (512 KB) (Denmark)"
+	name "Guldkorn Expressen (Denmark) (512 kB)"
 	rom ( name "GuldkornExpressen_v1.1_Dk_512KB.lha" size 775305 crc CFD59BD3 sha1 90bbdb1af9597aafe7853d2257f15e825260abf2 )
+)
+
+game (
+	name "Gulp! (Europe) (En,Fr,De,Es,It) (CD32)"
+	rom ( name "Gulp_v1.0_CD32.lha" size 2103433 crc 23BFA2CF sha1 13302044c264e0072b5b01d543eb6ffd2cc2909e )
+)
+
+game (
+	name "Gulp! (Europe) (En,Fr,De,Es,It)"
+	rom ( name "Gulp_v1.1-C_2632.lha" size 2108549 crc 81F910B2 sha1 60556e8ea18947e95f8f226974b1cebcc69b8179 )
 )
 
 game (
@@ -6562,12 +7472,12 @@ game (
 
 game (
 	name "Gunship (Europe)"
-	rom ( name "Gunship_v1.1_0658.lha" size 451828 crc A0A66E3F sha1 12166f27aaf543dd00f8bcc8704d920f8fe785e9 )
+	rom ( name "Gunship_v1.2_0658.lha" size 452261 crc 5F1F2D56 sha1 d6f5da74f36b72e4cdccdbdafc0dc46954c28f86 )
 )
 
 game (
 	name "Gunship (USA)"
-	rom ( name "Gunship_v1.1_NTSC_1489.lha" size 456881 crc C9A7DD22 sha1 f2d69d935685f30197a2a0737c3b7e5bf8d0398e )
+	rom ( name "Gunship_v1.2_NTSC_1489.lha" size 457314 crc F3A4D087 sha1 9679a27b1b59446b8bea98760592e590d2c848ca )
 )
 
 game (
@@ -6601,7 +7511,7 @@ game (
 )
 
 game (
-	name "Hagar (Germany)"
+	name "Hagar the Horrible (Germany)"
 	rom ( name "HagarTheHorrible_v1.0_De.lha" size 1113327 crc C8D0D492 sha1 4a4b621b0da8d7b1a8b4d0a9bd5b533ca5807c23 )
 )
 
@@ -6612,12 +7522,12 @@ game (
 
 game (
 	name "Hammer Boy (Europe)"
-	rom ( name "HammerBoy_v1.1_1349.lha" size 589136 crc A8D974B6 sha1 ff89a25c7dd5911f573e65868b7d798046172e46 )
+	rom ( name "HammerBoy_v1.3_1349.lha" size 589144 crc B07D3B98 sha1 45bff5ca1b4bd6088dc8c7d3a23e6be5f6fe3f3e )
 )
 
 game (
 	name "Hammerfist (Europe)"
-	rom ( name "Hammerfist_v1.2_1358.lha" size 389570 crc 284DCDCA sha1 7b7cd75520eb1a092912a6fa23281b3643c1d57f )
+	rom ( name "Hammerfist_v1.3_1358.lha" size 389433 crc 8B3CE5B3 sha1 c833c96d761942b5445cd81118705bb8cce1d7b7 )
 )
 
 game (
@@ -6647,12 +7557,22 @@ game (
 
 game (
 	name "Hard Drivin' (Europe)"
-	rom ( name "HardDrivin_v2.04_0126.lha" size 279890 crc A56FF074 sha1 66fd14f65e5ec56c977191f3db3dd1d4a1f81ad7 )
+	rom ( name "HardDrivin_v3.0_0126.lha" size 281271 crc 34194C38 sha1 a65241c88ce519be890532b4d94a7c8dec4bbba4 )
 )
 
 game (
 	name "Hard 'n' Heavy (Europe)"
-	rom ( name "HardNHeavy_v1.02_1631.lha" size 315168 crc 824C01D2 sha1 7597b5d77393e38832fccc5213d41d92217bc5dd )
+	rom ( name "HardNHeavy_v1.03_1631.lha" size 315307 crc 0446484C sha1 38db289650628983a6e7fdf00e64d20fd5ac80d8 )
+)
+
+game (
+	name "Hare Raising Havoc (Europe)"
+	rom ( name "HareRaisingHavoc_v1.0.lha" size 3366194 crc 091E9128 sha1 88ded451cf2cafc398badc0fcc59a430c7dadc3c )
+)
+
+game (
+	name "Hare Raising Havoc (USA)"
+	rom ( name "HareRaisingHavoc_v1.0_NTSC_2043.lha" size 3367521 crc CC75D218 sha1 0a324880e4f1520b38290f76f3812ae6bb03751d )
 )
 
 game (
@@ -6661,7 +7581,7 @@ game (
 )
 
 game (
-	name "Harlequin (512 KB) (Europe)"
+	name "Harlequin (Europe) (512 kB)"
 	rom ( name "Harlequin_v1.3.1_512KB_2029.lha" size 1599368 crc EFDBA90A sha1 89a775544ec0db5dcd0b06ab419b6735ba9a2bce )
 )
 
@@ -6691,8 +7611,13 @@ game (
 )
 
 game (
+	name "Harricana (France)"
+	rom ( name "Harricana_v1.2_Fr.lha" size 599098 crc 03D1A7D8 sha1 c0efe648958f74a7341b7f08fb75ed9aba5f3066 )
+)
+
+game (
 	name "Harrier Combat Simulator (USA)"
-	rom ( name "HarrierCombatSimulator_v1.0_NTSC_0919.lha" size 303404 crc 28683FD9 sha1 e27460f5fc2bc0e19cbae7428087d1b52e0f525b )
+	rom ( name "HarrierCombatSimulator_v1.01_NTSC_0919.lha" size 303512 crc 8AACAE2B sha1 44ecd96e50f4e6c56951b94a48caab8c369e7db8 )
 )
 
 game (
@@ -6702,12 +7627,12 @@ game (
 
 game (
 	name "Hawkeye (Europe)"
-	rom ( name "Hawkeye_v1.0.lha" size 532770 crc 10244A13 sha1 e4602fbf9931512022ef1e88572623226ac9c122 )
+	rom ( name "Hawkeye_v1.1_1963.lha" size 525425 crc F4AE9DF7 sha1 9d5e0ce93e180986a145a40692e5c566dc1d54e6 )
 )
 
 game (
 	name "Head over Heels (Europe)"
-	rom ( name "HeadOverHeels_v1.0_1674.lha" size 152352 crc 95CEC94A sha1 d62467d82ff22ca6ddb7d1af0b62787bb618cd53 )
+	rom ( name "HeadOverHeels_v1.1_1674.lha" size 165611 crc 4712E475 sha1 32aec5d029a56f1bf5d08d7ca18554c7c909f43d )
 )
 
 game (
@@ -6721,7 +7646,7 @@ game (
 )
 
 game (
-	name "Heart of the Dragon (3 Disk) (Europe)"
+	name "Heart of the Dragon (Europe) (3 Disk)"
 	rom ( name "HeartOfTheDragon_v1.1_3Disk.lha" size 1349445 crc AC88BE64 sha1 63c50d4964bf46b0c2178b8cf7b2b717d099b6cd )
 )
 
@@ -6757,17 +7682,22 @@ game (
 
 game (
 	name "Heimdall (Europe)"
-	rom ( name "Heimdall_v2.0a.lha" size 4229193 crc A83C3F2D sha1 86763c00ab0fcbd5f13029d7ab32a519a0ebe0bc )
+	rom ( name "Heimdall_v2.3_0234.lha" size 4229546 crc 5F6F77FA sha1 5fc33e454e725cdf30b2f119224e5d7717975b43 )
 )
 
 game (
 	name "Heimdall (Germany)"
-	rom ( name "Heimdall_v2.0a_De.lha" size 4225464 crc 9F3FC9F5 sha1 5612181e6bb98fe2fdebd1daf432bfdab6a0da2b )
+	rom ( name "Heimdall_v2.3_De.lha" size 4227360 crc D0D59514 sha1 09082c34b4d0b9b850c68917acf646050b5230bf )
+)
+
+game (
+	name "Heimdall (Spain)"
+	rom ( name "Heimdall_v2.3_Es.lha" size 4184261 crc A246E242 sha1 4a30d64bf7bbb80c1c432ee73464597eedf71d34 )
 )
 
 game (
 	name "Heimdall (France)"
-	rom ( name "Heimdall_v2.0a_Fr.lha" size 4225517 crc 45D1EC9C sha1 d83a4297ef7b69b817af0c149c16e91468dbb519 )
+	rom ( name "Heimdall_v2.3_Fr.lha" size 4227411 crc 0EB27AF2 sha1 39d2fe4757c4dffad0966ec96709729f03b4dea3 )
 )
 
 game (
@@ -6797,7 +7727,7 @@ game (
 
 game (
 	name "Hellrun Machine, The (Europe)"
-	rom ( name "HellrunMachine_v1.0.lha" size 385678 crc 0FF1E298 sha1 453f7758f7ca0c55d68fe04c78cacdea206ee464 )
+	rom ( name "HellrunMachine_v2.0_2035.lha" size 371139 crc 4BEF21D4 sha1 3fa175fda3b375ddc24741bb4fb715d67b975123 )
 )
 
 game (
@@ -6812,17 +7742,22 @@ game (
 
 game (
 	name "HeroQuest - Return of the Witch Lord (Europe)"
-	rom ( name "HeroQuest&ReturnOfTheWitchLord_v1.3_0127&0508.lha" size 773729 crc 3F84C094 sha1 1f3c96e9684cff5c570417efae15381a6a710291 )
+	rom ( name "HeroQuest&ReturnOfTheWitchLord_v1.3a_0127&0508.lha" size 766513 crc EC9F12B5 sha1 de1025cb4acba530ba4d88702decebb90af55834 )
 )
 
 game (
-	name "HeroQuest II - Legacy of Sorasil (Europe)"
-	rom ( name "HeroQuest2_v1.0_1455.lha" size 2024568 crc C33F81B2 sha1 a1be19903bd3f033b907ebd38e4a586ffeccfc05 )
+	name "HeroQuest II - Legacy of Sorasil (Europe) (En,Fr,De)"
+	rom ( name "HeroQuest2_v1.1_1455.lha" size 1953637 crc CF41D688 sha1 57faecddc3954e729f9cf8b6c8ae23291812f8f8 )
 )
 
 game (
 	name "HeroQuest (Europe)"
-	rom ( name "HeroQuest_v1.3_0127.lha" size 489898 crc 40C15739 sha1 b006097472c3ec706f2c9098a0354d113506bd70 )
+	rom ( name "HeroQuest_v1.3a_0127.lha" size 482684 crc 986807A7 sha1 2a10b8d9c8253a5b35a1f8ae76046fad4ca2cf23 )
+)
+
+game (
+	name "Hero's Quest - So You Want To Be A Hero (Europe)"
+	rom ( name "HerosQuest_v1.4b_0795.lha" size 3025122 crc FD404A45 sha1 4b927e83dfc32d415d4c78821c3f069248183c39 )
 )
 
 game (
@@ -6837,17 +7772,23 @@ game (
 
 game (
 	name "High Steel (Europe)"
-	rom ( name "HighSteel_v1.0_1397.lha" size 214291 crc 7A3F6C98 sha1 3e2680db649d11683d8fc47b44d34f29eb925e1a )
+	rom ( name "HighSteel_v1.1_1397.lha" size 216567 crc 1337D50C sha1 504095b998fdef126592e427fa269748166c041a )
+
 )
 
 game (
 	name "Highway Hawks (Europe)"
-	rom ( name "HighwayHawks_v1.0_2538.lha" size 1100151 crc 37089200 sha1 bb3c92d73381a7aaf78a698b7256c25d705807a1 )
+	rom ( name "HighwayHawks_v1.1-B_2538.lha" size 1100661 crc 7ECDEF17 sha1 71c3bd8c09390a3987235143c43b8e103c2d6aac )
 )
 
 game (
 	name "Highway Patrol 2 (Europe)"
-	rom ( name "HighwayPatrol2_v1.1_2305.lha" size 422139 crc 7C5B746D sha1 d615f8e26be484077e9cea6a468e97fc8be96ddd )
+	rom ( name "HighwayPatrol2_v1.3_2305.lha" size 379224 crc 7304EE3F sha1 66f8c5d1723fd58abede747b8cdd9b52247b2726 )
+)
+
+game (
+	name "Highway Patrol 2 (Europe) (Fast)"
+	rom ( name "HighwayPatrol2_v1.3_Fast_2305.lha" size 379515 crc B8CACB64 sha1 76c7f68719be6511b3d7bbfce0b264420378642e )
 )
 
 game (
@@ -6861,7 +7802,7 @@ game (
 )
 
 game (
-	name "Hill Street Blues (Europe)"
+	name "Hill Street Blues (Europe) (En,Fr,De,Es,It)"
 	rom ( name "HillStreetBlues_v1.1_0659.lha" size 821344 crc BAFB40B8 sha1 484690834b7629b53cc5df28db768156145b4c61 )
 )
 
@@ -6881,23 +7822,28 @@ game (
 )
 
 game (
-	name "Hired Guns (Europe)"
-	rom ( name "HiredGuns_v1.0_1MB_1114.lha" size 3157470 crc 79A3ED84 sha1 9eb9b3881f27df85cfe3c2a7b795515d5b6681f2 )
+	name "Hired Guns (Europe) (En,Fr,De,Es,It)"
+	rom ( name "HiredGuns_v1.0_1114.lha" size 3157072 crc 394842A7 sha1 72cdee4093d18f258bd6eda163fea6ee49974fbe )
 )
 
 game (
-	name "Hired Guns (512 KB) (Europe)"
-	rom ( name "HiredGuns_v1.0_512KB_1114.lha" size 3157826 crc 31D75CCF sha1 f81594c73400203ac54d784fbccfdf1f63a58ae8 )
+	name "Hired Guns (Europe) (En,Fr,De,Es,It) (512 kB)"
+	rom ( name "HiredGuns_v1.0_512k_1114.lha" size 3157835 crc 12B79B8C sha1 a29ec68869a5b5764d7a16a60a2802a152f017d0 )
 )
 
 game (
 	name "Hired Guns (Europe) (Demo)"
-	rom ( name "HiredGunsDemo_v1.0_1MB.lha" size 680573 crc D54844B8 sha1 17d97f39cc50b20c7b0e050c017232cafc00d270 )
+	rom ( name "HiredGunsDemo_v1.0.lha" size 680588 crc E72EA95B sha1 6d72f7677cf2c6469112875eed27bb1ce9567475 )
 )
 
 game (
-	name "Hired Guns (512 KB) (Europe) (Demo)"
-	rom ( name "HiredGunsDemo_v1.0_512KB.lha" size 680631 crc 641881A1 sha1 555119c6b3486030c855b6136466bc6225c4b616 )
+	name "Hired Guns (Europe) (Demo) (512 kB)"
+	rom ( name "HiredGunsDemo_v1.0_512k.lha" size 680725 crc B80BC0F5 sha1 312131cb6b254162dfa0bb93776903318ebaae03 )
+)
+
+game (
+	name "Historia Interminable II, La (Spain)"
+	rom ( name "HistoriaInterminable2_v1.4_Es.lha" size 853004 crc 2B9AC1FB sha1 4a63ecdc5cf91d482a70d8dccaab48592d2b24e6 )
 )
 
 game (
@@ -6906,14 +7852,15 @@ game (
 )
 
 game (
-	name "Hired Guns (Germany)"
+	name "Historyline 1914-1918 (Germany)"
 	rom ( name "Historyline_v1.5_De_0336.lha" size 4151481 crc 2638DF73 sha1 2bb404bc08b623f700966f8aacd6c22141e72ece )
 )
 
 game (
-	name "Hired Guns (France)"
+	name "Historyline 1914-1918 (France)"
 	rom ( name "Historyline_v1.5_Fr.lha" size 4160716 crc 627815C5 sha1 ee191d17fd4053495b99a8b4c01dabf1821c2948 )
 )
+
 
 game (
 	name "Hitchhiker's Guide to the Galaxy, The (Europe)"
@@ -6921,13 +7868,18 @@ game (
 )
 
 game (
+	name "Hoi (Europe)"
+	rom ( name "Hoi_v1.0_0962.lha" size 1429878 crc 5F202259 sha1 5f5221a5d4d998e564822e5817263828d162e221 )
+)
+
+game (
 	name "Hole-In-One - Miniature Golf & Data Disks (Europe)"
-	rom ( name "HoleInOne&DataDisks_v1.1.lha" size 974358 crc CFEB4652 sha1 becd35b9a8eaeb6807aca472930567a31a81f879 )
+	rom ( name "HoleInOne&DataDisks_v1.2.lha" size 974830 crc 2C093619 sha1 acc5d848b78a21d8868caa66f2acc63d4d80823b )
 )
 
 game (
 	name "Hole-In-One - Miniature Golf (Europe)"
-	rom ( name "HoleInOne_v1.1.lha" size 359325 crc F64FD29A sha1 739cae5a60b294f7ce7aab47f2b0161b98410811 )
+	rom ( name "HoleInOne_v1.2.lha" size 359831 crc 1F6C17C2 sha1 d73927988ecfa154433a6d3a16e709c39d0e8621 )
 )
 
 game (
@@ -6961,7 +7913,7 @@ game (
 )
 
 game (
-	name "Hook (Europe)"
+	name "Hook (Europe) (En,Fr,De)"
 	rom ( name "Hook_v1.2_0887.lha" size 2845406 crc 72EDA2F7 sha1 e19763a7e62b03f743151fe547200ac2019afa2b )
 )
 
@@ -6971,8 +7923,13 @@ game (
 )
 
 game (
+	name "Hostages (USA)"
+	rom ( name "Hostage_v1.2_NTSC_1173.lha" size 446139 crc 596B60E4 sha1 f2b39394e39e70331c554a4b012dfb908711283f )
+)
+
+game (
 	name "Hostages (Europe)"
-	rom ( name "Hostages_v1.1_0186.lha" size 475487 crc 09119154 sha1 6c349df784c1b97074469cca9ea15cb3232e1786 )
+	rom ( name "Hostages_v1.2_0186.lha" size 439238 crc 22A15026 sha1 89938037acf6880c6336b81c20e4586a0fea04fe )
 )
 
 game (
@@ -7001,6 +7958,21 @@ game (
 )
 
 game (
+	name "HoverForce (USA)"
+	rom ( name "Hoverforce_v2.1_NTSC_2867.lha" size 251266 crc 500F9143 sha1 958efa8d64d1b1e3c14647c45210acd293923f48 )
+)
+
+game (
+	name "Hoversprint (Europe)"
+	rom ( name "Hoversprint_v1.0_2109.lha" size 576942 crc EA4EBD91 sha1 14a27b291a8b202c8f53918cc5ac5d049b63da33 )
+)
+
+game (
+	name "Hoyle Volume III (Europe)"
+	rom ( name "HoyleVolume3_v1.2.lha" size 1232126 crc 9B528F33 sha1 f50629fe027dbbc7be411878456324abc4ad9c86 )
+)
+
+game (
 	name "Huckleberry Hound in Hollywood Capers (Europe)"
 	rom ( name "HuckleberryHound_v1.1.lha" size 426114 crc AB64A849 sha1 fad0aa3829f228f7b1ae63b29dbb1013e3a6fd6b )
 )
@@ -7012,32 +7984,32 @@ game (
 
 game (
 	name "Hugo - Pa Nye Eventyr (Denmark)"
-	rom ( name "Hugo1_v1.0_Dk.lha" size 3192072 crc 80B9148C sha1 319eaaf8cd04d7c6d7b90f9e481d2f82b94a875a )
+	rom ( name "Hugo1_v1.1_Dk.lha" size 3189640 crc B728128A sha1 e9af607feba9353eb1decacdab0bf8afd858bf68 )
 )
 
 game (
 	name "Hugo - Pa Nye Eventyr (Finland)"
-	rom ( name "Hugo1_v1.0_Fi.lha" size 2860762 crc C9B9EFDB sha1 5cf051bbed2a60e8eced4640b75aa2c6310ade2b )
+	rom ( name "Hugo1_v1.1_Fi.lha" size 2858753 crc 1C1EA671 sha1 837c384de28e1243e28319f8c9b02686251076d7 )
 )
 
 game (
 	name "Hugo - Pa Nye Eventyr 2 (Denmark)"
-	rom ( name "Hugo2_v1.0_Dk.lha" size 3539184 crc FF5E57AC sha1 4b615b4f9427dc191e500c56b1ca06e757f016c7 )
+	rom ( name "Hugo2_v1.1_Dk.lha" size 3536884 crc C134009A sha1 1d165389a33063baca081f4a515d16354919dbbb )
 )
 
 game (
 	name "Hugo - Pa Nye Eventyr 2 (Finland)"
-	rom ( name "Hugo2_v1.0_Fi.lha" size 2721629 crc 4BE39947 sha1 ab5ae66c59a23d06f0bd3a766ae76518afdbae56 )
+	rom ( name "Hugo2_v1.1_Fi.lha" size 2719758 crc 0A998D3A sha1 b322ebddf71576b027b44ffc4bdefe1e33eafbc1 )
 )
 
 game (
 	name "Hugo (Germany)"
-	rom ( name "Hugo_v1.0_De_0685.lha" size 4600117 crc BDCA4E96 sha1 731b70ece4dc61b35decad59d223956f90dd1110 )
+	rom ( name "Hugo_v1.1_De_0685.lha" size 4597996 crc E013CE62 sha1 13d36a9b5e90a4ad306a70c42f8e251fd56025a5 )
 )
 
 game (
 	name "Hugo (Sweden)"
-	rom ( name "Hugo_v1.0_Se.lha" size 4680677 crc 64018DFF sha1 2c46d85f67f2a5c71d77bddb4659a5939fa3e38c )
+	rom ( name "Hugo_v1.1_Se.lha" size 4667606 crc C13AA3FB sha1 d2ff6d5bf458143e5df61e43c5ab3b8c5841333e )
 )
 
 game (
@@ -7047,17 +8019,22 @@ game (
 
 game (
 	name "Human Race - The Jurassic Levels (Europe)"
-	rom ( name "Humans2_v1.01_1036.lha" size 2311697 crc 0AFE8603 sha1 1c783f0ae5adba424af4094b97ce327370c742eb )
+	rom ( name "Humans2_v1.6-B_1036.lha" size 2558557 crc 0F5759F3 sha1 5621f9fd10557a478488a740f4ebbe150a059641 )
 )
 
 game (
 	name "Human Race - The Jurassic Levels (Germany)"
-	rom ( name "Humans2_v1.01_De_0510.lha" size 2311317 crc F2931D03 sha1 d20b042e49f6a27b8217f281d9f3ab51ee75811b )
+	rom ( name "Humans2_v1.6-B_De_0510.lha" size 2558194 crc F34BCC88 sha1 8d3bb72cad3f4e9295141b5c5cfb9cdb506e64cf )
 )
 
 game (
 	name "Humans III - Evolution - Lost in Time (Europe) (AGA)"
-	rom ( name "Humans3_v1.1_AGA_2382.lha" size 2079746 crc 908A2F8B sha1 79c115499adcdf30b4e8fb4d69e000b41d9f7bfd )
+	rom ( name "Humans3_v1.2_AGA_2382.lha" size 2089743 crc 24CE0BD8 sha1 3d55e95b1fa66e949c236f328afa98a2d20e8e1a )
+)
+
+game (
+	name "Humans III - Evolution - Lost in Time (Europe) (CD32)"
+	rom ( name "Humans3_v1.2_CD32.lha" size 4738876 crc 004BF608 sha1 58a3063d5b08e9f6337de450c78c5f7b8edcd758 )
 )
 
 game (
@@ -7082,22 +8059,22 @@ game (
 
 game (
 	name "Hunter (Europe)"
-	rom ( name "Hunter_v1.30_3014.lha" size 311133 crc A526B75A sha1 9009e874a20e7e5a42ccdca2a3a6819898796d34 )
+	rom ( name "Hunter_v2.0c_3014.lha" size 312362 crc 934EDAEC sha1 579478b13411c2c5a0aca3ce7c758351a17f4058 )
 )
 
 game (
 	name "Hunter (Germany)"
-	rom ( name "Hunter_v1.30_De.lha" size 312217 crc 1223C303 sha1 d4396fa0814fbefabbf5724807b50e23a2828b61 )
+	rom ( name "Hunter_v2.0c_De.lha" size 313318 crc 75B7541F sha1 768966bcbaf7161e68a79c3f64646d1e865102d7 )
 )
 
 game (
 	name "Hunter (France)"
-	rom ( name "Hunter_v1.30_Fr.lha" size 312084 crc E4E9CBCD sha1 6f098a3301e00acb77dc1a4724ea843bd4b38fd8 )
+	rom ( name "Hunter_v2.0c_Fr.lha" size 313180 crc FF8E775E sha1 2a020d158cba8c0efc18b14fdeeb80cda701e254 )
 )
 
 game (
 	name "Hunt for Red October, The (Europe)"
-	rom ( name "HuntForRedOctober_v1.0_0128.lha" size 356862 crc CA208794 sha1 3b25cb8aeb145ab569b3a07bbe1dd24e16bbc99e )
+	rom ( name "HuntForRedOctober_v1.1_0128.lha" size 357277 crc 65161ADE sha1 8748f847e4b501450ed8cf5ea7d9c78dc0064a7c )
 )
 
 game (
@@ -7107,7 +8084,7 @@ game (
 
 game (
 	name "Hybris (USA)"
-	rom ( name "Hybris_v2.3_NTSC_1457.lha" size 640964 crc 74BEAF61 sha1 9e73047d80ecb3fd3fc5e5125bc8d3ec42b70537 )
+	rom ( name "Hybris_v2.4_NTSC_1457.lha" size 650207 crc 5DC0B4CB sha1 a3d899b9804a5e7967ac11c0c80ce37aa1e619e6 )
 )
 
 game (
@@ -7117,12 +8094,17 @@ game (
 
 game (
 	name "Hyperdome (Europe)"
-	rom ( name "Hyperdome_v1.0.lha" size 278046 crc ED378F76 sha1 e2b9212f59e48498f3b6d9941a0ec2f0b64bd0f5 )
+	rom ( name "Hyperdome_v1.0.lha" size 278079 crc 7F89C8C4 sha1 6f3cdc017929e65269caee3161c4cca457db0b46 )
+)
+
+game (
+	name "Hyperforce (Europe)"
+	rom ( name "Hyperforce_v1.0_0493.lha" size 177978 crc 1D42F3B4 sha1 360469672d631dd4f10d388a9d12766d625f36a7 )
 )
 
 game (
 	name "Hyperion (Europe)"
-	rom ( name "Hyperion_v1.0.lha" size 413563 crc A62ACA05 sha1 ad3d3c5729b157767c1d6fe5fdd4622c584fc88c )
+	rom ( name "Hyperion_v2.0_0260.lha" size 413858 crc E715C525 sha1 5e2ec1ce9e38e6621b5ae95f773975627d0565f4 )
 )
 
 game (
@@ -7137,17 +8119,22 @@ game (
 
 game (
 	name "IK+ (Europe)"
-	rom ( name "IK+_v1.8_2063.lha" size 191644 crc 61B94CE8 sha1 066a43d17271b9f523350a8c3639c554c0a2bb0a )
+	rom ( name "IK+_v1.9_2063.lha" size 191871 crc 5ED26C1B sha1 9353935125023998a8eb53e902f0189364b765a4 )
 )
 
 game (
 	name "IK+ (Europe) (CD32)"
-	rom ( name "IK+_v1.8_CD32.lha" size 191693 crc 88FAB96E sha1 f94162bccd9045cd40c2fe96e9f71e20dfe24336 )
+	rom ( name "IK+_v1.9_CD32.lha" size 191920 crc 1105BB0B sha1 b5f4a0535102d0a03ed5f66df5a94a071358144d )
 )
 
 game (
 	name "Ikari Warriors (Europe)"
-	rom ( name "IkariWarriors_v2.0_0771.lha" size 206315 crc 3B215320 sha1 ddb95b77bda169c131db2d29ed66e9fe85636ef4 )
+	rom ( name "IkariWarriors_v2.01_0771.lha" size 205182 crc 20D1B4C3 sha1 2d29e79524e3f50086cd7d041f5ba659d9da9ec2 )
+)
+
+game (
+	name "I Ludicrus (Europe)"
+	rom ( name "ILudicrus_v1.0.lha" size 313349 crc 36467EF1 sha1 f1b0cbfd48b819cf60aec5f493fcb3f4c5154426 )
 )
 
 game (
@@ -7157,17 +8144,17 @@ game (
 
 game (
 	name "Immortal, The (Europe)"
-	rom ( name "Immortal_v3.0_0340.lha" size 815200 crc 36CFC46D sha1 5c776002994b2e385b52b06649bd85466c031d6f )
+	rom ( name "Immortal_v3.2_0340.lha" size 815301 crc 738BC88F sha1 426c564ec2fb9c8026807f4f46d19fbaa92e0bdd )
 )
 
 game (
 	name "Impact 95 (Europe)"
-	rom ( name "Impact95_v1.1.lha" size 222381 crc 69CD4E41 sha1 bec0aaa02a3efb6bae6f2ae48b7311063991fcf3 )
+	rom ( name "Impact95_v1.2.lha" size 226738 crc 00C85FE8 sha1 7dd942dcac233219c66a2e78fd3d0df11eb73b26 )
 )
 
 game (
 	name "Impact (Europe)"
-	rom ( name "Impact_v1.1_2462.lha" size 219252 crc BA0EE563 sha1 4278d9c67b135ee78c0d3983f378c9d77de23216 )
+	rom ( name "Impact_v1.2_2462.lha" size 223613 crc 10B90313 sha1 20686c11414ee1c444cd4fcb754564b5bf9c7ac2 )
 )
 
 game (
@@ -7181,7 +8168,7 @@ game (
 )
 
 game (
-	name "Impossible Mission 2025 - The Special Edition (Europe)"
+	name "Impossible Mission 2025 - The Special Edition (Europe) (En,Fr,De,Es,It)"
 	rom ( name "ImpossibleMission2025_v2.0-B_1107.lha" size 981447 crc B2FAED3B sha1 9c7df0348d71a66e35a78a771010a81d81624fff )
 )
 
@@ -7207,27 +8194,27 @@ game (
 
 game (
 	name "Indiana Jones and the Fate of Atlantis - A Graphic Adventure (Europe)"
-	rom ( name "IndianaJones&TheFateOfAtlantisAdventure_v2.2_0851.lha" size 5658521 crc 73DE066D sha1 ab563e94a45528711a312bd2c5b4f806c6a4616f )
+	rom ( name "IndianaJones&TheFateOfAtlantisAdventure_v2.3_0851.lha" size 5658689 crc 7DCF7218 sha1 ea24680842874cacf76aca380b73d0edeab4cd63 )
 )
 
 game (
 	name "Indiana Jones and the Fate of Atlantis - Ein Grafik Adventure (Germany)"
-	rom ( name "IndianaJones&TheFateOfAtlantisAdventure_v2.2_De_0342.lha" size 5673683 crc C7D75B06 sha1 92a4418c809905a080c11be6d28ce03c803c60a0 )
+	rom ( name "IndianaJones&TheFateOfAtlantisAdventure_v2.3_De_0342.lha" size 5673851 crc 3B653D0D sha1 e872caf562e19aab9301aae59e6e60762c1b167b )
 )
 
 game (
 	name "Indiana Jones and the Fate of Atlantis - A Graphic Adventure (Spain)"
-	rom ( name "IndianaJones&TheFateOfAtlantisAdventure_v2.2_Es.lha" size 5658017 crc 2C9F73DA sha1 714097d767b6407f4e6437b2f1df7d5de1a77e16 )
+	rom ( name "IndianaJones&TheFateOfAtlantisAdventure_v2.3_Es.lha" size 5658185 crc 6834D50A sha1 0d0fb80bf2a8bbc7756dd2003e63172a10dfd502 )
 )
 
 game (
 	name "Indiana Jones and the Fate of Atlantis - A Graphic Adventure (France)"
-	rom ( name "IndianaJones&TheFateOfAtlantisAdventure_v2.2_Fr_1639.lha" size 5676439 crc 870FA927 sha1 dc3f7155fc4c6683123c887acfa86c36281f58e2 )
+	rom ( name "IndianaJones&TheFateOfAtlantisAdventure_v2.3_Fr_1639.lha" size 5676757 crc 18397694 sha1 0db18f38ff804cb45ad3f160f527bc80963bf577 )
 )
 
 game (
 	name "Indiana Jones and the Fate of Atlantis - A Graphic Adventure (Italy)"
-	rom ( name "IndianaJones&TheFateOfAtlantisAdventure_v2.2_It.lha" size 5662354 crc 85D3F1FA sha1 0625531f58ff6188098b871939496ef90731e13a )
+	rom ( name "IndianaJones&TheFateOfAtlantisAdventure_v2.3_It.lha" size 5662522 crc B7793FAB sha1 9b54b6735f64db6561a7546e75656997941fd244 )
 )
 
 game (
@@ -7237,32 +8224,32 @@ game (
 
 game (
 	name "Indiana Jones and the Last Crusade - Das Graphic Adventure (Germany)"
-	rom ( name "IndianaJones&TheLastCrusadeAdventure_v1.5_De_0343.lha" size 1419509 crc 2EFDF0D6 sha1 9b7747e671b2092bf90b04b90bf231b64fc2bbe7 )
+	rom ( name "IndianaJones&TheLastCrusadeAdventure_v2.1_De_0343.lha" size 1424628 crc A1D72D66 sha1 703a9e51d5c3d2d919354933913fdf9e1a276fdd )
 )
 
 game (
 	name "Indiana Jones and the Last Crusade - Das Graphic Adventure (Germany) (CDTV)"
-	rom ( name "IndianaJones&TheLastCrusadeAdventure_v1.5_De_CDTV.lha" size 1420129 crc 6C7EC283 sha1 419a26048f17cb25cbfeb45c2d8df56d445c1c3c )
+	rom ( name "IndianaJones&TheLastCrusadeAdventure_v2.1_De_CDTV.lha" size 1424221 crc 7B9CB49A sha1 5311b683ddfc334e3f9a99dc7f110297e91b8604 )
 )
 
 game (
 	name "Indiana Jones and the Last Crusade - The Graphic Adventure (Spain)"
-	rom ( name "IndianaJones&TheLastCrusadeAdventure_v1.5_Es.lha" size 1420329 crc DD4A8A97 sha1 31f997a51d014c6390d53b68a04661a5a29cf297 )
+	rom ( name "IndianaJones&TheLastCrusadeAdventure_v2.1_Es.lha" size 1425447 crc 65FD1D25 sha1 46b4c548fb00620f66fe55326ac19c0b0237ddb7 )
 )
 
 game (
 	name "Indiana Jones and the Last Crusade - The Graphic Adventure (France)"
-	rom ( name "IndianaJones&TheLastCrusadeAdventure_v1.5_Fr_1986.lha" size 1423080 crc 702A4D23 sha1 f8c0c05031d2ca114786f65bf8963479feb1c58d )
+	rom ( name "IndianaJones&TheLastCrusadeAdventure_v2.1_Fr_1986.lha" size 1428202 crc A1568EDD sha1 889b8fefd929f25a7534bd753de52984e270fb32 )
 )
 
 game (
 	name "Indiana Jones and the Last Crusade - The Graphic Adventure (Italy)"
-	rom ( name "IndianaJones&TheLastCrusadeAdventure_v1.5_It_2323.lha" size 1433419 crc BE69B283 sha1 3ccb4bd850999d22c29be35495b34e22ecd157d6 )
+	rom ( name "IndianaJones&TheLastCrusadeAdventure_v2.1_It_2323.lha" size 1438532 crc 4D1DB887 sha1 76adbf16d89bf4d3b5a5357ed8c998a105dcb105 )
 )
 
 game (
 	name "Indiana Jones and the Last Crusade - The Graphic Adventure (USA)"
-	rom ( name "IndianaJones&TheLastCrusadeAdventure_v1.5_NTSC_1990.lha" size 1419286 crc 595B10FD sha1 896b79f21a0e9104cc9fa766caebf6ed36139139 )
+	rom ( name "IndianaJones&TheLastCrusadeAdventure_v2.1_NTSC_1990.lha" size 1424415 crc 45CAB19D sha1 b22352c34841cc08395b6afb68707cf8acdd282f )
 )
 
 game (
@@ -7272,7 +8259,17 @@ game (
 
 game (
 	name "Indianapolis 500 - The Simulation (Europe)"
-	rom ( name "Indianapolis500_v2.0_0686.lha" size 495936 crc 1E0ED155 sha1 25b72654f437529a2aec774f69f254973299c6d7 )
+	rom ( name "Indianapolis500_v3.0_0686.lha" size 506389 crc A555FA14 sha1 2ea21d5b49afa4c739c031df1ef4277d7c904641 )
+)
+
+game (
+	name "Indian Mission (Germany)"
+	rom ( name "IndianMission_v1.0_De.lha" size 403226 crc C4C87DDB sha1 0db328e6f3d8feb2fffe77ef568f066a740a9e6b )
+)
+
+game (
+	name "Indian Mission (France)"
+	rom ( name "IndianMission_v1.0_Fr.lha" size 408646 crc 6063A3E3 sha1 95450ebaf7edb08bbc64f6ff97840e317e111fcf )
 )
 
 game (
@@ -7281,7 +8278,7 @@ game (
 )
 
 game (
-	name "Indigo (Image) (Europe)"
+	name "Indigo (Europe) (Image)"
 	rom ( name "Indigo_v1.1_Image.lha" size 560891 crc EB3FD81F sha1 6cb94423b8a846b36464f3fabe2cb22d7c5c19b0 )
 )
 
@@ -7292,12 +8289,17 @@ game (
 
 game (
 	name "Indy Heat (Europe)"
-	rom ( name "IndyHeat_v1.1.lha" size 800957 crc B7506224 sha1 36ad3f8831240d77fa77b35da5e1af10df5b06ce )
+	rom ( name "IndyHeat_v1.21_2436.lha" size 804551 crc 469E5524 sha1 506345326afee1db3557a878d24075e5d8c4460d )
 )
 
 game (
 	name "Inertia Drive (Europe)"
-	rom ( name "InertiaDrive_v1.0.lha" size 68997 crc 1A5BDBDF sha1 caac8f7470bfb1cea8e2ecfa704a0cf992024e57 )
+	rom ( name "InertiaDrive_v1.1.lha" size 69259 crc 663E6861 sha1 90b47f0bf33b80973ba6b121af31531d532e54d0 )
+)
+
+game (
+	name "Inertia Drive (Europe) (MegaPak)"
+	rom ( name "InertiaDrive_v1.1_MegaPak.lha" size 66501 crc 83C8B38D sha1 6035177e9829e310cb194bc3ea3c6683697d506e )
 )
 
 game (
@@ -7306,7 +8308,7 @@ game (
 )
 
 game (
-	name "Infestation (Europe)"
+	name "Infestation (Europe) (En,Fr,De)"
 	rom ( name "Infestation_v1.1.lha" size 389405 crc D90AFB7A sha1 c5ba9606a165afdc953a1a59c4c0cdb42e8eef38 )
 )
 
@@ -7317,21 +8319,26 @@ game (
 
 game (
 	name "Innocent Until Caught (Europe)"
-	rom ( name "InnocentUntilCaught_v1.01_1824.lha" size 4316696 crc 932C1B9D sha1 975bfca40d8af28a9a17ac009b0fc673e22401e5 )
+	rom ( name "InnocentUntilCaught_v1.02_1824.lha" size 4317385 crc A48222E2 sha1 1efcc7a99963006c885e1fa3be9b40a2576cba62 )
 )
 
 game (
 	name "Innocent Until Caught (Germany)"
-	rom ( name "InnocentUntilCaught_v1.01_De.lha" size 4325884 crc A86BDD2B sha1 dbe3b955723cd389275acfce168ffdaf042e0451 )
+	rom ( name "InnocentUntilCaught_v1.02_De.lha" size 4326578 crc 111232DE sha1 7859128de2f5f38eba9c0a6d96011987c7f9f9ba )
 )
 
 game (
 	name "Innocent Until Caught (France)"
-	rom ( name "InnocentUntilCaught_v1.01_Fr.lha" size 4323880 crc 78C5BB28 sha1 fa6d34e0d5742410f4082161bdb4683e675e3832 )
+	rom ( name "InnocentUntilCaught_v1.02_Fr.lha" size 4324569 crc 031DD37A sha1 b27262da7c6bcb4ba9831be99e9ded87cb5e5657 )
 )
 
 game (
-	name "Insanity Fight (Europe)"
+	name "Innocent Until Caught (Italy)"
+	rom ( name "InnocentUntilCaught_v1.02_It.lha" size 4318846 crc E1E6A34F sha1 668c8288a8be3905ab36aae51070feaabb7ca6ba )
+)
+
+game (
+	name "Insanity Fight (Europe) (En,De)"
 	rom ( name "InsanityFight_v1.2.lha" size 534956 crc BEB9875A sha1 e5d13e2ab5b80cf8da996943510aeeaada7bf53f )
 )
 
@@ -7342,27 +8349,27 @@ game (
 
 game (
 	name "Insects in Space (Europe)"
-	rom ( name "InsectsInSpace_v1.1.lha" size 267793 crc EE8B36EA sha1 c81bac085dcf457b6e2dbf069a19c0132b16f9d8 )
-)
-
-game (
-	name "Intact (15 MB) (Europe)"
-	rom ( name "Intact_v1.0_15MB.lha" size 643186 crc 018EB6EE sha1 727d9838a14961b9e1dff71336667402aba998c6 )
+	rom ( name "InsectsInSpace_v1.2_0829.lha" size 211230 crc DF9CCE16 sha1 fdc1c485cd4424abec7ea15564a07c57096b149c )
 )
 
 game (
 	name "Intact (Europe)"
-	rom ( name "Intact_v1.0_1MB.lha" size 643096 crc 822144F0 sha1 e1eefcfdbc5a7bcf24d8c9cf226b1a92befa953b )
+	rom ( name "Intact_v1.1_15MB.lha" size 644634 crc 1FD91726 sha1 0c5a743223aa7b785999561fc455a22add47df9b )
 )
 
 game (
-	name "Intact (512 KB) (Europe)"
-	rom ( name "Intact_v1.0_512KB.lha" size 643089 crc 4F54F378 sha1 f8210f12f6745b8de97b1947dea04b756879955b )
+	name "Intact (Europe) (1 MB)"
+	rom ( name "Intact_v1.1_1MB.lha" size 644612 crc A8F9B676 sha1 c1bb38b21fc211c933b15625b1fcca329c025dc2 )
+)
+
+game (
+	name "Intact (Europe) (512 kB)"
+	rom ( name "Intact_v1.1_512k.lha" size 644593 crc 7EF2EAD9 sha1 c1942f9c8f104cfb810c0ecdd585495d335d0918 )
 )
 
 game (
 	name "International 3D Tennis (Europe)"
-	rom ( name "International3DTennis_v1.0_1609.lha" size 402720 crc F9516518 sha1 0b9bc1717f825120d3bb4d21dd28d640ee6afa6a )
+	rom ( name "International3DTennis_v1.1_1609.lha" size 403530 crc 97E5520F sha1 da2c2f0d1641517bca18826f06c861fa29a29473 )
 )
 
 game (
@@ -7381,8 +8388,14 @@ game (
 )
 
 game (
+	name "International Soccer Challenge (Europe)"
+	rom ( name "InternationalSoccerChallenge_v1.0_0866.lha" size 470931 crc FF72EC6E sha1 6fff036fba032e03a6616231dbdb6960d014ae23 )
+)
+
+
+game (
 	name "International Sports Challenge (Europe)"
-	rom ( name "InternationalSportsChallenge_v1.01_2815.lha" size 1559898 crc 9C932F9C sha1 9fb2a574aebb167d582c34710cff7d4614ef72f5 )
+	rom ( name "InternationalSportsChallenge_v1.02_2815.lha" size 1560107 crc 4001C220 sha1 a4e5e5b6f5e0f5e99bbb474501e1afb07dca08c9 )
 )
 
 game (
@@ -7401,13 +8414,18 @@ game (
 )
 
 game (
-	name "Interphase (Amiga Format) (Europe)"
+	name "Interphase (Europe) (Coverdisk - Amiga Format #18)"
 	rom ( name "Interphase_v1.9_AmigaFormat.lha" size 216933 crc 81768139 sha1 2bf494fde700cdaba868a5f3717fe65ff2d9b81f )
 )
 
 game (
 	name "Into the Eagle's Nest... (Europe)"
 	rom ( name "IntoTheEaglesNest_v1.1.lha" size 249005 crc 2756048C sha1 beefee9cdd2c070544bd180a3cd2bf64e4b6dc6a )
+)
+
+game (
+	name "Intrigue à la Renaissance (France)"
+	rom ( name "IntrigueALaRenaissance_v1.0_Fr.lha" size 498797 crc 6335793F sha1 4347a88c8badc9f10fa0d3a5998d170276adbad2 )
 )
 
 game (
@@ -7421,23 +8439,33 @@ game (
 )
 
 game (
-	name "Inve$t (Germany) (Compilation - No. 1 Collection)"
+	name "Inve$t (Germany)"
 	rom ( name "Invest_v1.2_De_2Disk.lha" size 712656 crc DB66A255 sha1 53843e335fa52b240f036beb7f43f9f61ae46d9e )
 )
 
 game (
+	name "Inviyya (Europe) (Demo)"
+	rom ( name "InviyyaDemo_v1.1.lha" size 210201 crc 1C89C9EC sha1 b9596e8544db7cd14b2138e962ff5f14163c8082 )
+)
+
+game (
+	name "I Play 3D Soccer (Europe) (En,Fr,De,It)"
+	rom ( name "IPlay3DSoccer_v1.01_2104.lha" size 410891 crc A2A6886F sha1 59943c46904d04d42742f37d2413da789e372011 )
+)
+
+game (
 	name "Iron Lord (Europe)"
-	rom ( name "IronLord_v1.11_1650.lha" size 1019751 crc D45ABAD0 sha1 b3c15946a6ffacfa435bc5a2f859cc713878db78 )
+	rom ( name "IronLord_v1.2_1650.lha" size 888054 crc 166E9D1D sha1 dea4c32d7af0ad9a0f7019168d92f34b6c24eef9 )
 )
 
 game (
 	name "Iron Lord (Germany)"
-	rom ( name "IronLord_v1.11_De_1530.lha" size 1021299 crc 4B1F8683 sha1 9b7708589f262921718ed2c1f0d51c3ce43a577a )
+	rom ( name "IronLord_v1.2_De_1530.lha" size 891339 crc C47EDB91 sha1 83312dffd186169210c97500a74683c993e57be9 )
 )
 
 game (
 	name "Iron Lord (France)"
-	rom ( name "IronLord_v1.11_Fr_2444.lha" size 1019291 crc 1C1B3021 sha1 7a1b4b3f83d8ccb7ad53d5c756056a0037c7a519 )
+	rom ( name "IronLord_v1.2_Fr_2444.lha" size 888959 crc BD440852 sha1 8e8289f2897708929d70fcfa35afa65e9765f573 )
 )
 
 game (
@@ -7451,7 +8479,7 @@ game (
 )
 
 game (
-	name "Ishar 2 - Messengers of Doom (Europe)"
+	name "Ishar 2 - Messengers of Doom (Europe) (En,Fr,De)"
 	rom ( name "Ishar2_v1.4_2747.lha" size 1902445 crc B04F191F sha1 8f48ad1897d46b67efd7b59233366b279f58a2fe )
 )
 
@@ -7467,31 +8495,31 @@ game (
 
 game (
 	name "Ishar 3 - The Seven Gates of Infinity (Europe)"
-	rom ( name "Ishar3_v1.4_2749.lha" size 3422792 crc 7E5CE6BC sha1 c5e591ccd32aeb68401ef80df3e98ed7dab1a40c )
+	rom ( name "Ishar3_v1.5_2749.lha" size 3423814 crc D0F49886 sha1 be6c128b2c3204769a1012a64b7c51de2a6bf209 )
 )
 
 game (
 	name "Ishar 3 - The Seven Gates of Infinity (Europe) (En,Fr,De) (AGA)"
-	rom ( name "Ishar3_v1.4_AGA_2245.lha" size 5306272 crc 1941ACDA sha1 38b36a469dfb7c13e57167f1c3ce207bfac2f6e2 )
+	rom ( name "Ishar3_v1.5_AGA_2245.lha" size 5307258 crc 277EDD7A sha1 12160efbe6fd84ed7502660d914e41334c2be6d7 )
 )
 
 game (
 	name "Ishar 3 - The Seven Gates of Infinity (Germany)"
-	rom ( name "Ishar3_v1.4_De.lha" size 3425206 crc 3B7FA0CE sha1 aee0236ff3de6b85823c945712f679f8b55fdfda )
+	rom ( name "Ishar3_v1.5_De.lha" size 3426217 crc 5462C7CB sha1 c4393fc8e682758f22533923314448c0e71b41bf )
 )
 
 game (
 	name "Ishar 3 - The Seven Gates of Infinity (France)"
-	rom ( name "Ishar3_v1.4_Fr_2664.lha" size 3425485 crc CEA55BFF sha1 3a00ea9299e076438dcfd2dcab729b5aaee58c51 )
+	rom ( name "Ishar3_v1.5_Fr_2664.lha" size 3426506 crc 8722CB11 sha1 43ac254d4d8b7036e9123f9fff432c2994cbc77d )
 )
 
 game (
-	name "Ishar - Legend of the Fortress (Europe)"
+	name "Ishar - Legend of the Fortress (Europe) (En,Fr,De,It)"
 	rom ( name "Ishar_v1.4_0187.lha" size 1173394 crc AE388494 sha1 83bab9b8ff8f94174b9245731c6a1b1805d7c26a )
 )
 
 game (
-	name "Ishar - Legend of the Fortress (Europe) (AGA)"
+	name "Ishar - Legend of the Fortress (Europe) (En,Fr,De,It) (AGA)"
 	rom ( name "Ishar_v1.4_AGA.lha" size 1397881 crc C18A24B3 sha1 e3c2e50b350233f1f94262840a8bbe2d09f3f75e )
 )
 
@@ -7507,12 +8535,12 @@ game (
 
 game (
 	name "Island of Lost Hope, The (Europe)"
-	rom ( name "IslandOfLostHope_v1.0.lha" size 705223 crc DFD04223 sha1 65685c0a4fce93ce602c3daac2c59205eb5c8e38 )
+	rom ( name "IslandOfLostHope_v1.1_1318.lha" size 703664 crc EFFD2476 sha1 dcee69fb02128a10aec56a985a057c842e467549 )
 )
 
 game (
 	name "ISS - Incredible Shrinking Sphere (Europe)"
-	rom ( name "ISS_v1.0_0287.lha" size 384888 crc C29DA0A1 sha1 3f59137fcda18a7c74a672a3ce556a57c016f544 )
+	rom ( name "ISS_v1.2_0287.lha" size 385134 crc 9EDAABFA sha1 a5d89736733224f24ebb9ee82c0bdb19142e50c9 )
 )
 
 game (
@@ -7531,18 +8559,38 @@ game (
 )
 
 game (
-	name "Antheads - It Came from the Desert II Data Disk (Europe)"
-	rom ( name "ItCameFromTheDesert2_v2.0.lha" size 1712091 crc F23AEB1F sha1 8fd4d6797f43231b63daeaf874af595fbebf6edd )
+	name "It Came From The Desert II (Europe)"
+	rom ( name "ItCameFromTheDesert2_v2.1_0014&0262.lha" size 1627673 crc 5F42D4F3 sha1 6b2f8283345faf7990a9c384b3501f475372637e )
+)
+
+game (
+	name "It Came From The Desert II (Italy) (Unl)"
+	rom ( name "ItCameFromTheDesert2_v2.1_It.lha" size 1613591 crc 757ADE13 sha1 01626119294aa70690a3840d665be3b01e32412b )
 )
 
 game (
 	name "It Came from the Desert (Europe)"
-	rom ( name "ItCameFromTheDesert_v2.0_0014.lha" size 1657837 crc 6FB58F8C sha1 acb56d26e21e06a89c8b6a775dae7bad120ed3ef )
+	rom ( name "ItCameFromTheDesert_v2.1_0014.lha" size 1623205 crc CAADA494 sha1 d2bdbfbc3a04728dcaa50927efa8355e320d04fd )
+)
+
+game (
+	name "It Came from the Desert (Spain) (Unl)"
+	rom ( name "ItCameFromTheDesert_v2.1_Es.lha" size 1608491 crc 014E212E sha1 301ccf3215056db40172f5a36b0cca7abe8d5a88 )
+)
+
+game (
+	name "It Came from the Desert (Greece)"
+	rom ( name "ItCameFromTheDesert_v2.1_Gr.lha" size 1614673 crc 44CABF48 sha1 d50a3ae2cbe0f111dde767bcb73dd98dd8a069a9 )
+)
+
+game (
+	name "It Came from the Desert (Italy) (Unl)"
+	rom ( name "ItCameFromTheDesert_v2.1_It.lha" size 1623719 crc 1CC20487 sha1 5146badd93a9e3276b97433b49cd03b11cf7670a )
 )
 
 game (
 	name "Ivanhoe (Europe)"
-	rom ( name "Ivanhoe_v1.0_1648.lha" size 752293 crc 62EF254C sha1 3add8c1d31455979e884dcca6e25251cc81b9625 )
+	rom ( name "Ivanhoe_v1.2_1648.lha" size 753395 crc 6F25F85C sha1 baedc444ef7f9a1d54433fca65534ecdadbeeaf1 )
 )
 
 game (
@@ -7551,38 +8599,43 @@ game (
 )
 
 game (
-	name "Jaguar XJ220 (Europe)"
+	name "Jagd auf Roter Oktober (Germany)"
+	rom ( name "JagdAufRoterOktober_v1.1_De_0344.lha" size 348864 crc E47AA4A7 sha1 10149c3107c70deae1568fd1fc61cda14855ef07 )
+)
+
+game (
+	name "Jaguar XJ220 (Europe) (En,Fr,De,It)"
 	rom ( name "JaguarXJ220_v1.7_Files_1200.lha" size 1656611 crc EA431BCD sha1 ad8efc23bbac65ecd365701d696cf2f0e63f51b1 )
 )
 
 game (
-	name "Jaguar XJ220 (Chip) (Europe)"
+	name "Jaguar XJ220 (Europe) (En,Fr,De,It) (Chip)"
 	rom ( name "JaguarXJ220_v1.7_Files_Chip_1200.lha" size 1657369 crc 409726FE sha1 a56ad91c741566b80dde64e8a5c07cc31a2086e7 )
 )
 
 game (
-	name "Jaguar XJ220 (Image) (Europe)"
+	name "Jaguar XJ220 (Europe) (En,Fr,De,It) (Image)"
 	rom ( name "JaguarXJ220_v1.7_Image_1200.lha" size 1660510 crc 8BC7CABD sha1 fa4c093efe5b941f658242e8fbd409239c7df406 )
 )
 
 game (
-	name "Jaguar XJ220 (Image) (Chip) (Europe)"
+	name "Jaguar XJ220 (Europe) (En,Fr,De,It) (Image) (Chip)"
 	rom ( name "JaguarXJ220_v1.7_Image_Chip_1200.lha" size 1660563 crc D49327E1 sha1 a68963ab35f59d198721e8d5af872b2c50f813f0 )
 )
 
 game (
-	name "Jahangir Khan World Championship Squash (Europe)"
+	name "Jahangir Khan World Championship Squash (Europe) (En,Fr,De,Es,It)"
 	rom ( name "JahangirKhansWorldChampionshipSquash_v1.0_0129.lha" size 587084 crc D20F0677 sha1 f51662440782fbedc460f14ad1504baa8ac12b68 )
 )
 
 game (
 	name "James Bond - The Stealth Affair (USA)"
-	rom ( name "JamesBondTheStealthAffair_v2.0_NTSC_2016.lha" size 2095898 crc 67298344 sha1 f297f22e23b8ebcdfe677282d53034363b6def10 )
+	rom ( name "JamesBondTheStealthAffair_v2.1_NTSC_2016.lha" size 2097505 crc B5312C1A sha1 6d50907b3d309fe2a1a49682396ef52f2cbfd9e7 )
 )
 
 game (
 	name "James Pond II - Codename RoboCod (Europe) (CD32)"
-	rom ( name "JamesPond2_v1.0_CD32.lha" size 2433862 crc 84CB3ADB sha1 bf71c9bc6905860a9e8098939a8e444ac92f9942 )
+	rom ( name "JamesPond2_v1.0_CD32.lha" size 2430057 crc 8E6F92CF sha1 306e5856fbafa6009ec6850ea5c94548afe02d2c )
 )
 
 game (
@@ -7597,7 +8650,12 @@ game (
 
 game (
 	name "James Pond 3 - Operation Starfish (Europe) (CD32)"
-	rom ( name "JamesPond3_V1.02_CD32.lha" size 1776862 crc B67EA318 sha1 6b403196a527e27293ebb0eb2df6a59ff69d0dc5 )
+	rom ( name "JamesPond3_v2.1_CD32.lha" size 1787605 crc 1A5764A1 sha1 bb37d3da11b8bb7a028b6c5aeba520179169bbd0 )
+)
+
+game (
+	name "James Pond 3 - Operation Starfish (France) (CD32)"
+	rom ( name "JamesPond3_v2.1_CD32_Fr.lha" size 1788083 crc 5577F4C4 sha1 ac28798ff6496f26bffd04c0bc72c26fd84659a3 )
 )
 
 game (
@@ -7607,7 +8665,7 @@ game (
 
 game (
 	name "James Pond - Underwater Agent (Europe)"
-	rom ( name "JamesPond_v2.1.lha" size 511042 crc 2D66CC78 sha1 776913f0042d626b658348b17438c806cdf91620 )
+	rom ( name "JamesPond_v2.5.lha" size 570323 crc 8BEDB81A sha1 47bae0052ddf79d8f4f1633876c0048ac3d92f06 )
 )
 
 game (
@@ -7657,7 +8715,12 @@ game (
 
 game (
 	name "Jet Set Willy II (Europe)"
-	rom ( name "JetSetWilly2_v0501.1_1115.lha" size 725696 crc 29388A72 sha1 653015915b23218908a9c43f5f7fc304cd3644f0 )
+	rom ( name "JetSetWilly2_v5.0_1115.lha" size 721522 crc EDFDC625 sha1 ded7104634a67d8ca75b8f0242e014a08e670af4 )
+)
+
+game (
+	name "Jetsons, The - George Jetson and the Legend of Robotopia (Europe)"
+	rom ( name "JetsonsLegendOfRobotopia_v1.0.lha" size 1244162 crc 1B935851 sha1 ec5d498ade0b803d66580d6567a5d8f3e3248d06 )
 )
 
 game (
@@ -7687,7 +8750,7 @@ game (
 
 game (
 	name "Jimmy White's Whirlwind Snooker (Europe)"
-	rom ( name "JimmyWhitesWhirlwindSnooker_v2.0_2466.lha" size 206375 crc CEE8A54A sha1 e0063fb8a1be05cf356c973c1aa3d6965c4e4572 )
+	rom ( name "JimmyWhitesWhirlwindSnooker_v2.2_2466.lha" size 235645 crc AD4C6EF9 sha1 67473d75d8a68575a4461a3f0e9605ba74304898 )
 )
 
 game (
@@ -7697,7 +8760,7 @@ game (
 
 game (
 	name "Jim Power in Mutant Planet (Europe)"
-	rom ( name "JimPower_v2.1_0068.lha" size 1674934 crc 84A90869 sha1 4527b9a771df1707009959da32ce3764ceadc27a )
+	rom ( name "JimPower_v3.3_0068.lha" size 1676309 crc C21DC29C sha1 fa3819be4572a4b7fa24752454e00691ed8da0f6 )
 )
 
 game (
@@ -7711,13 +8774,23 @@ game (
 )
 
 game (
+	name "Joakim von Anka - Skattsökaren (Sweden)"
+	rom ( name "JoakimVonAnkaSkattsoekaren_v1.1_Se.lha" size 158119 crc 98302337 sha1 22fffe9b1390fb4413d77e5cacf19eb61b432d15 )
+)
+
+game (
 	name "Jocky Wilson's Darts Challenge (Europe)"
 	rom ( name "JockyWilsonsDartsChallenge_v1.1.lha" size 469363 crc 86F7DD80 sha1 f9b786bae5e15289e696e44c1e85ed056b9f3815 )
 )
 
 game (
 	name "Joe & Mac - Caveman Ninja (Europe)"
-	rom ( name "Joe&MacCavemanNinja_v1.0b_2179.lha" size 1926692 crc 4217ABC1 sha1 fb9cd7cd16525acb9c957bec7e8cf642e677699b )
+	rom ( name "Joe&MacCavemanNinja_v2.0_2179.lha" size 1927636 crc 8D2D7288 sha1 069fe90557122522d380a2b0167c0ad13b2d1d6d )
+)
+
+game (
+	name "Joe & Mac - Caveman Ninja (Europe) (Fast)"
+	rom ( name "Joe&MacCavemanNinja_v2.0_Fast_2179.lha" size 1927727 crc E0DA62ED sha1 eb9b37065b6193ebaab156e9c96251daeb3f45fc )
 )
 
 game (
@@ -7731,7 +8804,7 @@ game (
 )
 
 game (
-	name "John Barnes European Football (Europe)"
+	name "John Barnes European Football (Europe) (En,Fr,De,Es,It)"
 	rom ( name "JohnBarnesEuropeanFootball_v1.01_1925.lha" size 544178 crc C7D9730D sha1 50deeb45381a9ac6287cc34f562aa8e1392b8bd6 )
 )
 
@@ -7756,6 +8829,11 @@ game (
 )
 
 game (
+	name "Journey to the Center of the Earth (Europe)"
+	rom ( name "JourneyToTheCenterOfTheEarth_v1.0_1901.lha" size 855349 crc 6EACCB28 sha1 ab8a3d24aafd1f7ea2c05e7934fd54f8a02fec40 )
+)
+
+game (
 	name "Jouster 3 (Europe)"
 	rom ( name "Jouster3_v1.0.lha" size 611253 crc F72302D2 sha1 5d227304080d4eedfa6cde6f0815afd1f653a9f9 )
 )
@@ -7772,7 +8850,12 @@ game (
 
 game (
 	name "Jumping Jack'Son (Europe)"
-	rom ( name "JumpingJackSon_v1.41_1040.lha" size 538589 crc 8F61D971 sha1 ee44fc6e78c42d9f9933199c3e76f704a85b434f )
+	rom ( name "JumpingJackSon_v2.0_1040.lha" size 537066 crc 19C63DD8 sha1 6906c4de4830cf8567cf78c403498e2de6ee5a16 )
+)
+
+game (
+	name "Jump Machine (Europe)"
+	rom ( name "JumpMachine_v1.0.lha" size 292406 crc 73E37326 sha1 bb3dca453619f4924bf5f9974d0a68a83af8074f )
 )
 
 game (
@@ -7781,13 +8864,18 @@ game (
 )
 
 game (
+	name "Jungle Book, The (Europe)"
+	rom ( name "JungleBook_v1.0_0516.lha" size 392026 crc DB4EA379 sha1 444ce2e1730e2fcd6b936802733cf4bd1b88f410 )
+)
+
+game (
 	name "Jungle Strike (Europe)"
-	rom ( name "JungleStrike_v1.1_1MB_0188.lha" size 1759116 crc 811DC4CC sha1 39af405a92b2c528af9f0dfef00ca423a30bc5d7 )
+	rom ( name "JungleStrike_v1.1_0188.lha" size 1759002 crc 725024DC sha1 05835070cd39f5d510eb978f4fa99c6f74e3fe18 )
 )
 
 game (
 	name "Jungle Strike (Europe) (AGA)"
-	rom ( name "JungleStrike_v1.1_2MB_2581.lha" size 2172823 crc C5CFD771 sha1 8c5a06f646d2eb4da29dff0cc77b529f1a618f46 )
+	rom ( name "JungleStrike_v1.1_AGA_2581.lha" size 2172981 crc 5AB261C6 sha1 c45e61053ab3aeea9fc1f4409df6c54f30ff1058 )
 )
 
 game (
@@ -7812,21 +8900,21 @@ game (
 
 game (
 	name "Jurassic Park (Europe) (En,Fr,De,Es,It) (AGA)"
-	rom ( name "JurassicPark_v1.5_AGA_0836.lha" size 3768969 crc 5D025EE8 sha1 e5e1d560c5f7da5de78cf57305ab8432d0c75284 )
+	rom ( name "JurassicPark_v2.0_AGA_0836.lha" size 3776935 crc 72202100 sha1 3723c3a70bf148a1781d4da3855a2fc8cf065fe3 )
 )
 
 game (
-	name "Jurassic Park (Europe)"
-	rom ( name "JurassicPark_v1.6_0048.lha" size 3764084 crc 9568146F sha1 cfa6fd01a96f1ab1c32c0c111c836c5ed52dde22 )
+	name "Jurassic Park (Europe) (En,Fr,De,Es,It)"
+	rom ( name "JurassicPark_v2.0_0048.lha" size 3772215 crc 475921D9 sha1 89ff6a74bffefcabdb5c5991977e31ade114a27b )
 )
 
 game (
-	name "K240 (Europe)"
+	name "K240 (Europe) (En,Fr,De)"
 	rom ( name "K240_v1.1_1MB_1565.lha" size 1801330 crc 9017B6EF sha1 a571bc29de6db1f2259f48e589ebc678dbc20f9e )
 )
 
 game (
-	name "K240 (512 KB) (Europe)"
+	name "K240 (Europe) (En,Fr,De) (512 kB)"
 	rom ( name "K240_v1.1_512KB_1565.lha" size 1801512 crc B10BDEA1 sha1 e15e49db9042992f7f8469797fd4de87e12ad86b )
 )
 
@@ -7851,7 +8939,7 @@ game (
 )
 
 game (
-	name "Kalas Puffs Expressen (512 KB) (Sweden)"
+	name "Kalas Puffs Expressen (Sweden) (512 kB)"
 	rom ( name "KalasPuffsExpressen_v1.1_Se_512KB.lha" size 762720 crc 76BF05E7 sha1 192f97ea99647217d727268e1f7d699dabe0633f )
 )
 
@@ -7862,7 +8950,7 @@ game (
 
 game (
 	name "Karate Kid Part II, The (Europe)"
-	rom ( name "KarateKid2_v1.1.lha" size 275925 crc 7F1EF625 sha1 46c347a85a6ca16a4c7b1355084751ca7f12e842 )
+	rom ( name "KarateKid2_v1.2.lha" size 277508 crc 5887B99E sha1 01174eb5c155656330a497baedc22979382e5505 )
 )
 
 game (
@@ -7871,18 +8959,23 @@ game (
 )
 
 game (
-	name "Karting Grand Prix (Europe)"
-	rom ( name "KartingGrandPrix_v1.0_0517.lha" size 369819 crc 6ADC859A sha1 7c514838b246c81c5fb0b8065efd687d65e338af )
+	name "Karate King & CityDefence (Europe)"
+	rom ( name "KarateKing&CityDefence_v1.1.lha" size 481343 crc ED71B0D6 sha1 c06cad9dc1da3951023e26690ee0079bb7247fb1 )
 )
 
 game (
-	name "Katakis (1 Disk) (Europe)"
-	rom ( name "Katakis_v1.2_1Disk_1273.lha" size 678246 crc B1562668 sha1 32f607b4dc9b64bd666df2ed748bdd00dd07317b )
+	name "Karting Grand Prix (Europe)"
+	rom ( name "KartingGrandPrix_v1.1_0517.lha" size 370693 crc DC1A907C sha1 2daafedbeb535100057dd2ebea1e15ceb3019a7d )
+)
+
+game (
+	name "Katakis (Europe) (Compilation - 5th Anniversary)"
+	rom ( name "Katakis_v2.0_1Disk_1273.lha" size 678609 crc C55A46C4 sha1 484d468481f52be54a010f14db3d698b3118a53d )
 )
 
 game (
 	name "Katakis (Europe)"
-	rom ( name "Katakis_v1.2_2Disk_0347.lha" size 866895 crc B3EC511A sha1 4526becdce4c5aa2ae81cf46566c0116b811e03d )
+	rom ( name "Katakis_v2.0_2Disk_0347.lha" size 867260 crc 088D26CF sha1 acc883250b1df230721051d99f018e7e8c250703 )
 )
 
 game (
@@ -7897,12 +8990,12 @@ game (
 
 game (
 	name "Kelly X (Europe)"
-	rom ( name "KellyX_v1.0_1133.lha" size 109684 crc 28EBD648 sha1 51b71a6d3e343828ddd53f4a1a9ada183a02aefb )
+	rom ( name "KellyX_v1.1_1133.lha" size 113628 crc 61F5AD55 sha1 b0ea7d4b111eb54c482232642f4a8a97ed977ccc )
 )
 
 game (
 	name "Kennedy Approach (Europe)"
-	rom ( name "KennedyApproach_v1.01_1506.lha" size 171513 crc 3E29573B sha1 b3332cc6adc374640d170812bed549f55760f9a7 )
+	rom ( name "KennedyApproach_v1.02_1506.lha" size 175747 crc 0E2B49E8 sha1 308758a68e9ab61af32190c7c2ed41cb5445a2bd )
 )
 
 game (
@@ -7946,83 +9039,83 @@ game (
 )
 
 game (
-	name "Kick Off + Extra Time (1 Disk) (Europe)"
+	name "Kick Off & Extra Time (Europe) (En,Fr,De,It,Nl) (1 Disk)"
 	rom ( name "KickOff&ExtraTime_v1.2_1Disk_0881.lha" size 310296 crc 55875618 sha1 741bf392f2b09d3885dea07c435c9d0bbc26efbd )
 )
 
 game (
-	name "Kick Off + Extra Time (Europe)"
+	name "Kick Off & Extra Time (Europe) (En,Fr,De,It,Nl)"
 	rom ( name "KickOff&ExtraTime_v1.2_2Disk_0189&0073.lha" size 408603 crc 18361528 sha1 9bcbe2d7d1a7e3317453d8e8b2ce58504ec8b7df )
 )
 
 game (
 	name "Kick Off 2 (Europe)"
-	rom ( name "KickOff216_v1.08_2191.lha" size 567557 crc A729568D sha1 e53d31235e6d35880aff1f4c315e16e97df6acab )
-)
-
-game (
-	name "Kick Off 2 (Europe)"
-	rom ( name "KickOff2_v1.08_0760.lha" size 443655 crc AB65D9ED sha1 ddaf520233b728f8e66bdee0e8f719de7c8130fa )
+	rom ( name "KickOff2_v1.09a_2191.lha" size 567920 crc 2D30F343 sha1 f04b7f38222ec17242938d2b2fd3ad5e8c9ac712 )
 )
 
 game (
 	name "Kick Off 2 (Germany)"
-	rom ( name "KickOff2_v1.08_De_1245.lha" size 444495 crc E92DE57B sha1 ce12930ac2dc1887b04233ee8a60fc8d4f086b04 )
+	rom ( name "KickOff2_v1.09a_De_1245.lha" size 444708 crc 1ACA7C7C sha1 52b2164f41c07291b1f0d8ccc16c9ad773599fdf )
 )
 
 game (
 	name "Kick Off 2 (Spain)"
-	rom ( name "KickOff2_v1.08_Es_2507.lha" size 445050 crc EA2AE8C1 sha1 0b7adc4ae54d8fd32176aeee70a5962534746f1f )
+	rom ( name "KickOff2_v1.09a_Es_2507.lha" size 445263 crc 33BCC4FF sha1 345cea2ba34c4f203e6efdf28a7c038c0074d24c )
 )
 
 game (
 	name "Kick Off 2 (France)"
-	rom ( name "KickOff2_v1.08_Fr.lha" size 444370 crc 2179EC45 sha1 cb70e290ccff2286ab1a85d58270b095f4705b55 )
+	rom ( name "KickOff2_v1.09a_Fr.lha" size 444583 crc 5AB2C03C sha1 f28385ef10038aa9fa3ed97ea5b1f883a5a9af83 )
 )
 
 game (
 	name "Kick Off 2 (Italy)"
-	rom ( name "KickOff2_v1.08_It_2574.lha" size 445050 crc 59D3E4E8 sha1 7c40364809cb5233b51a4de8220caf3929ef28b3 )
+	rom ( name "KickOff2_v1.09a_It_2574.lha" size 445263 crc 967F7CFA sha1 a23907149b9d65b31d77421df48566e0e353080b )
 )
 
 game (
 	name "Kick Off 2 - Competition Version (Europe)"
-	rom ( name "KickOff2CompetitionVersion_v1.08.lha" size 386010 crc 9ED6357C sha1 132cb3ac43150b655b1340ce2f31d4a24773349f )
+	rom ( name "KickOff2CompetitionVersion_v1.09a.lha" size 386223 crc 103E9642 sha1 f388affbaed38649a809b5567add1866deac3b1d )
 )
 
 game (
 	name "Kick Off 2 - The Final Whistle (Europe)"
-	rom ( name "KickOff2FinalWhistle_v1.03_0166.lha" size 719273 crc 43E40137 sha1 b0f0438ed7656f8deee67770812e6cd0003b1f16 )
+	rom ( name "KickOff2FinalWhistle_v1.04_0166.lha" size 720637 crc 4D11F62E sha1 14ae35433e0e57057a771dce2f621b5f1b9d22d1 )
 )
 
 game (
 	name "Kick Off 2 - The Final Whistle (Germany)"
-	rom ( name "KickOff2FinalWhistle_v1.03_De_2739.lha" size 721021 crc 263146AD sha1 676c756514afe8f49ceac76a3d0469bb959b02dd )
+	rom ( name "KickOff2FinalWhistle_v1.04_De_2739.lha" size 722410 crc CEEF02C9 sha1 f1ef656193f33fa39b66e4b71884e8889e94a555 )
+)
+
+game (
+	name "Kick Off 2 - The Final Whistle (France)"
+	rom ( name "KickOff2FinalWhistle_v1.04_Fr.lha" size 722222 crc 0B95F50E sha1 112520a7b224af855523a501d5fd149478c642f9 )
 )
 
 game (
 	name "Kick Off 2 - The Final Whistle - Competition Version (Europe)"
-	rom ( name "KickOff2FinalWhistleCompetitionVersion_v1.03.lha" size 718279 crc CE03D525 sha1 b83492f886977536cf9492eea1bb14d29f6a7ac6 )
+	rom ( name "KickOff2FinalWhistleCompetitionVersion_v1.04.lha" size 719650 crc FE337FE6 sha1 0e71d110ee33a1919a998f74915658d23b6da320 )
 )
 
 game (
-	name "Kick Off 2 + World Cup '90 (Europe)"
-	rom ( name "KickOff2PlusWorldCup90_v1.08_0168.lha" size 454220 crc 49CAF06E sha1 a7f2661cfee7a48db3789f6d09c6e5655c17f114 )
+	name "Kick Off 2 & World Cup '90 (Europe)"
+	rom ( name "KickOff2PlusWorldCup90_v1.09a_0168.lha" size 454433 crc 25978279 sha1 6aaad06839ca6b8c097e856aa7ee2fe7808a8212 )
 )
 
 game (
-	name "Kick Off 2 + World Cup '90 (Germany)"
-	rom ( name "KickOff2PlusWorldCup90_v1.08_De_0689.lha" size 454655 crc D9AB9256 sha1 317bea4f1d43af618b95bfa812d2973da8f60ff6 )
+	name "Kick Off 2 & World Cup '90 (Germany)"
+	rom ( name "KickOff2PlusWorldCup90_v1.09a_De_0689.lha" size 454868 crc 4D3D01DB sha1 39f95da2670890753fc1e1d9c7df061a4b61f326 )
 )
 
 game (
-	name "Kick Off 2 + World Cup '90 (France)"
-	rom ( name "KickOff2PlusWorldCup90_v1.08_Fr.lha" size 454589 crc 8B4298DE sha1 1669889d12cac4af5bf5aefc351dafe3661913cd )
+	name "Kick Off 2 & World Cup '90 (France)"
+	rom ( name "KickOff2PlusWorldCup90_v1.09a_Fr.lha" size 454802 crc 0C85BB4C sha1 717a1eb8467288b2abbb43ab70e7991df50f2528 )
 )
 
 game (
-	name "Kick Off 2 + World Cup '90 (Italy)"
-	rom ( name "KickOff2PlusWorldCup90_v1.08_It_2573.lha" size 454561 crc ABA16676 sha1 9d768b62577d7bac4383a904b5a118b3fe01a54a )
+	name "Kick Off 2 & World Cup '90 (Italy)"
+	rom ( name "KickOff2PlusWorldCup90_v1.09a_It_2573.lha" size 454774 crc A659F68C sha1 f87be1cbb00cad2a4b02664b53ea82326f1f84bb )
 )
 
 game (
@@ -8032,11 +9125,16 @@ game (
 
 game (
 	name "Kick Off 3 (Europe)"
-	rom ( name "KickOff3_v1.0_0191.lha" size 870509 crc 82A558CA sha1 82c3adf5ce44cb2ea377b71443d296df88ccbd2d )
+	rom ( name "KickOff3_v1.01_0191.lha" size 871206 crc FDAE3D01 sha1 b0f29b6c8d7805b3e2fcbfd4e45def4b907ed7f3 )
 )
 
 game (
-	name "Kick Off 3 - European Challenge (Europe)"
+	name "Kick Off 3 (Europe) (AGA)"
+	rom ( name "KickOff3_v1.01_AGA_1854.lha" size 914278 crc 705C6622 sha1 600b93b0220505811f5e2b07d5db7a4b8f49983c )
+)
+
+game (
+	name "Kick Off 3 - European Challenge (Europe) (En,Fr,De,Es,It)"
 	rom ( name "KickOff3EuropeanChallenge_v1.0_0170.lha" size 1165343 crc A7606111 sha1 617d698138f61c981c236c93fd241410dc7ec196 )
 )
 
@@ -8072,7 +9170,7 @@ game (
 
 game (
 	name "Kid Gloves (Europe)"
-	rom ( name "KidGloves_v1.2_1372.lha" size 219737 crc DA9A2827 sha1 0595a4810bb3204a7d69d55c4c84c0ef412b2a59 )
+	rom ( name "KidGloves_v2.0_1372.lha" size 222912 crc DAB652FA sha1 edd614015d241c92b26ea6eb3201e2413fd9c1d6 )
 )
 
 game (
@@ -8091,18 +9189,23 @@ game (
 )
 
 game (
-	name "Killing Cloud, The (Europe)"
-	rom ( name "KillingCloud_v1.0_3031.lha" size 1083685 crc 15F51C13 sha1 6dffc05b84239aa819ae9bc54c80c992bc82c7ba )
+	name "Killing Cloud, The (Europe) (En,Fr,De)"
+	rom ( name "KillingCloud_v2.3_3031.lha" size 1104171 crc D6B54891 sha1 1fdd43133a6be44b68de4c997d93ba745b6ac8d9 )
 )
 
 game (
 	name "Killing Cloud, The (USA)"
-	rom ( name "KillingCloud_v1.0_NTSC_3019.lha" size 1040896 crc 2D88A9EE sha1 ceb7a7fd5e6bd2867ee2a9f4012059fa43af08b9 )
+	rom ( name "KillingCloud_v2.3_NTSC_3019.lha" size 1053178 crc 2B550FC0 sha1 a5c0052f6befc1d844f3cbe426ceaab7d7255e03 )
 )
 
 game (
-	name "Killing Game Show, The (Europe, Australia)"
-	rom ( name "KillingGameShow_v1.2.lha" size 1485043 crc EB1A2CDC sha1 c0e5b9e89bd3b05abb892d2c2cec120eaf50ea40 )
+	name "Killing Game Show, The (Europe)"
+	rom ( name "KillingGameShow_v1.3.lha" size 1491821 crc 6A84CE1B sha1 ccae91c708f6a6d082ff0cc866ed1ffad02f7324 )
+)
+
+game (
+	name "Killing Game Show, The (USA)"
+	rom ( name "KillingGameShow_v1.3_NTSC.lha" size 1491879 crc 6F38732E sha1 91960730cb6f77f047002cea017d246bc5e2413b )
 )
 
 game (
@@ -8116,8 +9219,13 @@ game (
 )
 
 game (
-	name "Kingmaker - The Quest for the Crown (Europe)"
-	rom ( name "KingmakerQuestForTheCrown_v1.1_1616.lha" size 899841 crc 788029C1 sha1 0d90c1f59a3345173779e80fa649f1325e6f1d79 )
+	name "Kingdoms of England (Europe)"
+	rom ( name "KingdomsOfEngland_v1.01.lha" size 1254393 crc A635668A sha1 cf38abe95e9f960b39f4317e7c46abaf75fa472c )
+)
+
+game (
+	name "Kingmaker - The Quest for the Crown (Europe) (En,Fr,De)"
+	rom ( name "Kingmaker_v1.2_1616.lha" size 899418 crc 648E56FE sha1 167b27fa982355bd319401a0fe479bf344a18df2 )
 )
 
 game (
@@ -8126,7 +9234,7 @@ game (
 )
 
 game (
-	name "Kingpin - Arcade Sports Bowling (1 MB) (Europe)"
+	name "Kingpin - Arcade Sports Bowling (Europe) (1 MB)"
 	rom ( name "Kingpin_v1.0_1Mb_2888.lha" size 762877 crc 9F4D4971 sha1 e290faa006bc0f137c3f947671a19efc77228919 )
 )
 
@@ -8157,7 +9265,7 @@ game (
 
 game (
 	name "King's Quest II - Romancing the Throne (Europe)"
-	rom ( name "KingsQuest2_v2.0_2126.lha" size 469279 crc DAEC10D5 sha1 c75596350728a9dea4736b355c4c6aa870964a9e )
+	rom ( name "KingsQuest2_v2.0_2126.lha" size 363423 crc DA3B574E sha1 eeb067cfc35b2cbfbdbe2dea500b9c265d439c9a )
 )
 
 game (
@@ -8167,7 +9275,7 @@ game (
 
 game (
 	name "King's Quest IV - The Perils of Rosella (Europe)"
-	rom ( name "KingsQuest4_v1.1_0822.lha" size 2898613 crc 9033ECEB sha1 a578edd42e2e979239fc3597c66dcf5a20189ae2 )
+	rom ( name "KingsQuest4_v2.0_0822.lha" size 2354000 crc 2A22BACD sha1 f7361fca1baf21df71ed2695d6407e9d563780dd )
 )
 
 game (
@@ -8181,7 +9289,7 @@ game (
 )
 
 game (
-	name "King's Quest V - Absence Makes the Heart Go Yonder (MT32) (Germany)"
+	name "King's Quest V - Absence Makes the Heart Go Yonder (Germany) (MT32)"
 	rom ( name "KingsQuest5_v1.3_De_MT32.lha" size 6521276 crc 37F08B99 sha1 4cb512f0d0f9758d1adbcbe9d304e0ec662fb53e )
 )
 
@@ -8191,12 +9299,12 @@ game (
 )
 
 game (
-	name "King's Quest V - Absence Makes the Heart Go Yonder (MT32) (Italy)"
+	name "King's Quest V - Absence Makes the Heart Go Yonder (Italy) (MT32)"
 	rom ( name "KingsQuest5_v1.3_It_MT32.lha" size 6059031 crc 150A093E sha1 c5be3b0cbae543dcf66c38780ca1e89e6d468a0b )
 )
 
 game (
-	name "King's Quest V - Absence Makes the Heart Go Yonder (MT32) (Europe)"
+	name "King's Quest V - Absence Makes the Heart Go Yonder (Europe) (MT32)"
 	rom ( name "KingsQuest5_v1.3_MT32.lha" size 6258080 crc E609E983 sha1 415bcc59b0094ae2122c311abe09bff707b37570 )
 )
 
@@ -8217,17 +9325,12 @@ game (
 
 game (
 	name "King's Quest - Quest for the Crown (Europe)"
-	rom ( name "KingsQuest_v1.1_1333.lha" size 390232 crc 376D54B1 sha1 b12eb5d800ed37409e5110daf3f64f69b6e2d056 )
+	rom ( name "KingsQuest_v2.0_1333.lha" size 288536 crc 3F6BA7ED sha1 3851f7188d57992337a6f9fc44856aed1281b521 )
 )
 
 game (
-	name "King's Quest I - Quest for the Crown (Enhanced) (Europe)"
-	rom ( name "KingsQuestEnhanced_v1.1b_1436.lha" size 2924502 crc 9160CD26 sha1 25eeda5902d034b02d12090e6f4fb23785e09d06 )
-)
-
-game (
-	name "King's Quest I - Quest for the Crown (Enhanced) (MT32) (Europe)"
-	rom ( name "KingsQuestEnhanced_v1.1b_MT32_1436.lha" size 2927741 crc 683A5986 sha1 91b495f8f3568cf8b618c5994a7d72bd13f720cd )
+	name "King's Quest I - Quest for the Crown (Europe) (Enhanced)"
+	rom ( name "KingsQuestEnhanced_v1.3_1436.lha" size 2931299 crc 3BD87E5A sha1 bb5bf7bd5cd476b8dba0fbb7d58ecad73a074a66 )
 )
 
 game (
@@ -8242,12 +9345,17 @@ game (
 
 game (
 	name "Knight Force (Europe)"
-	rom ( name "KnightForce_v1.2_1574.lha" size 571463 crc F6861F7E sha1 874895a79b0366bc702789d7b9440655c2a9e1d8 )
+	rom ( name "KnightForce_v2.2_1574.lha" size 546459 crc 796076E9 sha1 1b256e5d4c144ebb4ce9d4c4e46d8e5d94d1fa72 )
 )
 
 game (
-	name "Knightmare (Europe)"
-	rom ( name "Knightmare_v1.1_0966.lha" size 1296493 crc 0E65F15C sha1 8173955653d45df1126024705772d8cc7daea94f )
+	name "Knightmare (Europe) (Konami)"
+	rom ( name "Knightmare_v1.1_Konami.lha" size 642522 crc 0E8CD5A9 sha1 f981c2602787e01019e356c91dbc73bf2e889b03 )
+)
+
+game (
+	name "Knightmare (Europe) (Mindscape)"
+	rom ( name "Knightmare_v2.1_Mindscape_0966.lha" size 1324566 crc D1F73DAB sha1 b79388270d42ee5bc21f51b86988fb55ff21ceed )
 )
 
 game (
@@ -8267,22 +9375,27 @@ game (
 
 game (
 	name "Knights of the Sky (Europe)"
-	rom ( name "KnightsOfTheSky_v1.3_0522.lha" size 880186 crc 382AC2D0 sha1 d151fa3052c0808dac10d813e1e08833a8a669df )
+	rom ( name "KnightsOfTheSky_v1.4_0522.lha" size 880895 crc 8790D371 sha1 85a6b514c623e6172feef6c64ada3a52142946ec )
 )
 
 game (
 	name "Kristal, The (Europe)"
-	rom ( name "Kristal_v1.2_0024.lha" size 1933460 crc 8DDD2254 sha1 70a5ee5dcdb3e13dfd436e842719e202f8447e2c )
+	rom ( name "Kristal_v1.3_0024.lha" size 1934023 crc 19DB2DEC sha1 4fdc204450d8f04e70b2de06ebe8081b663d76eb )
 )
 
 game (
 	name "Kristal, The (Germany)"
-	rom ( name "Kristal_v1.2_De.lha" size 1933418 crc F7DF1369 sha1 1d8056973bd1882576e753532420f240b037d7a8 )
+	rom ( name "Kristal_v1.3_De.lha" size 1933981 crc 947F1ADF sha1 1db81c97a731c320338e65d270d43134917b8e03 )
 )
 
 game (
 	name "Kristal, The (USA)"
-	rom ( name "Kristal_v1.2_NTSC_1194.lha" size 1922637 crc E92CB305 sha1 040265a4b10867629f315b23ea50299cac8c33b9 )
+	rom ( name "Kristal_v1.3_NTSC_1194.lha" size 1923200 crc DF1E74DB sha1 37ede585d5d5b874d1107161c25f8d6b1f1e4457 )
+)
+
+game (
+	name "Krogharr - An Epic Barbarian Quest (Europe) (Demo)"
+	rom ( name "KrogharrDemo_v1.0.lha" size 345439 crc ED3B294F sha1 814630ce3166b123de55551e468bf8843598fd14 )
 )
 
 game (
@@ -8296,13 +9409,13 @@ game (
 )
 
 game (
-	name "Kult - The Temple of Flying Saucers (Europe)"
-	rom ( name "Kult_v1.1b_0661.lha" size 540478 crc 25DDC968 sha1 59fe5c4cfe2545acd97ad137cfab4d170055afae )
+	name "Kult - The Temple of Flying Saucers (Europe) (En,Fr,De)"
+	rom ( name "Kult_v1.2_0661.lha" size 556775 crc ACC3CB99 sha1 56e7d43244c8f0783c5e7707571e36640667bbbf )
 )
 
 game (
 	name "Kwasimodo (Europe)"
-	rom ( name "Kwasimodo_v1.2_2957.lha" size 204736 crc 49107BAF sha1 130b59dfefb5ad46256390c9e5baec8b15100d53 )
+	rom ( name "Kwasimodo_v1.3_2957.lha" size 205308 crc AD03EF4F sha1 917485bf13f748cd0773acb616155e9c630e893c )
 )
 
 game (
@@ -8311,7 +9424,7 @@ game (
 )
 
 game (
-	name "Labyrinth (Denmark)"
+	name "Labyrinth (Denmark) (Det Nye COMputer)"
 	rom ( name "Labyrinth_v1.0.1_DetNyeCOMputer_Dk.lha" size 244111 crc 0B4ABECD sha1 989b874d4bebfef1330c4830346f9fa65d2413b9 )
 )
 
@@ -8361,13 +9474,33 @@ game (
 )
 
 game (
+	name "Lancaster (Europe)"
+	rom ( name "Lancaster_v1.0_2885.lha" size 503208 crc BEBCED13 sha1 9da98c918dcc6c16c8aaa4cc3a3f7895565391c2 )
+)
+
+game (
 	name "Lancelot (Europe)"
 	rom ( name "Lancelot_v1.0_0216.lha" size 503551 crc 34AA92AA sha1 5393744b1f5f355fdb52abe8809586ce73bfd7ae )
 )
 
 game (
 	name "Landsitz von Mortville, Der (Germany)"
-	rom ( name "LandsitzVonMortville_v1.1a_De.lha" size 617464 crc AE921230 sha1 75c521b38b897a5f3109cf0196d8efd06af1a3f3 )
+	rom ( name "LandsitzVonMortville_v2.0_De.lha" size 616419 crc ECCE99FE sha1 c9d0391cd556bbfcba1735876ef8b6ea0bbc9e1a )
+)
+
+game (
+	name "A La Poursuite De Carmen Sandiego Dans Le Monde (France)"
+	rom ( name "LaPoursuiteDeCarmenSandiegoDansLeMonde_v0.1_Fr.lha" size 474493 crc B00758FD sha1 ede769fa827f21b044a9d50521aa55836124b2b5 )
+)
+
+game (
+	name "Larrie and the Ardies (Europe) (Crysys)"
+	rom ( name "Larrie_v1.1_Crysys.lha" size 456596 crc B0D7DFC3 sha1 f239eeea677371a48a6b83f245f15f60fa00df00 )
+)
+
+game (
+	name "Larrie and the Ardies (Europe) (Kingsoft)"
+	rom ( name "Larrie_v1.1_Kingsoft.lha" size 453472 crc B1F9321E sha1 905d678f5ac3bd921f92ddc8add29d360b8a88b5 )
 )
 
 game (
@@ -8387,7 +9520,7 @@ game (
 
 game (
 	name "Last Action Hero (Europe)"
-	rom ( name "LastActionHero_v1.1.lha" size 1339048 crc 8C7529FF sha1 2ec5241c4d2064fc63a5db9db6a29199529aa91a )
+	rom ( name "LastActionHero_v1.2_1043.lha" size 1339666 crc 88839B25 sha1 4b3a2be4f31c7ff16193c87247c4d19504468b53 )
 )
 
 game (
@@ -8407,12 +9540,12 @@ game (
 
 game (
 	name "Last Ninja 3 (Europe)"
-	rom ( name "LastNinja3_v1.1_0495.lha" size 1657350 crc 057A4629 sha1 e499c731b22b93e4e8ca48766d48d7526d9d4939 )
+	rom ( name "LastNinja3_v1.1a_0495.lha" size 1657855 crc 98214E4F sha1 654712393ce46c26580089a4bef88f46921dc089 )
 )
 
 game (
 	name "Last Ninja 3 (Europe) (CD32)"
-	rom ( name "LastNinja3_v1.1_CD32.lha" size 1657381 crc 58B8DD7E sha1 3c33048bb9c228619fcc18ba642f18896ffb5f0f )
+	rom ( name "LastNinja3_v1.1a_CD32.lha" size 1657884 crc F837DEA0 sha1 d55970ad992d470549cb9238b0f85c8a18300aa7 )
 )
 
 game (
@@ -8446,12 +9579,12 @@ game (
 )
 
 game (
-	name "Leading Lap (CU Amiga) (Europe) (AGA)"
+	name "Leading Lap (Europe) (AGA) (CU Amiga)"
 	rom ( name "LeadingLapMPV_v1.0_AGA_CUAmiga.lha" size 475636 crc 3C7CBA8C sha1 95360adcbfa25064c1adb84d676f6d41fdb0141f )
 )
 
 game (
-	name "Leading Lap (CU Amiga) (Europe)"
+	name "Leading Lap (Europe) (CU Amiga)"
 	rom ( name "LeadingLapMPV_v1.0_CUAmiga.lha" size 281843 crc B8039A07 sha1 de4d896e0a6404d62eaf99ca6050a24274d3e4cb )
 )
 
@@ -8467,7 +9600,7 @@ game (
 
 game (
 	name "Leatherneck (Europe)"
-	rom ( name "Leatherneck_v1.0.lha" size 171615 crc CCF99122 sha1 ce3476fe29fab41040496ef8ce572b2c8aa46e22 )
+	rom ( name "Leatherneck_v1.0.lha" size 176079 crc A42555C4 sha1 87fac0da39c6da4107d76125ff469ef340fb6492 )
 )
 
 game (
@@ -8477,7 +9610,7 @@ game (
 
 game (
 	name "LED Storm (Europe)"
-	rom ( name "LEDStorm_v2.0_0934.lha" size 352043 crc 12752C3E sha1 e2dc9401944bf5682e88d4623aed9c42e1b443de )
+	rom ( name "LEDStorm_v2.0_0934.lha" size 352741 crc 6BAC6955 sha1 f4ad8d862d529d0e18cd0d35e4803745acb2e395 )
 )
 
 game (
@@ -8486,7 +9619,7 @@ game (
 )
 
 game (
-	name "Legacy (No Intro) (Europe)"
+	name "Legacy (Europe) (No Intro)"
 	rom ( name "Legacy_v1.0_NoIntro.lha" size 190222 crc AF4AC7D8 sha1 4bba9c23e0c5e251f6eb231cb28d6142d6bbc6a5 )
 )
 
@@ -8507,37 +9640,37 @@ game (
 
 game (
 	name "Legend of Faerghail (Europe)"
-	rom ( name "LegendOfFaerghail_v2.0b_2844.lha" size 1871217 crc D23A75AD sha1 cc043f7ddf66f877b4f5b946b7f0a10d3000ebae )
+	rom ( name "LegendOfFaerghail_v2.1_2844.lha" size 1872069 crc 4DA68A0B sha1 0f23af8cb7e46bb72a2bbf99b455e2948426a39b )
 )
 
 game (
 	name "Legend of Faerghail (Germany)"
-	rom ( name "LegendOfFaerghail_v2.0b_De_0524.lha" size 1880724 crc F0350712 sha1 181ac864d6698034d90cff7eadbf520b295bfd8e )
+	rom ( name "LegendOfFaerghail_v2.1_De_0524.lha" size 1881572 crc 9B065AF9 sha1 d1bcd01653c79e657d7b8afbaa6798decb681db3 )
 )
 
 game (
 	name "Legend of Faerghail (USA)"
-	rom ( name "LegendOfFaerghail_v2.0b_NTSC_2843.lha" size 1872274 crc B342AB28 sha1 b1241eb90b84b08058f58a31a7922a70fd1c6fc1 )
+	rom ( name "LegendOfFaerghail_v2.1_NTSC_2843.lha" size 1873114 crc EC2E6F00 sha1 e06b68da58347cdd8cc4f3630e5ef586f84b157d )
 )
 
 game (
 	name "Legend of Kyrandia, The - Book One (Europe)"
-	rom ( name "LegendOfKyrandia_v1.1_1575.lha" size 6069925 crc 1977726E sha1 b8a5cab1f5a46f65f2ec26ac293931ceda59bf5b )
+	rom ( name "LegendOfKyrandia_v2.0_1575.lha" size 6078532 crc 297539F9 sha1 137bd21843d391041b46d80a8b3cc83030554dc6 )
 )
 
 game (
 	name "Legend of Kyrandia, The - Book One (Germany)"
-	rom ( name "LegendOfKyrandia_v1.1_De_0372.lha" size 6076480 crc D32DBF41 sha1 cfd88cc78dd6766475ae22320432b2e28ed07671 )
+	rom ( name "LegendOfKyrandia_v2.0_De_0372.lha" size 6077626 crc 3452AB41 sha1 280a32ed1ab9853d7e559fae05b76e1ac111429f )
 )
 
 game (
 	name "Legend of Kyrandia, The - Book One (France)"
-	rom ( name "LegendOfKyrandia_v1.1_Fr.lha" size 6081362 crc 88748A56 sha1 de119c365771e0b96477845c4fd6dbb29a7b3da1 )
+	rom ( name "LegendOfKyrandia_v2.0_Fr.lha" size 6082492 crc 17F757B4 sha1 e28f8bd3a7b72308490a212f3fa4724168873dbb )
 )
 
 game (
 	name "Legend of Kyrandia, The - Book One (Italy)"
-	rom ( name "LegendOfKyrandia_v1.1_It.lha" size 6074351 crc 19601501 sha1 ab8ddfc63e9cd8aecd4f0c3c44f664700620ffaa )
+	rom ( name "LegendOfKyrandia_v2.0_It.lha" size 6075492 crc 456B7A4D sha1 0922332d19a767543cc8f25dff046e4b032ed8f2 )
 )
 
 game (
@@ -8546,13 +9679,13 @@ game (
 )
 
 game (
-	name "Legend of the Lost (Europe)"
-	rom ( name "LegendOfTheLost_v1.0_2971.lha" size 607074 crc 39DB9A94 sha1 f873679a24c4a0ca24da74bd0616c82a0b3cb76f )
+	name "Legend of the Lost (Europe) (En,Fr,De,Es,It)"
+	rom ( name "LegendOfTheLost_v1.02_2971.lha" size 610739 crc 395BB135 sha1 1bcfea8ba1e506a064c1ba50d862a3213a4a2757 )
 )
 
 game (
 	name "Legend of the Sword (Europe)"
-	rom ( name "LegendOfTheSword_v1.0_0797.lha" size 496661 crc 9E65E022 sha1 82adbb4c14ae5c212c1510b211f26dc25a57c0c2 )
+	rom ( name "LegendOfTheSword_v1.01_0797.lha" size 496633 crc A4F72656 sha1 a05c9b014f537610a98df11811ad91928907d024 )
 )
 
 game (
@@ -8571,12 +9704,12 @@ game (
 )
 
 game (
-	name "Legends of Valour (Germany)"
+	name "Legends of Valour - Volume 1 - The Dawning (Germany)"
 	rom ( name "LegendsOfValour_v1.0_De_0525.lha" size 1721543 crc 0BDA7AFF sha1 67050bdbf22493b813202f5e6f7bf74478997c95 )
 )
 
 game (
-	name "Legends of Valour (France)"
+	name "Legends of Valour - Volume 1 - The Dawning (France)"
 	rom ( name "LegendsOfValour_v1.0_Fr_1768.lha" size 1717212 crc 3FFABF30 sha1 6b3c5fce3776ec0718a4306a493860379d21eefc )
 )
 
@@ -8586,13 +9719,23 @@ game (
 )
 
 game (
+	name "Legions of Dawn (Europe)"
+	rom ( name "LegionsOfDawn_v1.0.lha" size 1094033 crc 18A071DA sha1 ddb4374cd24784dd8f066a39479f5b16e30952b2 )
+)
+
+game (
 	name "Leisure Suit Larry II - Leisure Suit Larry goes Looking for Love (Europe)"
-	rom ( name "LeisureSuitLarry2_v1.2_0193.lha" size 2454149 crc 830BAC13 sha1 b1aa9c5d7d497d9fa7c6a485495d7ed52aa019d0 )
+	rom ( name "LeisureSuitLarry2_v1.3_0193.lha" size 2454759 crc 321F9941 sha1 191f0557d0bac1854d9989c8f5ee44ae6f2956b0 )
 )
 
 game (
 	name "Leisure Suit Larry III - Passionate Patti in Pursuit of the Pulsating Pectorals (Europe)"
-	rom ( name "LeisureSuitLarry3_v1.4_0690.lha" size 2550115 crc EC7046BB sha1 fa74e73c8d60027de0156656cf5a0b1969d0c3af )
+	rom ( name "LeisureSuitLarry3_v2.4_0690.lha" size 2552181 crc B2233A47 sha1 61203e0517e2ddc7e43ad1917c111b67809f0b2b )
+)
+
+game (
+	name "Leisure Suit Larry III - Passionate Patti in Pursuit of the Pulsating Pectorals (Germany)"
+	rom ( name "LeisureSuitLarry3_v2.4_De.lha" size 3075142 crc B6161137 sha1 1ca4d09871b108f2642216d294dec072c9fc3c74 )
 )
 
 game (
@@ -8606,48 +9749,48 @@ game (
 )
 
 game (
-	name "Leisure Suit Larry 5 - Passionate Patti Macht Beim Geheimdienst Mit (MT32) (Germany)"
+	name "Leisure Suit Larry 5 - Passionate Patti Macht Beim Geheimdienst Mit (Germany) (MT32)"
 	rom ( name "LeisureSuitLarry5_v1.5_De_MT32.lha" size 5249313 crc FB527B96 sha1 e24908ae2d552bde4b950457c99ac7cda851edea )
 )
 
 game (
-	name "Leisure Suit Larry 5 - Passionate Patti Does a Little Undercover Work (MT32) (Europe)"
+	name "Leisure Suit Larry 5 - Passionate Patti Does a Little Undercover Work (Europe) (MT32)"
 	rom ( name "LeisureSuitLarry5_v1.5_MT32_2244.lha" size 4961562 crc C294DA3D sha1 54c10449da30b653fd94843782155982c1c91cce )
 )
 
 game (
-	name "Leisure Suit Larry in - The Land of the Lounge Lizards (Europe)"
+	name "Leisure Suit Larry in the Land of the Lounge Lizards (Europe)"
 	rom ( name "LeisureSuitLarry_v1.0_0349.lha" size 418548 crc AB0D2738 sha1 f90986970e701919b24d823a7c8e54b5a037dc2f )
 )
 
 game (
-	name "Leisure Suit Larry 1 - In the Land of the Lounge Lizards (Europe)"
-	rom ( name "LeisureSuitLarryEnhanced_v1.1.lha" size 2649649 crc 0072530E sha1 cfda018cf52e3eb5af717251f6b6fa150f0a50a8 )
+	name "Leisure Suit Larry in the Land of the Lounge Lizards (Europe) (Enhanced)"
+	rom ( name "LeisureSuitLarryEnhanced_v1.1.lha" size 2651066 crc B2A4DC46 sha1 9968ba10ea50966dadc0351d8b1884d9b220136b )
 )
 
 game (
-	name "Leisure Suit Larry 1 - In the Land of the Lounge Lizards (MT32) (Europe)"
-	rom ( name "LeisureSuitLarryEnhanced_v1.1_MT32.lha" size 2652328 crc C08F6D63 sha1 7419ec445ead844002495ecc82a7658ed69597e4 )
+	name "Leisure Suit Larry in the Land of the Lounge Lizards (Europe) (Enhanced) (MT32)"
+	rom ( name "LeisureSuitLarryEnhanced_v1.1_MT32.lha" size 2651110 crc 3A61082D sha1 3ba84558374880fa436ce5b6896515083b2bac2f )
 )
 
 game (
 	name "Lemmings 2 - The Tribes (Europe)"
-	rom ( name "Lemmings2_v1.6_1MB_0351.lha" size 2318837 crc C02F4CA7 sha1 33e6e433df751a94ad406c84326b47bfafbe41b8 )
+	rom ( name "Lemmings2_v1.8_1MB_0351.lha" size 2319192 crc 517F5F91 sha1 1aed7b98207c8849947f47f893966d17df5ac13b )
 )
 
 game (
 	name "Lemmings 2 - The Tribes (USA)"
-	rom ( name "Lemmings2_v1.6_1MB_NTSC_1976.lha" size 2323804 crc A3294D24 sha1 aca0a88765fa8b1886c719e0ff058c1c94a6d429 )
+	rom ( name "Lemmings2_v1.8_1MB_NTSC_1976.lha" size 2324156 crc 6F73B52E sha1 455b94c13f454895f98e4316e9f95c2dafb40509 )
 )
 
 game (
-	name "Lemmings 2 - The Tribes (512 KB) (Europe)"
-	rom ( name "Lemmings2_v1.6_512KB_0351.lha" size 2319007 crc B38E9A19 sha1 2d8b6bb58108ca02d04ff7e990ffef3c8fb95436 )
+	name "Lemmings 2 - The Tribes (Europe) (512 kB)"
+	rom ( name "Lemmings2_v1.8_512KB_0351.lha" size 2319363 crc 17E5A7F4 sha1 4006af3dfc98deb86bc973346551524a5c45c51d )
 )
 
 game (
-	name "Lemmings 2 - The Tribes (512 KB) (USA)"
-	rom ( name "Lemmings2_v1.6_512KB_NTSC_1976.lha" size 2323980 crc D3D3FF5A sha1 7c14599af5150b9fbf76f627cbdb2afed9cc6a73 )
+	name "Lemmings 2 - The Tribes (USA) (512 kB)"
+	rom ( name "Lemmings2_v1.8_512KB_NTSC_1976.lha" size 2324332 crc C996F08C sha1 3fcfe852e57303d4fb19921ad5efb8aeaa29dfe7 )
 )
 
 game (
@@ -8676,17 +9819,17 @@ game (
 )
 
 game (
-	name "Lemmings (Image) (Europe)"
+	name "Lemmings (Europe) (Image)"
 	rom ( name "Lemmings_v1.5_Image_2089.lha" size 1496496 crc DA05C6AC sha1 60f8b964ab97d779750812539ef173757c441161 )
 )
 
 game (
-	name "Lemmings (Image) (Alt. Levels) (Europe)"
+	name "Lemmings (Europe) (Image) (Alt. Levels)"
 	rom ( name "Lemmings_v1.5_Image_AltLevels_2238.lha" size 1498116 crc CB11BA0D sha1 f33874d0a7643f22192b484050e1d6d79eb1e8fc )
 )
 
 game (
-	name "Lemmings (Image) (USA)"
+	name "Lemmings (USA) (Image)"
 	rom ( name "Lemmings_v1.5_Image_NTSC_0901.lha" size 1493072 crc 0463BACE sha1 7cebe6fcfab4e966e01a608cf997e3a0ba2018e0 )
 )
 
@@ -8731,18 +9874,23 @@ game (
 )
 
 game (
-	name "Leonardo (High Density) (Europe)"
+	name "Leonardo (Europe) (High Density)"
 	rom ( name "Leonardo_v1.1_HighDensity.lha" size 491733 crc A7B30244 sha1 2980ecaf0430f636b5e4f587ae8d3a55a6fefec0 )
 )
 
 game (
 	name "Les Manley in - Search for The King (Europe)"
-	rom ( name "LesManleyInSearchForTheKing_v1.2.lha" size 2332339 crc 6B295753 sha1 5d35f83e9978e150646222a2c9ede164cbcbbb26 )
+	rom ( name "LesManleyInSearchForTheKing_v1.3_2671.lha" size 2331929 crc D4C62B15 sha1 429c83c18ec034935e657200b0224287cd17fa3d )
+)
+
+game (
+	name "Bases De L Écrit Niveau 6ème/3ème, Les (France)"
+	rom ( name "LEssentialMathsNiveau6eme_v1.0_Fr.lha" size 335163 crc 5CE08FBF sha1 1baf1d1d0f9a2f36287c005778f1363bd4de0309 )
 )
 
 game (
 	name "Lethal Weapon (Europe)"
-	rom ( name "LethalWeapon_v1.3_0814.lha" size 870520 crc 3C7B01A7 sha1 9ea0b5a24acb06ae71e063b33ecb5077fbc771dc )
+	rom ( name "LethalWeapon_v2.1_0814.lha" size 876132 crc 5524CA7C sha1 7a44c841321dd3b17412082828fcaa15a3807006 )
 )
 
 game (
@@ -8777,7 +9925,7 @@ game (
 
 game (
 	name "Light Corridor, The (Europe)"
-	rom ( name "LightCorridor_v1.0_0526.lha" size 573193 crc 7F0AD300 sha1 210c875c10a26482e28eb368f3a073b206e61462 )
+	rom ( name "LightCorridor_v2.0_0526.lha" size 244124 crc 569C6322 sha1 6effda04629268992e1a28889ed393f210e61d0a )
 )
 
 game (
@@ -8787,7 +9935,7 @@ game (
 
 game (
 	name "Limes and Napoleon (Europe)"
-	rom ( name "Limes&Napoleon_v1.0.lha" size 530927 crc 7CEA5836 sha1 05a4a027f16cafbb25e9ebacda25a5e797f35678 )
+	rom ( name "Limes&Napoleon_v1.1_2983.lha" size 531275 crc 3DAFF2CA sha1 39dd0a6fcfac7447b8c1b10456c3286610f8e15c )
 )
 
 game (
@@ -8826,7 +9974,7 @@ game (
 )
 
 game (
-	name "Lionheart (1 MB) (Europe) (Demo)"
+	name "Lionheart (Europe) (Demo) (1 MB)"
 	rom ( name "LionheartDemo_v1.2_1MB.lha" size 416607 crc 0AD6A6C8 sha1 1f4474f567328d055025d9bd2114cbbd901649ff )
 )
 
@@ -8837,12 +9985,12 @@ game (
 
 game (
 	name "Liquid Kids (Europe)"
-	rom ( name "LiquidKids_v1.1_Files.lha" size 833999 crc D2E4FB81 sha1 2f52da22b7dc47be065e8d5be105f115c057ea0d )
+	rom ( name "LiquidKids_v1.3_Files.lha" size 826035 crc FDFDEF61 sha1 e676afdf0821adf3976325232212136a56749d0f )
 )
 
 game (
-	name "Liquid Kids (Image) (Europe)"
-	rom ( name "LiquidKids_v1.1_Image.lha" size 818487 crc 3B83E6F9 sha1 beb0423c3f17f5ec641e31c230a42fd74b74571e )
+	name "Liquid Kids (Europe) (Image)"
+	rom ( name "LiquidKids_v1.3_Image.lha" size 819297 crc 36F02B7A sha1 bc295037f844c480ee1c9f42208769fa5e072fb2 )
 )
 
 game (
@@ -8856,13 +10004,34 @@ game (
 )
 
 game (
+	name "Little Princess 2 (Europe) (PD/Freeware)"
+	rom ( name "LittlePrincess2_v1.1.lha" size 527857 crc 5C65086D sha1 a1e2c96e9ee77bdcc2fc156fa97619c5143afc82 )
+)
+
+game (
+	name "Little Princess (Europe) (PD/Freeware)"
+	rom ( name "LittlePrincess_v1.0.lha" size 276719 crc 6A9AA24E sha1 4fe13aaf8e87f4c69ac46ccbd0402bb00c6181f2 )
+)
+
+game (
 	name "Little Puff in Dragonland (Europe)"
 	rom ( name "LittlePuffInDragonland_v1.0.lha" size 355198 crc DE2669F8 sha1 4f173a86fad5870e1595f1b73d604f68e96700a6 )
 )
 
 game (
+	name "Little Red Riding Hood (Europe)"
+	rom ( name "LittleRedRidingHood_v1.0.lha" size 950835 crc 7C768B7C sha1 e5adf8ec5b9515b97059bafb21a79d74ab9ad711 )
+)
+
+
+game (
 	name "Live and Let Die (Europe)"
 	rom ( name "LiveAndLetDie_v1.1_2187.lha" size 338923 crc 088CC1CF sha1 7dc81710112d1668a6904ac688398bce749245d5 )
+)
+
+game (
+	name "Liverpool - The Computer Game (Europe)"
+	rom ( name "Liverpool_v1.0_0528.lha" size 908033 crc 60F9D467 sha1 685e38ad628453e23f70eaa04c0fd36a120a55ed )
 )
 
 game (
@@ -8876,73 +10045,83 @@ game (
 )
 
 game (
-	name "Llamatron - 2112 (512 KB) (Europe)"
+	name "Llamatron - 2112 (Europe) (512 kB)"
 	rom ( name "Llamatron_v1.1_512KB.lha" size 144091 crc 71B06631 sha1 5e4a589258b1d48fea9d3064223c9b152533e726 )
 )
 
 game (
-	name "Locomotion (Europe)"
-	rom ( name "Locomotion_v1.0.lha" size 260810 crc 77E58603 sha1 49dd1f9ff64707e36785d8819cda486be788b8b7 )
+	name "Locomotion (Germany) (Kingsoft)"
+	rom ( name "Locomotion_v1.1_Kingsoft_De.lha" size 274360 crc A191B1A3 sha1 43b42dcc30cb236f4706a961997a72c509e84026 )
 )
 
 game (
 	name "Log!cal (Europe)"
-	rom ( name "Logical_v1.1_0529.lha" size 440338 crc 5DD5FF9C sha1 8aff9cab82f49e87c1fd1cd1a6e43bf11eb4b2a1 )
+	rom ( name "Logical_v1.2_0529.lha" size 443082 crc CF2C7BBF sha1 03379d520a25c5864f6156477c78c29105f004b0 )
 )
 
 game (
 	name "Log!cal (Europe) (CDTV)"
-	rom ( name "Logical_v1.1_CDTV.lha" size 423165 crc 5D75BDF0 sha1 05f056d6cfee55993fa247c7bda10fc859b27971 )
+	rom ( name "Logical_v1.2_CDTV.lha" size 425921 crc 18CEF6FB sha1 d5620e4af3e3644ebf061dc9dcba9088edb37602 )
 )
 
 game (
 	name "Logo (Europe)"
-	rom ( name "Logo_v1.0.lha" size 1400600 crc A378B46A sha1 1b695d19d440f38da47360f8dc237471807d6a2d )
+	rom ( name "Logo_v1.1.lha" size 1401323 crc F30B1985 sha1 3e70f4721ec63510367d680eeefa9f6a0042949e )
 )
 
 game (
 	name "Lollypop (Europe)"
-	rom ( name "Lollypop_v1.0.lha" size 3401702 crc 2566BD5C sha1 b3bdc2bc46cde615292e4608dfc85fb80e704c49 )
+	rom ( name "Lollypop_v2.0_2864.lha" size 3325109 crc B3CD3E6A sha1 f8d659380f730a56c1e775acb90d72e82e85d557 )
 )
 
 game (
 	name "Lombard RAC Rally (Europe) (Budget - The Hit Squad)"
-	rom ( name "LombardRACRally_v1.1_1Disk_1144.lha" size 463171 crc 5504C524 sha1 8e60fee754f4a68bed0f445f56aed7500bc736e0 )
+	rom ( name "LombardRACRally_v2.0_1Disk_1144.lha" size 466815 crc 98859D01 sha1 147ec80701fcd47228106611d44fbc82d68cf83d )
+)
+
+game (
+	name "Lombard RAC Rally (Germany) (Budget - The Hit Squad)"
+	rom ( name "LombardRACRally_v2.0_1Disk_De_1928.lha" size 467084 crc FD9BA18D sha1 dc433f49f1d812fad960de4f294c423eff02d856 )
 )
 
 game (
 	name "Lombard RAC Rally (Europe)"
-	rom ( name "LombardRACRally_v1.1_2Disk_1098.lha" size 488308 crc C86B8C5A sha1 230ed5fa2e52090b3d6b1fa20fdbe1847b0a829a )
+	rom ( name "LombardRACRally_v2.0_2Disk_1098.lha" size 579788 crc 927C5427 sha1 179ec5e6181139b3188b5ec83a8f1501291c6fd6 )
+)
+
+game (
+	name "Lombard RAC Rally (Germany)"
+	rom ( name "LombardRACRally_v2.0_2Disk_De.lha" size 581193 crc 21EF5F58 sha1 7cf23e131c8c698616d748895ff1280f467b9ce7 )
 )
 
 game (
 	name "Loom (Europe)"
-	rom ( name "Loom_v2.0-C_0618.lha" size 1203337 crc 92A29731 sha1 46bd828cdcb5eea467cf6ab6f3c0b95b94f87551 )
+	rom ( name "Loom_v2.1_0618.lha" size 1203636 crc 81EF31BF sha1 e98ba71035332e42a268cb0b1b69f787fbd9d6e3 )
 )
 
 game (
 	name "Loom (Germany)"
-	rom ( name "Loom_v2.0-C_De_0075.lha" size 1208317 crc 9D5A1E4B sha1 c2f87d250faed790f4222f65b37d64ec96ad33b8 )
+	rom ( name "Loom_v2.1_De_0075.lha" size 1208615 crc DDBA3C44 sha1 4016dea651e9b3493c5a7550955785a260a820d0 )
 )
 
 game (
 	name "Loom (Germany) (CDTV)"
-	rom ( name "Loom_v2.0-C_De_CDTV.lha" size 1234718 crc 327B1238 sha1 cf72304298e7ac95cdd14eb8926e9117c8bf427e )
+	rom ( name "Loom_v2.1_De_CDTV.lha" size 1235014 crc 0370CB94 sha1 b5d58de18021ac025ffee61093f9c1bf34aa243b )
 )
 
 game (
 	name "Loom (Spain)"
-	rom ( name "Loom_v2.0-C_Es.lha" size 1212534 crc B9116D47 sha1 9c6c583b41cf08f2fe95fee3490d643a4d4f8544 )
+	rom ( name "Loom_v2.1_Es.lha" size 1212830 crc DA42B1D2 sha1 d10337129515a50b437c8041b4e4865f4ace46cb )
 )
 
 game (
 	name "Loom (France)"
-	rom ( name "Loom_v2.0-C_Fr.lha" size 1207677 crc 98566FD6 sha1 0bf085dd1e82b8df7b40c6e3eec0cecd396ca6b6 )
+	rom ( name "Loom_v2.1_Fr.lha" size 1207973 crc 84C24747 sha1 721693e1c2e9916d3ee5d2fa31c5a4a7f35807e1 )
 )
 
 game (
 	name "Loom (Italy)"
-	rom ( name "Loom_v2.0-C_It.lha" size 1205409 crc C5363CF2 sha1 893cd30bc0db481b60eeb7380982023284dee1f2 )
+	rom ( name "Loom_v2.1_It.lha" size 1205701 crc 8C71BDD5 sha1 7f72c92c0f47936b68a453925806243c7cd5e119 )
 )
 
 game (
@@ -8951,7 +10130,7 @@ game (
 )
 
 game (
-	name "Lords of Chaos (Europe)"
+	name "Lords of Chaos & Expansion Kit One (Europe) (En,Fr,De)"
 	rom ( name "LordsOfChaos&DataDisk_v1.2.lha" size 1330901 crc EF6CB47A sha1 c04dfe9f5e61497105d132c4c77763df75204b71 )
 )
 
@@ -8981,12 +10160,12 @@ game (
 )
 
 game (
-	name "Lords of the Realm (Fast) (Germany) (AGA)"
+	name "Lords of the Realm (Germany) (AGA) (Fast)"
 	rom ( name "LordsOfTheRealm_v1.0_AGA_De_Fast.lha" size 2893080 crc 41434CAB sha1 6741e0f3d191ad24f000a5b95cc554a7ffb3196e )
 )
 
 game (
-	name "Lords of the Realm (Fast) (Europe) (AGA)"
+	name "Lords of the Realm (Europe) (AGA) (Fast)"
 	rom ( name "LordsOfTheRealm_v1.0_AGA_Fast.lha" size 2890727 crc 26C91B2C sha1 4f26cefd1da1f50ba0406737164c558aa63d514c )
 )
 
@@ -8996,7 +10175,7 @@ game (
 )
 
 game (
-	name "Lords of the Realm (Fast) (France) (AGA)"
+	name "Lords of the Realm (France) (AGA) (Fast)"
 	rom ( name "LordsOfTheRealm_v1.0_AGA_Fr_Fast_2445.lha" size 2890720 crc 6AE96F8D sha1 f8438b45ec714a7251a45bcac4ce8576b082dddc )
 )
 
@@ -9022,7 +10201,7 @@ game (
 
 game (
 	name "Lorna (Europe)"
-	rom ( name "Lorna_v1.0a.lha" size 682702 crc 6DCD4F98 sha1 d344cb4f082a005676d8f8b3667c4793bd18a819 )
+	rom ( name "Lorna_v1.1.lha" size 694131 crc 16B6FB76 sha1 efec93f8eeafc66ae5bf8694a89c7d4f4cccf891 )
 )
 
 game (
@@ -9031,23 +10210,18 @@ game (
 )
 
 game (
-	name "Templos Sagrados, Los (Spain)"
-	rom ( name "LosTemplosSagrados_v1.0_Es.lha" size 1740129 crc 4D710C65 sha1 c225d0b6f3604e719aa91219bc70837341caeefa )
-)
-
-game (
-	name "Lost In Mine (Poland)"
+	name "Lost in Mine (Poland)"
 	rom ( name "LostInMine_v1.1_Pl.lha" size 1440682 crc D61E5E0B sha1 37399616e538b7a45b6fabed454eb458fca3f01e )
 )
 
 game (
-	name "Lost Patrol (Europe)"
-	rom ( name "LostPatrol_v1.3_0773.lha" size 1474774 crc FD5151CC sha1 844206cf387e5c6611e814716ea4c59905f89100 )
+	name "Lost Patrol (Europe) (En,Fr,De)"
+	rom ( name "LostPatrol_v2.1_0773.lha" size 1474378 crc 88D1F463 sha1 3c045284f679d2fc1457a360088750cfc9b14b55 )
 )
 
 game (
 	name "Lost Patrol (USA)"
-	rom ( name "LostPatrol_v1.3_NTSC_0498.lha" size 1475749 crc F5B22EF8 sha1 f05ac12276282319a445f0394d47f14f6ee7e6d3 )
+	rom ( name "LostPatrol_v2.1_NTSC_0498.lha" size 1475200 crc CAE9E4D0 sha1 df64b270f4c8e661a19c578fcecdd8e10d93e057 )
 )
 
 game (
@@ -9081,6 +10255,11 @@ game (
 )
 
 game (
+	name "Lothar Matthäus Super Soccer (Germany)"
+	rom ( name "LotharMatthaeusSuperSoccer_v1.0_De_1728.lha" size 1187544 crc 17FB972F sha1 d0ecf91bed2d1ec95df6b413da5cf3031b430e51 )
+)
+
+game (
 	name "Lothar Matthaus - Die Interaktive Fussballsimulation (Germany) (En)"
 	rom ( name "LotharMatthausDieInteraktiveFussballsimulation_v1.1.lha" size 1050331 crc 52E3CC80 sha1 d8d3b4da6f0ad3b5afde5a27e0c22ebf3b998782 )
 )
@@ -9088,6 +10267,11 @@ game (
 game (
 	name "Lotus Turbo Challenge 2 (Europe)"
 	rom ( name "Lotus2_v1.13_0497.lha" size 921350 crc 4748594D sha1 f34c1757ecd09d9d4c6426788e02a23bfc2aaed3 )
+)
+
+game (
+	name "Lotus Turbo Challenge 2 (Europe) (CD32)"
+	rom ( name "Lotus2_v1.13_CD32.lha" size 853746 crc 1DC67840 sha1 d558d9e0814047c598bb72ccfd9274bd17fce499 )
 )
 
 game (
@@ -9101,7 +10285,7 @@ game (
 )
 
 game (
-	name "Classic Lotus Trilogy, The (Europe) (CD32)"
+	name "Lotus Esprit Turbo Challenge (Europe) (CD32)"
 	rom ( name "Lotus_v1.1_CD32.lha" size 760963 crc 5E61CC52 sha1 efe69ac2395f554322655e6a79d102eab1492243 )
 )
 
@@ -9117,22 +10301,22 @@ game (
 
 game (
 	name "Lure of the Temptress (Europe)"
-	rom ( name "LureOfTheTemptress_v1.4.lha" size 2608773 crc B830C1A0 sha1 addd1cf07445c80da8ba09d7fc76096a2ddd248f )
+	rom ( name "LureOfTheTemptress_v2.2_2030.lha" size 2606956 crc B1E4772F sha1 e6d92585369130d83d9dc8e9d9443b668c5d39d5 )
 )
 
 game (
 	name "Lure of the Temptress (Germany)"
-	rom ( name "LureOfTheTemptress_v1.4_De.lha" size 2578388 crc 96421ACA sha1 0a55b68032bae091bffccd4b390807e583b8903a )
+	rom ( name "LureOfTheTemptress_v2.2_De.lha" size 2572627 crc 5BD42AE5 sha1 e2b3e4a5eab24507153e5c4c1c71e2a1b150095d )
 )
 
 game (
 	name "Lure of the Temptress (France)"
-	rom ( name "LureOfTheTemptress_v1.4_Fr_2040.lha" size 2576856 crc 81F33A8E sha1 376f571cbf787fae008a7349b17f0599a690c534 )
+	rom ( name "LureOfTheTemptress_v2.2_Fr_2040.lha" size 2571090 crc E0BAE384 sha1 2a673bd8a234afdcb311194fbed5bace395b2e1f )
 )
 
 game (
 	name "Lure of the Temptress (Italy)"
-	rom ( name "LureOfTheTemptress_v1.4_It_2028.lha" size 2589360 crc 7FB99172 sha1 f9ddb8f927dd98772323deb0343537fd2d48dd29 )
+	rom ( name "LureOfTheTemptress_v2.2_It_2028.lha" size 2583595 crc 190D2540 sha1 cb47bead2d994057c1f5f88136c58a42b25ac46c )
 )
 
 game (
@@ -9147,12 +10331,12 @@ game (
 
 game (
 	name "Mach 3 (Europe)"
-	rom ( name "Mach3_v1.0_2638.lha" size 443768 crc 9F3D0CEA sha1 af86aa273b2ebff41cb0dcc3d2455573be153a32 )
+	rom ( name "Mach3_v1.1_2638.lha" size 383838 crc 1696CF82 sha1 20084d2233127ee4725fddef2633c05de7ac94f0 )
 )
 
 game (
 	name "Mad Professor Mariarti (Europe)"
-	rom ( name "MadProfessorMariarti_v1.2_0662.lha" size 413092 crc 93461C96 sha1 7a008d435dc47664b6ff0613662741d3337e9750 )
+	rom ( name "MadProfessorMariarti_v1.4_0662.lha" size 418119 crc 060A06D8 sha1 c6b9e79e1b89289ba5c57b2b3377d6ea6856e0cd )
 )
 
 game (
@@ -9167,22 +10351,32 @@ game (
 
 game (
 	name "Mad TV (Europe)"
-	rom ( name "MadTV_v1.1.lha" size 851685 crc 01D6DEE3 sha1 6f51b137a43978ed1167566549800cd6e85b15e0 )
+	rom ( name "MadTV_v1.2.lha" size 798551 crc F6A67E0B sha1 c810ebc29fc22610b76b492c7e883d89b96d60d3 )
 )
 
 game (
 	name "Mad TV (Germany)"
-	rom ( name "MadTV_v1.1_De_0533.lha" size 956721 crc 2D1DB62A sha1 cfea144bffc0446bf05cac538d4c56a11f5e3e57 )
+	rom ( name "MadTV_v1.2_De_0533.lha" size 779831 crc 3C2FD5D7 sha1 7283a5587da4e64bcfc3852ae0b32206220e47fb )
+)
+
+game (
+	name "Mad TV (Spain)"
+	rom ( name "MadTV_v1.2_Es.lha" size 798961 crc 90A7A537 sha1 9c77628942facb556e3bce527c85b809e989a875 )
 )
 
 game (
 	name "Mad TV (France)"
-	rom ( name "MadTV_v1.1_Fr.lha" size 956766 crc F23F7B4F sha1 207f1aa5088bb29c612411fd4c6700f0db880bcf )
+	rom ( name "MadTV_v1.2_Fr.lha" size 779841 crc 84E1A42D sha1 d8bc2fd57d03134c42d6e81ea9b7fc1675fa0f99 )
 )
 
 game (
 	name "Mafdet and the Book of the Dead (Europe)"
 	rom ( name "MafdetAndTheBookOfTheDead_v1.0.lha" size 130135 crc CD14D415 sha1 702be2cfc25e2ea116765c59fe2f181bd8e91a05 )
+)
+
+game (
+	name "Magica (Europe) (PD/Freeware)"
+	rom ( name "Magica_v1.01.lha" size 120110 crc AF985932 sha1 7425d6dedb3df404eb84909695d8af59751646ca )
 )
 
 game (
@@ -9196,7 +10390,7 @@ game (
 )
 
 game (
-	name "Magic Fly (512 KB) (Europe)"
+	name "Magic Fly (Europe) (512 kB)"
 	rom ( name "MagicFly_v1.0_512KB.lha" size 330428 crc 1DB7DC24 sha1 8c5002a90b6149eeda1b2160e45325241749bcbb )
 )
 
@@ -9211,13 +10405,13 @@ game (
 )
 
 game (
-	name "Magic Johnson's Fast Break (Arcadia) (Europe)"
+	name "Magic Johnson's Fast Break (Europe) (Arcadia)"
 	rom ( name "MagicJohnsonsFastBreak_v0.1_Arcadia.lha" size 555144 crc A7B3C1F9 sha1 0f91808a33ec7b6aa4855f0f89c474e079ed197a )
 )
 
 game (
 	name "Magicland Dizzy (Europe)"
-	rom ( name "MagiclandDizzy_v1.5_1145.lha" size 437004 crc 85204867 sha1 9a8748b7ef23a3c3eb48993c620db93915bd42f3 )
+	rom ( name "MagiclandDizzy_v1.6_1145.lha" size 412914 crc BAA3269A sha1 77858b10ee9d51d1d2ef906d28dcaa9c12fc9dbc )
 )
 
 game (
@@ -9227,22 +10421,32 @@ game (
 
 game (
 	name "Magic Marble (Europe)"
-	rom ( name "MagicMarble_v1.0.lha" size 437762 crc 05C966D9 sha1 555a2d417e721587ce4f63dc59cf37279e8cd711 )
+	rom ( name "MagicMarble_v1.2_2188.lha" size 438428 crc 4FDFF292 sha1 97eb7635ebff20e18546af7cf341a27688689cad )
 )
 
 game (
 	name "Magic Pockets (Europe)"
-	rom ( name "MagicPockets_v3.0_0917.lha" size 876509 crc 4D720126 sha1 cce59a21c0e307f002519c6c324869b104ae3459 )
+	rom ( name "MagicPockets_v3.3_0917.lha" size 877902 crc AF3741F3 sha1 d37998bf03b124c8163a6306c0b9145f3145707d )
 )
 
 game (
 	name "Magic Pockets (USA)"
-	rom ( name "MagicPockets_v3.0_NTSC.lha" size 876787 crc 6CDF2ADB sha1 d8858bebd79cc3a761fb4d9864c1788fd1719504 )
+	rom ( name "MagicPockets_v3.3_NTSC.lha" size 878184 crc 73C86BA7 sha1 e828f175cacc26f3f2f08030347f56e01a8e131c )
 )
 
 game (
 	name "Magic Pockets (Europe) (Demo)"
 	rom ( name "MagicPocketsDemo_v1.0.lha" size 237371 crc E4334B99 sha1 de8e61ad8635a556166bb4c9cc4a9191c315f749 )
+)
+
+game (
+	name "Magic Serpent (Europe)"
+	rom ( name "MagicSerpent_v1.0.lha" size 348330 crc 947F8570 sha1 7e07f95d24793af6323165d0eb91464103bc3f3f )
+)
+
+game (
+	name "Magic Serpent (Europe) (CDTV)"
+	rom ( name "MagicSerpent_v1.0_CDTV.lha" size 336314 crc 136517F7 sha1 7b3413f583c7d8a4cc457f92e57691669dee5c3e )
 )
 
 game (
@@ -9253,6 +10457,16 @@ game (
 game (
 	name "Major Motion (Europe)"
 	rom ( name "MajorMotion_v1.0_1756.lha" size 183039 crc 21A444DA sha1 2522e0bb2a9a52d918bc7358c62e0e5cab4294c6 )
+)
+
+game (
+	name "Manager, The (Europe)"
+	rom ( name "Manager_v1.02_1310.lha" size 976870 crc 5AC93A91 sha1 72394974d012e67a0c5849c396d137aa7955fd79 )
+)
+
+game (
+	name "Manager, The (Italy)"
+	rom ( name "Manager_v1.02_It.lha" size 994207 crc 19751229 sha1 3e8a556222ba72bbdbaf0510261b7ada1b8cade7 )
 )
 
 game (
@@ -9277,12 +10491,12 @@ game (
 
 game (
 	name "Manchester United - Premier League Champions - 1994-95 Season Data Disk (Europe)"
-	rom ( name "ManchesterUnitedPLC&DataDisks_v1.01_1789&1790.lha" size 2090275 crc 48244BF0 sha1 a6caf00297ee90c6c68b40890a78d85dc0e4ca0e )
+	rom ( name "ManchesterUnitedPLC&DataDisk_v1.04_1789&1790.lha" size 2090555 crc D83A0499 sha1 fe4eadffb65aa9e60ad86bad94f63bb1f69407f1 )
 )
 
 game (
 	name "Manchester United - Premier League Champions (Europe)"
-	rom ( name "ManchesterUnitedPLC_v1.01_1790.lha" size 1398870 crc 008CD08B sha1 f13b1cd44447dc650c0ae5289251ee47aca6d883 )
+	rom ( name "ManchesterUnitedPLC_v1.04_1790.lha" size 1399200 crc A1B35A95 sha1 a13eed79c74ab511a10027997fa91e08807793fa )
 )
 
 game (
@@ -9297,12 +10511,17 @@ game (
 
 game (
 	name "Manhattan Dealers (Europe)"
-	rom ( name "ManhattanDealers_v1.2.lha" size 372776 crc 0A8C81F8 sha1 9598f6e38be3a1defb147ad3d4aa9fd96cfda4f6 )
+	rom ( name "ManhattanDealers_v2.1_0353.lha" size 373120 crc ADB2B8E5 sha1 8485324318d87870aeb0bd1ea51fd11c4bb611cc )
+)
+
+game (
+	name "Manhattan Dealers (Germany)"
+	rom ( name "ManhattanDealers_v2.1_De.lha" size 353831 crc F58B55C1 sha1 2318640ab67e6dd3f32e6dee56b62bcbe004a9d8 )
 )
 
 game (
 	name "Manhattan Dealers (France)"
-	rom ( name "ManhattanDealers_v1.2_Fr.lha" size 352589 crc 3BC4DEBB sha1 c557305946db450c3beb58e7932ef7b3cc17ff09 )
+	rom ( name "ManhattanDealers_v2.1_Fr.lha" size 352938 crc 9CBFFC94 sha1 f52c303da3fa8d1f7dd5a43f00a11429fed99d98 )
 )
 
 game (
@@ -9336,28 +10555,33 @@ game (
 )
 
 game (
+	name "Maniac Mansion (Italy)"
+	rom ( name "ManiacMansion_v1.6_It.lha" size 594158 crc 24CDDA4B sha1 d9ada2eb792b9fe764ae5f0afc8ad098be41ee90 )
+)
+
+game (
 	name "Maniax (Europe)"
 	rom ( name "Maniax_v2.0.lha" size 294686 crc 15754571 sha1 ba2b5b3f2eb11a1939a2f8c99aac73c7fdeb83eb )
 )
 
 game (
 	name "Manic Miner (Europe)"
-	rom ( name "ManicMiner_v0501.2_1116.lha" size 576795 crc 8C228853 sha1 dfc1075b5f3c48fc4892dfe59f31b17265197840 )
+	rom ( name "ManicMiner_v2.0_1116.lha" size 574203 crc 4ECD02DB sha1 78e4e436b74b2c275ab157898c4878529191a090 )
 )
 
 game (
 	name "Manix (Europe)"
-	rom ( name "Manix_v1.1_2533.lha" size 513815 crc E64DCE2A sha1 87966de6d90f606eb56be382850119662147d957 )
+	rom ( name "Manix_v2.0_2533.lha" size 297407 crc 59F3DAD9 sha1 f53d4e5a1c43c67000761bf89421748b9ba8082b )
 )
 
 game (
 	name "Manoir de Mortvielle, Le (France)"
-	rom ( name "ManoirDeMortvielle_v1.1a_Fr_2148.lha" size 616952 crc 33379BFC sha1 52484836060e37e4faabe201aa916398a2f56ee3 )
+	rom ( name "ManoirDeMortvielle_v2.0_Fr_2148.lha" size 615901 crc B2FC653F sha1 d41644b8cb567dd83611d22ad7cb75512a81dd92 )
 )
 
 game (
 	name "Marble Madness (Europe)"
-	rom ( name "MarbleMadness_v2.2_0013.lha" size 398000 crc CFEDFE2F sha1 eaae4a747428edacb36500ea59d2103bff03ec13 )
+	rom ( name "MarbleMadness_v2.3_0013.lha" size 398169 crc 3C981923 sha1 8d1f87563787948ced0cad9fae50107db91eb961 )
 )
 
 game (
@@ -9377,7 +10601,7 @@ game (
 
 game (
 	name "Master Axe - The Genesis of MysterX (Europe)"
-	rom ( name "MasterAxe_v1.1.lha" size 2388764 crc E7489F6C sha1 e599e652c619e60e78b9791c65096f1c824b55b1 )
+	rom ( name "MasterAxe_v2.2.lha" size 2390006 crc 2F9B0AF9 sha1 ec837d10b314fb9154d7d6b307edd1e97487f34b )
 )
 
 game (
@@ -9387,7 +10611,7 @@ game (
 
 game (
 	name "Masterblazer (Europe)"
-	rom ( name "Masterblazer_v1.2_0699.lha" size 895238 crc 8C8AD310 sha1 c6ed07bb259a4fd0d7fcb4131698d825f08b3149 )
+	rom ( name "Masterblazer_v2.0_0699.lha" size 906262 crc A54D241F sha1 41d1b6c2b94a695f41567fad78027b6ada1f6b27 )
 )
 
 game (
@@ -9427,7 +10651,17 @@ game (
 
 game (
 	name "MAX Rally (Europe)"
-	rom ( name "MaxRally_v1.1.lha" size 1016676 crc 2FBAE9A0 sha1 753174cf083601a3c138793b41288eab97a7cee3 )
+	rom ( name "MaxRally_v1.3.lha" size 1036281 crc 9986E140 sha1 d2efcfb22ed1be5c013b7a7dca08b5f7709daeb7 )
+)
+
+game (
+	name "MAX Rally (Europe) (AGA)"
+	rom ( name "MaxRally_v1.3_AGA.lha" size 1036785 crc 1EE35445 sha1 e215ba619b8320f5298b831efd67932729a2d6e8 )
+)
+
+game (
+	name "MAX Rally (Europe) (Low Mem)"
+	rom ( name "MaxRally_v1.3_LowMem.lha" size 1037277 crc 593EE6E9 sha1 e63159df19ac41f8bff4395d2b82bbaee030e96d )
 )
 
 game (
@@ -9441,33 +10675,43 @@ game (
 )
 
 game (
-	name "Maya (Fast) (Spain)"
+	name "Maya (Spain) (Fast)"
 	rom ( name "Maya_v1.4_Es_Fast.lha" size 572180 crc 1A2891CD sha1 dfb46558b3705f05ed16aa349a6ae87451048505 )
 )
 
 game (
-	name "Maya (Fast) (Europe)"
+	name "Maya (Europe) (Fast)"
 	rom ( name "Maya_v1.4_Fast_1742.lha" size 564291 crc 6C261113 sha1 11326a44eea971dada982a5f424f5feea401e5b7 )
 )
 
 game (
 	name "Maya (France)"
-	rom ( name "Maya_v1.4_Fr.lha" size 570008 crc 1F4F6D7F sha1 f5e8df9ff316219c50cb73536f9c761198edea5d )
+	rom ( name "Maya_v1.4_Fr.lha" size 571400 crc F274B7D5 sha1 2095ffb740ef83b3ccbbb907b1c6884392db1f01 )
 )
 
 game (
-	name "Maya (Fast) (France)"
-	rom ( name "Maya_v1.4_Fr_Fast.lha" size 570262 crc 65CAE287 sha1 3fc7b0ed91634e728b9cccf087531e85d19e547f )
+	name "Maya (France) (Fast)"
+	rom ( name "Maya_v1.4_Fr_Fast.lha" size 571665 crc E9C1788B sha1 62122e8d2f3b89ab500aa6863029ef0850ac9db4 )
 )
 
 game (
-	name "Mayday Squad Heroes (Europe)"
-	rom ( name "MaydaySquadHeroes_v1.0_2219.lha" size 590522 crc 09AF5128 sha1 9e42016858344edb55077be9892495a22f232497 )
+	name "Mayday Squad (Europe)"
+	rom ( name "MaydaySquad_v2.0_2219.lha" size 581574 crc E0DF2577 sha1 9980fb3cba014b9b2ba1f7175942cf9781d8f1a5 )
+)
+
+game (
+	name "Mayday Squad (France)"
+	rom ( name "MaydaySquad_v2.0_Fr.lha" size 581670 crc F274C5BE sha1 9b11fbc5c992217c8298243cf3f55600e6f0d314 )
 )
 
 game (
 	name "McDonaldland (Europe)"
-	rom ( name "McDonaldLand_v1.4.1_0970.lha" size 634084 crc 974E1D58 sha1 fd5472e3f5fc9fc78758e8bd0cc60032c509f1ce )
+	rom ( name "McDonaldLand_v1.5_0970.lha" size 635740 crc 5BDCF947 sha1 ed7599fbba848e5d48c5bc02c2f4e447d56f2c60 )
+)
+
+game (
+	name "McDonaldland (Europe) (v2)"
+	rom ( name "McDonaldLandV2_v1.5.lha" size 564284 crc 563E6223 sha1 e62bbe826491773e8991759475894a626708565f )
 )
 
 game (
@@ -9501,18 +10745,23 @@ game (
 )
 
 game (
-	name "MegaBall v4.0 (Europe)"
-	rom ( name "MegaBall_v1.02.lha" size 1298771 crc 8FF51BB8 sha1 2637fbe1ba1b6c422307986aa6bff505b4f490d1 )
+	name "Mean Streets (USA)"
+	rom ( name "MeanStreets_v1.2_NTSC.lha" size 1079679 crc 8CA9900F sha1 02d012173482fdd9bdeac33d5add124dc189bee2 )
 )
 
 game (
-	name "MegaBall v4.0 (1 MB) (Europe)"
-	rom ( name "MegaBall_v1.02_1MB.lha" size 1298978 crc 0C6B467B sha1 107044a5a8ec683d3b0873db4f8ccaa53fda3dd9 )
+	name "MegaBall v4.0 (Europe)"
+	rom ( name "MegaBall_v1.03.lha" size 1299320 crc 8A554F78 sha1 16c508b538e39b6d595160300951409a85890214 )
+)
+
+game (
+	name "MegaBall v4.0 (Europe) (1 MB)"
+	rom ( name "MegaBall_v1.03_1MB.lha" size 1299525 crc 235C8250 sha1 241a2a3335fb8f729afaa575844189115972b967 )
 )
 
 game (
 	name "MegaBall v4.0 (Europe) (AGA)"
-	rom ( name "MegaBall_v1.02_AGA.lha" size 1331151 crc E3D41CC8 sha1 58f9341aac1de616032589edf4ad16be304b2ce7 )
+	rom ( name "MegaBall_v1.03_AGA.lha" size 1332232 crc 3FF1AA5D sha1 67c8f747f9a7fe355091bec1e9e3c45b6c391eb1 )
 )
 
 game (
@@ -9541,23 +10790,18 @@ game (
 )
 
 game (
-	name "MegaTraveller 1 - The Zhodani Conspiracy (Europe)"
-	rom ( name "MegaTraveller1_v1.0.lha" size 679997 crc 0B28D927 sha1 7f57e62ca7c4bc98f57dcff84ea01cbcfa288764 )
-)
-
-game (
 	name "Mega Twins (Europe)"
 	rom ( name "MegaTwins_v1.4.1.lha" size 904923 crc D9455B39 sha1 df019271d3c67ec4f03c1a668a88f73312735573 )
 )
 
 game (
 	name "Mega Typhoon (Europe)"
-	rom ( name "MegaTyphoon_v1.1.lha" size 585964 crc 031D3CA2 sha1 02a5b8f6862e95574e2e548799bfe1dc6dee5a07 )
+	rom ( name "MegaTyphoon_v1.4.lha" size 586923 crc 6515B526 sha1 f449b82a4707679a600d8e5fe0c58d297d81a2ff )
 )
 
 game (
 	name "Menace (Europe)"
-	rom ( name "Menace_v1.2_0823.lha" size 422061 crc C2C40835 sha1 583edd9acb4e55c3476d582d4f1b43ac0f7986b8 )
+	rom ( name "Menace_v1.3_0823.lha" size 425528 crc 80C60643 sha1 cfeb1c54509acd1b40d34756f584b6aea6c8081b )
 )
 
 game (
@@ -9596,13 +10840,18 @@ game (
 )
 
 game (
+	name "Metal Gear (Europe)"
+	rom ( name "MetalGear_v1.1.lha" size 875892 crc 0A169351 sha1 2138d433c9e98d42864a43f115fbdb374c8ed9a5 )
+)
+
+game (
 	name "Metal Law (Europe)"
-	rom ( name "MetalLaw_v1.0.lha" size 411941 crc 39F60797 sha1 12ae60ee6fe63e56d94456fb386d508600324fc6 )
+	rom ( name "MetalLaw_v2.0.lha" size 419302 crc D804CDEA sha1 396569bd9c13bdb33d16a0024cecb9f94b083cf8 )
 )
 
 game (
 	name "Metal Masters (Europe)"
-	rom ( name "MetalMasters_v1.0_0534.lha" size 879087 crc 5C38BFE1 sha1 487d38ee2c66d091a2bcea2a0e1eacebee22e9f7 )
+	rom ( name "MetalMasters_v1.1_0534.lha" size 688725 crc 3CB71977 sha1 75ea5d3bc208c6d8320406585dd155bcbc7d70db )
 )
 
 game (
@@ -9626,13 +10875,28 @@ game (
 )
 
 game (
+	name "Metro-Cross (Europe)"
+	rom ( name "MetroCross_v1.1.lha" size 155045 crc 9D51AF25 sha1 6d10473c1cdaea86bbda61d8829b80af410c1307 )
+)
+
+game (
+	name "Mewilo (Germany)"
+	rom ( name "Mewilo_v1.0_De.lha" size 445459 crc 4D83FF83 sha1 15630528f8835122c01eb52ab253d2c653d0f5ee )
+)
+
+game (
+	name "Mewilo (France)"
+	rom ( name "Mewilo_v1.0_Fr.lha" size 453672 crc CF2B6EB9 sha1 2dd017b80a3708322ef27f3806b80230a53606d2 )
+)
+
+game (
 	name "MF Tanks (Europe)"
 	rom ( name "MFTanks_v1.0.lha" size 86263 crc D033803F sha1 417f422fd08d115fff5367c25f7502d0f545c7cf )
 )
 
 game (
 	name "Miami Chase (Europe)"
-	rom ( name "MiamiChase_v1.2a_2531.lha" size 1071991 crc 8DD9F1B4 sha1 2cc99ad556e2cf4816a39d4c9856e2b8357357a8 )
+	rom ( name "MiamiChase_v1.2b_2531.lha" size 1072078 crc C97EF6C2 sha1 e9a7a70c84becb9e6fd65f7fdb08e912d8734bdf )
 )
 
 game (
@@ -9656,7 +10920,7 @@ game (
 )
 
 game (
-	name "Mickey's 123's - The BIG Surprise Party (France)"
+	name "Mickey - Puzzles Animes (France)"
 	rom ( name "MickeyPuzzlesAnimes_v1.0_Fr_2476.lha" size 1225955 crc 4BF4B128 sha1 f4dbd9ca73042a91b074d52bcc4373da47541a81 )
 )
 
@@ -9717,17 +10981,17 @@ game (
 
 game (
 	name "Midwinter (Europe)"
-	rom ( name "Midwinter_v2.0b_0218.lha" size 453784 crc 6491AB36 sha1 f88164801c4052621e4a9b5104fb3857bcea09e3 )
+	rom ( name "Midwinter_v2.2_0218.lha" size 454242 crc C4A9C798 sha1 2b93942124ea38587fa8ba24c7c5a06d8d47e093 )
 )
 
 game (
 	name "Midwinter (Germany)"
-	rom ( name "Midwinter_v2.0b_De_0358.lha" size 454621 crc 3A614B26 sha1 b8ffdf4dfd4ea08793c9aa4354806fa9f0cda0f2 )
+	rom ( name "Midwinter_v2.2_De_0358.lha" size 455059 crc 7423B4ED sha1 867312317ec8769538a586667d9c35e34ab0f7ee )
 )
 
 game (
 	name "Midwinter (France)"
-	rom ( name "Midwinter_v2.0b_Fr_2553.lha" size 454642 crc C88A16A3 sha1 e5b2e5d2b594819a9951d1da5b46f2daf631884d )
+	rom ( name "Midwinter_v2.2_Fr_2553.lha" size 455070 crc EE89802A sha1 d1524909a20f961c7b925f811a8b797ce4c2931c )
 )
 
 game (
@@ -9737,7 +11001,7 @@ game (
 
 game (
 	name "MiG-29M Super Fulcrum (Europe)"
-	rom ( name "MiG29MSuperFulcrum_v1.0.lha" size 611020 crc B9EF223A sha1 bc414cb6166dce0cd2d3c0c2c25e97eb3a79e504 )
+	rom ( name "MiG29MSuperFulcrum_v1.01.lha" size 613867 crc 30C815BE sha1 4752a4ac4206ef81b7c7aa838bfdb152fc73af7d )
 )
 
 game (
@@ -9771,18 +11035,28 @@ game (
 )
 
 game (
+	name "Mike the Magic Dragon 9Europe)"
+	rom ( name "MikeTheMagicDragon_v1.0_3072.lha" size 523922 crc 6D165DD4 sha1 71100655ed49cbcf540229bb7a14c279e8ca3020 )
+)
+
+game (
 	name "Mikro Mortal Tennis (Europe)"
-	rom ( name "MikroMortalTennis_v1.0.lha" size 1995855 crc 130A46D8 sha1 e1d33b534c5ad08f2fd2f83d9411dc4073425d47 )
+	rom ( name "MikroMortalTennis_v1.1.lha" size 2008210 crc 89FBFA0D sha1 5bb506191d83add7cb7be4536ff8d9d11c3426d4 )
+)
+
+game (
+	name "Millenium - Return to Earth (Germany)"
+	rom ( name "Millenium_v1.5_De.lha" size 450929 crc 68ADCD52 sha1 f8e024dab14e313bec7e762fd7d841376ee8aede )
 )
 
 game (
 	name "Millenium - Return to Earth (USA)"
-	rom ( name "Millenium_v1.4_NTSC_2027.lha" size 465187 crc 7E1C5DC2 sha1 4a796b10282897600ae766dba6bf62f4a15c07a5 )
+	rom ( name "Millenium_v1.5_NTSC_2027.lha" size 464507 crc DA381E58 sha1 10d3b09c51c7635cf119b8c64b6369580ef71720 )
 )
 
 game (
 	name "Millennium 2.2 (Europe)"
-	rom ( name "Millennium22_v1.4_0537.lha" size 448510 crc E50D88A0 sha1 b116176e91d67716942b83a123bf6311ea6acaa4 )
+	rom ( name "Millennium22_v1.5_0537.lha" size 448608 crc F649C2D2 sha1 a2b4fc6e77f8d4d4a9135bf1aaed2e787fd4ce53 )
 )
 
 game (
@@ -9797,7 +11071,7 @@ game (
 
 game (
 	name "Mindroll (Europe)"
-	rom ( name "Mindroll_v1.1_0538.lha" size 462029 crc 3314560A sha1 cb559891916ce4f4f2b0317bad121dc11da3a1f0 )
+	rom ( name "Mindroll_v1.2_0538.lha" size 462672 crc 8A0EA277 sha1 faf5bc8a36c156e9e63393819b8511b1ecc49b25 )
 )
 
 game (
@@ -9821,12 +11095,17 @@ game (
 )
 
 game (
+	name "Minos (Europe)"
+	rom ( name "Minos_v1.0_2902.lha" size 694693 crc 71AC13CF sha1 941ce369176a18884db16853b5cc7e2d7416425c )
+)
+
+game (
 	name "Minskies Furballs (Europe)"
 	rom ( name "Minskies_v2.1.lha" size 3099992 crc BF814FF2 sha1 7c5f17f41f808046b87964ceb137b0123af95fca )
 )
 
 game (
-	name "Minskies... the abduction (Europe) (ECS, AGA)"
+	name "Minskies Furballs (Europe) (AGA)"
 	rom ( name "Minskies_v2.1_AGA.lha" size 3100197 crc 1DDCFD47 sha1 8809281c233c810ea8b03f64ab75a4baf9c2af64 )
 )
 
@@ -9837,17 +11116,32 @@ game (
 
 game (
 	name "Missiles Over Xerion (Europe)"
-	rom ( name "MissilesOverXerion_v1.0.lha" size 738530 crc 37944FC8 sha1 14f678972a68d36c5d97342461b9e4d7a156a882 )
+	rom ( name "MissilesOverXerion_v1.2_2625.lha" size 740485 crc 275D2A34 sha1 31062cfbdb59ee08e91a807d868ec5ba7cb88891 )
 )
 
 game (
 	name "Mission Elevator (Europe)"
-	rom ( name "MissionElevator_v1.0_1282.lha" size 185859 crc D170485E sha1 0a8ce57b6bde0321ae14aff5ab341bfd24cddd49 )
+	rom ( name "MissionElevator_v1.1_1282.lha" size 186441 crc 8C7AEA54 sha1 68f2f21dcbe7e4b56ff38be1c589e6edefd4d5e5 )
+)
+
+game (
+	name "Mixed-Up Mother Goose (Europe)"
+	rom ( name "MixedUpMotherGoose_v1.0_2680.lha" size 1306584 crc C8B578CA sha1 ea8e8ebfdbec35a91be5ab4593a5fa080be4d63b )
 )
 
 game (
 	name "Moebius - The Orb of Celestial Harmony (USA)"
 	rom ( name "Moebius_v1.0_NTSC_1385.lha" size 282322 crc 4A476509 sha1 ec191123f53976d1c599e68907b08943db00840c )
+)
+
+game (
+	name "Monkey Business (Europe)"
+	rom ( name "MonkeyBusiness_v1.0.lha" size 50493 crc 845B6E4F sha1 f899b50f41f5519c8085db4a65686e3dc7859901 )
+)
+
+game (
+	name "Monkey Business (Europe) (A1000)"
+	rom ( name "MonkeyBusiness_v1.0_A1000.lha" size 37794 crc D60FB8B1 sha1 e54ee5baaf53b32914c07d9108fee385b1df45be )
 )
 
 game (
@@ -9892,7 +11186,27 @@ game (
 
 game (
 	name "Moochies, The (Europe)"
-	rom ( name "Moochies_v1.0.lha" size 1426178 crc 59432BC8 sha1 9d5e89a31c1979e74412b643998f7ad921db1cb2 )
+	rom ( name "Moochies_v1.1_1425.lha" size 1426675 crc F6CD2462 sha1 ca35016e3cb404f9f8ecf01c1296bf94d7016281 )
+)
+
+game (
+	name "Moonbase - Lunar Colony Simulator (Europe)"
+	rom ( name "MoonBase_v1.1_2660.lha" size 311868 crc 79B77EB8 sha1 0b9f0f69872312f3ed687aeb9a41252861a1c789 )
+)
+
+game (
+	name "Moonbase - Lunar Colony Simulator (Europe) (512 kB)"
+	rom ( name "MoonBase_v1.1_512k_2660.lha" size 312010 crc BDB93E4B sha1 5db5dc721943670a6f4b00abd8060205c35dbadc )
+)
+
+game (
+	name "Moonbase - Lunar Colony Simulator (France) (512 kB)"
+	rom ( name "MoonBase_v1.1_512k_Fr.lha" size 334493 crc 5BE5930F sha1 e3aafd10e12b033985a849c574f484d871987856 )
+)
+
+game (
+	name "Moonbase - Lunar Colony Simulator (France)"
+	rom ( name "MoonBase_v1.1_Fr.lha" size 334353 crc 4F28ADD0 sha1 341b2f7aa7ae54c5b1467f479e4709e6941d11cd )
 )
 
 game (
@@ -9921,6 +11235,11 @@ game (
 )
 
 game (
+	name "Oh No! More Lemmings (Europe)"
+	rom ( name "MoreLemmings_v1.0.lha" size 971814 crc 6B1C7C57 sha1 d8797cf9e4e9d486014493d94f18057b1c0bef02 )
+)
+
+game (
 	name "Morph (Europe)"
 	rom ( name "Morph_v1.0_1148.lha" size 887313 crc 1EC3BEFF sha1 cd935290ba3dc8a7f7b4a49b075338cc01bca0d7 )
 )
@@ -9936,13 +11255,13 @@ game (
 )
 
 game (
-	name "Mortal Kombat II (1 MB) (Europe)"
-	rom ( name "MortalKombat2_v1.1.1_1MB_1105.lha" size 2824375 crc 7FE62175 sha1 09c5dbbdfd5c77db5078c2c62af236cbdd9a13e8 )
+	name "Mortal Kombat II (Europe)"
+	rom ( name "MortalKombat2_v1.4_1105.lha" size 2827591 crc B683847F sha1 20c1bf4d81f946ca978e710d25b60649869668d1 )
 )
 
 game (
-	name "Mortal Kombat II (Europe)"
-	rom ( name "MortalKombat2_v1.1.1_2MB_1105.lha" size 2824384 crc 9E92CE56 sha1 ca280e8a22b5d2901b3ea5cb0cbd479f7f9da1bf )
+	name "Mortal Kombat II (Europe) (1 MB)"
+	rom ( name "MortalKombat2_v1.4_1MB_1105.lha" size 2827607 crc A65BC923 sha1 ecda52af7746defbd490238cd2a0439c70494f3b )
 )
 
 game (
@@ -9951,7 +11270,7 @@ game (
 )
 
 game (
-	name "Mortal Kombat (Censored) (Europe)"
+	name "Mortal Kombat (Europe) (Censored)"
 	rom ( name "MortalKombat_v0.9_Censored_1319.lha" size 1675212 crc CE955C14 sha1 ab05e3a9d0395b7ef8eb285dde82592a148e5af6 )
 )
 
@@ -9967,12 +11286,12 @@ game (
 
 game (
 	name "Mortville Manor (Europe)"
-	rom ( name "MortvilleManor_v1.1a.lha" size 627289 crc C56E6306 sha1 c6657df2a97736a6ffa0ab9b1936854c60c2c957 )
+	rom ( name "MortvilleManor_v2.0_2904.lha" size 622597 crc CB4D4637 sha1 ae88be7e98b35da78a1288836077419a71c3973d )
 )
 
 game (
 	name "Mot (Europe)"
-	rom ( name "MOT_v1.0.lha" size 565160 crc C6AAE7F2 sha1 495f7c410f18a749de69bf48ab210c0e3b062cc9 )
+	rom ( name "Mot_v1.1.lha" size 506533 crc ADBE1106 sha1 074efb62e4fcc05a5ace2d58085e86049aacb50c )
 )
 
 game (
@@ -10011,7 +11330,7 @@ game (
 )
 
 game (
-	name "Mr Do! Run Run (Image) (Europe)"
+	name "Mr Do! Run Run (Europe) (Image)"
 	rom ( name "MrDoRunRun_v1.0_Image_2178.lha" size 132016 crc 0DA35C88 sha1 fb65161663f45eebac804ec2cce55ce039e5efc7 )
 )
 
@@ -10037,7 +11356,7 @@ game (
 
 game (
 	name "Munsters, The (Europe)"
-	rom ( name "Munsters_v1.1_1265.lha" size 263117 crc 97722C6A sha1 7c84f30c913ac6cf6cc1b10f248507cb05879386 )
+	rom ( name "Munsters_v1.2b_1265.lha" size 263581 crc D09B9C9A sha1 781ad438daca4b40a79eb8f92e7061f8f5eedc6a )
 )
 
 game (
@@ -10046,13 +11365,33 @@ game (
 )
 
 game (
-	name "Murders in Space (Europe) (En,Fr,De,It)"
-	rom ( name "MurdersInSpace_v1.1_Files_2344.lha" size 803499 crc 22BB20C8 sha1 1cd344d83ab2ce46d820977f5eba1039fde381d9 )
+	name "Murders in Space (Spain)"
+	rom ( name "MurdersInSpace_v1.4_Es_Files.lha" size 807440 crc 44B8BC44 sha1 6e0904bf553468ff23b4263f21ca1fdeb43e0ff8 )
 )
 
 game (
-	name "Murders in Space (Image) (Europe)"
-	rom ( name "MurdersInSpace_v1.1_Image_2344.lha" size 807659 crc CEB4459D sha1 f86a41ccae54c02a66aa27b1fe1139fdacceff1e )
+	name "Murders in Space (Spain) (Image)"
+	rom ( name "MurdersInSpace_v1.4_Es_Image.lha" size 811338 crc C7D5485F sha1 a4709d6579389754eb875bef50abf5e079187302 )
+)
+
+game (
+	name "Murders in Space (Europe) (En,Fr,De,It)"
+	rom ( name "MurdersInSpace_v1.4_Files_2344.lha" size 811780 crc 5A9B2A17 sha1 284e35d0800f50ebd2b1002485de6b0294123382 )
+)
+
+game (
+	name "Murders in Space (Europe) (En,Fr,De,It) (Image)"
+	rom ( name "MurdersInSpace_v1.4_Image_2344.lha" size 815943 crc D7C94691 sha1 b1cba7d7a2da37c4a202395685fb563d3a6883bd )
+)
+
+game (
+	name "Murders in Venice (Europe)"
+	rom ( name "MurdersInVenice_v1.0_2790.lha" size 4663678 crc C1E72435 sha1 dbb9f15417a1a45eeab0b3586c3367fbb948101e )
+)
+
+game (
+	name "Mutant League Hockey (Europe) (AGA)"
+	rom ( name "MutantLeagueHockey_v1.0_AGA.lha" size 1587602 crc FBD83881 sha1 0700a11c3f5704dd10c1925af327708112323b14 )
 )
 
 game (
@@ -10067,7 +11406,7 @@ game (
 
 game (
 	name "Mystical (Europe)"
-	rom ( name "Mystical_v1.2_0541.lha" size 453977 crc 59167EDF sha1 db73a85c956edc12b113ecf57612fdff392ffe20 )
+	rom ( name "Mystical_v2.0_0541.lha" size 454623 crc BED6BC22 sha1 14c33daf7b64035b2db47df3c440f5f7e7ac02f8 )
 )
 
 game (
@@ -10077,12 +11416,12 @@ game (
 
 game (
 	name "Myth - History in the Making (Europe)"
-	rom ( name "Myth_v1.3a_System3_0700.lha" size 2583099 crc 50C68E9F sha1 e88053a7f260a042b04e9d5c525e43d28dedfc51 )
+	rom ( name "Myth_v1.4_System3_0700.lha" size 2583883 crc A8E545BE sha1 a16bd511c06d646c54e59edb53c7f44a2d7559a5 )
 )
 
 game (
 	name "Myth - History in the Making (Europe) (CD32)"
-	rom ( name "Myth_v1.3a_System3_CD32.lha" size 2588542 crc 031A3863 sha1 6ec3c141225c47c780d2006c059bfd12da7e226c )
+	rom ( name "Myth_v1.4_System3_CD32.lha" size 2592514 crc 2180C9BF sha1 c736b5350cb8d7bf69ae152713676086278e0603 )
 )
 
 game (
@@ -10097,12 +11436,12 @@ game (
 
 game (
 	name "Narco Police (Europe)"
-	rom ( name "NarcoPolice_v1.1.lha" size 480291 crc BAD626EE sha1 fc810a401b52597d18329f168eb2f5589b1e021b )
+	rom ( name "NarcoPolice_v1.2.lha" size 486319 crc 9F0A663D sha1 0add0020fa1ca5279e408e4f5203435e9332f897 )
 )
 
 game (
 	name "Nathan Never (Italy)"
-	rom ( name "NathanNever_v1.0_It_2667.lha" size 1646384 crc 09F6BF6F sha1 a9a4e21a0225b543d6e5c0b6861a8b5a47249acd )
+	rom ( name "NathanNever_v1.0.1_It_2667.lha" size 1651656 crc 2950183F sha1 13a71c45fa6147f0be6ecbb8be31749b0194a50e )
 )
 
 game (
@@ -10126,23 +11465,33 @@ game (
 )
 
 game (
+	name "Navy Moves (Spain)"
+	rom ( name "NavyMoves_v1.2_Es.lha" size 492147 crc 8155EFB5 sha1 b2e6f843ae54f66e85378b473a4c17b756628d25 )
+)
+
+game (
 	name "Navy SEALs (Europe)"
-	rom ( name "NavySeals_v1.4_1251.lha" size 458087 crc EDDA0818 sha1 661f4b7258a1136fc1cb14c661d45cfba1bcff94 )
+	rom ( name "NavySeals_v2.1_1251.lha" size 459171 crc 02B22655 sha1 9f089f578586b57675e676a2448e00930b57d3e7 )
 )
 
 game (
 	name "Nebulus 2 - Pogo a Gogo (Europe)"
-	rom ( name "Nebulus2_v1.4_1713.lha" size 2501992 crc A0478D5E sha1 ee7da134630d9acf4eff0d136826293940df0004 )
+	rom ( name "Nebulus2_v1.6_Files_1713.lha" size 2534437 crc E100C872 sha1 8284756878d96615e2aa6b3f77952d3bfbc7a629 )
+)
+
+game (
+	name "Nebulus 2 - Pogo a Gogo (Europe) (Image)"
+	rom ( name "Nebulus2_v1.6_Image_1713.lha" size 2713166 crc 4FFA4940 sha1 b05601d1c6e99d14f8fb2614fc6c80410c703136 )
 )
 
 game (
 	name "Nebulus (Europe)"
-	rom ( name "Nebulus_v1.3_0361.lha" size 207129 crc DC945FD6 sha1 9ba45be31b271edcc5cb6b469df68c63bf0e7388 )
+	rom ( name "Nebulus_v1.5_0361.lha" size 207944 crc 67BA8752 sha1 1fa8846c590b0c12fc2abd5f4978ebea9d363435 )
 )
 
 game (
 	name "Necronom (Europe)"
-	rom ( name "Necronom_v1.1_0542.lha" size 771991 crc D8DBC073 sha1 0391bc4fa0cb11b2280b461ed91f51683d9ee8f7 )
+	rom ( name "Necronom_v1.2_0542.lha" size 772337 crc 3816EA23 sha1 9392b5f4d48180e91491b4a55fbed178d91cf799 )
 )
 
 game (
@@ -10157,7 +11506,7 @@ game (
 
 game (
 	name "Neuromancer (Europe)"
-	rom ( name "Neuromancer_v2.0_2604.lha" size 725780 crc B9703261 sha1 6bbc948114cb2af49f346b47b0048a990607b7b9 )
+	rom ( name "Neuromancer_v3.4_2604.lha" size 728509 crc 129BD15B sha1 090ecc8463ed2233014129dfcf16760537beae1c )
 )
 
 game (
@@ -10172,22 +11521,22 @@ game (
 
 game (
 	name "Never Mind (Europe)"
-	rom ( name "NeverMind_v1.0_1507.lha" size 378471 crc 1609D3BD sha1 7a14e1df6fc7d9fc46a716d08233bce017339a27 )
+	rom ( name "NeverMind_v1.1_1507.lha" size 379082 crc B091C9F9 sha1 d450d6c36698e54bd1d3a650c6667ce027b06cc6 )
 )
 
 game (
-	name "New York Warriors (USA) (1MB) (Europe)"
-	rom ( name "NewYorkWarriors_v1.4_1MB.lha" size 911090 crc 1C818CDC sha1 e37ae7c43bcef6001ea44aa997e0e766adcec5f4 )
+	name "New York Warriors (Europe) (1 MB)"
+	rom ( name "NewYorkWarriors_v1.5_1MB.lha" size 911597 crc 1DED401A sha1 d4f329b28fa4c8b83bf78fc0f541c59f158d9d63 )
 )
 
 game (
-	name "New York Warriors (Europe) (512KB)"
-	rom ( name "NewYorkWarriors_v1.4_512KB_0705.lha" size 667989 crc C0A545A5 sha1 af02665bc9205d7bfdad4e692601ef3a916d2c73 )
+	name "New York Warriors (Europe) (512 kB)"
+	rom ( name "NewYorkWarriors_v1.5_512k_0705.lha" size 668402 crc 2D72525D sha1 343d32bca00198d3a6fc8c4c0f6364deb5d9cb90 )
 )
 
 game (
 	name "NewZealand Story, The (Europe)"
-	rom ( name "NewZealandStory_v2.2_1180.lha" size 407121 crc F9C1BB48 sha1 15b4aa8b00a8610d9ac61f46e7c894cc729a062e )
+	rom ( name "NewZealandStory_v2.6_1180.lha" size 421362 crc 9BA73026 sha1 cb28808db0f1322c1209b8892748492055f11c06 )
 )
 
 game (
@@ -10197,7 +11546,7 @@ game (
 
 game (
 	name "Nibby Nibble (Europe)"
-	rom ( name "NibbyNibble_v1.0.lha" size 91999 crc C7D87FC1 sha1 1d8e7ec4abf6433e551c677b066ca8173fc86341 )
+	rom ( name "NibbyNibble_v1.1.lha" size 90476 crc BADB2CE0 sha1 c2f72fd3cb0a7bef912101b114766067d322b8e1 )
 )
 
 game (
@@ -10212,7 +11561,7 @@ game (
 
 game (
 	name "Nicky II (Europe)"
-	rom ( name "Nicky2_v1.1.lha" size 608120 crc 1A19B640 sha1 4ebb7bbd66f080fcd3bc94979f44a2c5e4ff27cf )
+	rom ( name "Nicky2_v1.2.lha" size 605434 crc 1D4B2A34 sha1 a224b028b4b81ca4b5b612225b468fd868e9c664 )
 )
 
 game (
@@ -10242,7 +11591,7 @@ game (
 
 game (
 	name "Nightbreed - The Action Game (Europe)"
-	rom ( name "NightbreedAction_v1.0.lha" size 1078626 crc 50749A10 sha1 4b74199efca17563348a90d6e046a56a024b1cbd )
+	rom ( name "NightBreedAction_v2.0_0849.lha" size 1043902 crc 1C6221E8 sha1 001bacf747478d0cc4386c698fbdf3544c8b89f2 )
 )
 
 game (
@@ -10252,12 +11601,12 @@ game (
 
 game (
 	name "Nightdawn (Europe)"
-	rom ( name "Nightdawn_v1.1_1301.lha" size 471915 crc DB9AEF76 sha1 3b5052b5ac4dcdff210ff1063ca0123d17130bcd )
+	rom ( name "Nightdawn_v1.2_1301.lha" size 476522 crc 8537894A sha1 343fb0369cde3d1eefe2c9749d8f368e18ffeb9b )
 )
 
 game (
 	name "Nightdawn (USA)"
-	rom ( name "Nightdawn_v1.1_NTSC_2015.lha" size 472419 crc 4348E54A sha1 9ba4ccab4229dd0fd5a7b5e1bae2f0f9714b957d )
+	rom ( name "Nightdawn_v1.2_NTSC_2015.lha" size 476584 crc 7D484AD3 sha1 843af42d70cbbec3e3ed7f52965bb244af69b942 )
 )
 
 game (
@@ -10276,7 +11625,7 @@ game (
 )
 
 game (
-	name "Ninja Mission (Arcadia) (Europe)"
+	name "Ninja Mission (Europe) (Arcadia)"
 	rom ( name "NinjaMission_v0.1_Arcadia.lha" size 470107 crc EE9CEB0C sha1 8f0416e642a72bb50bd5ea4e3c667eb3c693e10c )
 )
 
@@ -10292,7 +11641,7 @@ game (
 
 game (
 	name "Ninja Remix (Europe)"
-	rom ( name "NinjaRemix_v1.3.lha" size 1705503 crc 7BFE6DDD sha1 d9939a7a5a94e9f2026eb191513f374d8e86bc8e )
+	rom ( name "NinjaRemix_v1.1_3020.lha" size 1707696 crc 4F50EA7B sha1 9c08e181a7880d0ee87dee4c4652b727cdf9cca7 )
 )
 
 game (
@@ -10302,7 +11651,7 @@ game (
 
 game (
 	name "Ninja Warriors, The (Europe)"
-	rom ( name "NinjaWarriors_v1.2_0543.lha" size 1196940 crc 568AC598 sha1 96c86bffef86718bf83907b34278abcdaa5f6f0c )
+	rom ( name "NinjaWarriors_v1.4_0543.lha" size 1197467 crc 838748F4 sha1 4681fdae23b7f78a1a5944a811a2903899752586 )
 )
 
 game (
@@ -10311,18 +11660,18 @@ game (
 )
 
 game (
-	name "Nitro (Europe, Australia)"
-	rom ( name "Nitro_v1.2.lha" size 878333 crc 6952D67D sha1 38d4b490ceb0be550a9d6e02431fa45c97532efd )
+	name "Nitro (Europe)"
+	rom ( name "Nitro_v1.3.lha" size 885621 crc 1FC06EB1 sha1 1411d05d68372bc4a1519c646070f04e88050b94 )
 )
 
 game (
 	name "Nitro (USA)"
-	rom ( name "Nitro_v1.2_NTSC.lha" size 878439 crc 8A905E6E sha1 2258da28751daaecb406ba8ba68730abd04e9e83 )
+	rom ( name "Nitro_v1.3_NTSC.lha" size 885722 crc 071A8F8A sha1 951bab451fdd71a7af00434208d63d9399d48584 )
 )
 
 game (
 	name "Nitro Boost Challenge (Europe)"
-	rom ( name "NitroBoostChallenge_v0.3.lha" size 232535 crc B06BE1A6 sha1 9ce255ab3b123ff92fc8f0730ba20c1492dd499f )
+	rom ( name "NitroBoostChallenge_v0.4.lha" size 232739 crc E2ABF92E sha1 cfdbd929b06eb49799ed5aca43f21535910268a8 )
 )
 
 game (
@@ -10347,22 +11696,22 @@ game (
 
 game (
 	name "North & South (Europe)"
-	rom ( name "NorthAndSouth_v2.1_Files_0194.lha" size 573746 crc 93B4E261 sha1 a828244a477b438ff68529d77d8387da2b9de6df )
+	rom ( name "NorthAndSouth_v2.2_Files_0194.lha" size 570622 crc 8322C8E5 sha1 f5e3c84929242b076a7f019621fd527799f6e22e )
 )
 
 game (
 	name "North & South (USA)"
-	rom ( name "NorthAndSouth_v2.1_Files_NTSC_1780.lha" size 561425 crc 4E925883 sha1 60c7453b3267858bc8868c0e542b67ae5ba675dd )
+	rom ( name "NorthAndSouth_v2.2_Files_NTSC_1780.lha" size 558222 crc B664DE26 sha1 84f432025d0dd8259f16bbd669a71879c5c2f954 )
 )
 
 game (
-	name "North & South (Image) (Europe)"
-	rom ( name "NorthAndSouth_v2.1_Image_0194.lha" size 601910 crc B1A19FDB sha1 3343788f754196ff838e0aa65a6b98a7f034fec6 )
+	name "North & South (Europe) (Image)"
+	rom ( name "NorthAndSouth_v2.2_Image_0194.lha" size 600214 crc b9f633ab sha1 9a6c1ac5e397c1ec399d364108a350147bedca5a )
 )
 
 game (
-	name "North & South (Image) (USA)"
-	rom ( name "NorthAndSouth_v2.1_Image_NTSC_1780.lha" size 567023 crc 8B053131 sha1 9c61675a5e2d74b4fc1195e8f6f8df9d31cbe4c7 )
+	name "North & South (USA) (Image)"
+	rom ( name "NorthAndSouth_v2.2_Image_NTSC_1780.lha" size 565327 crc C73CA11D sha1 823dee001f26de53a31f99e77c19cbcdf048d8f7 )
 )
 
 game (
@@ -10372,12 +11721,12 @@ game (
 
 game (
 	name "No Second Prize (Europe)"
-	rom ( name "NoSecondPrize_v1.0.lha" size 756894 crc 96D5C117 sha1 07456ad43b14f3f01ab0edd186ab3c8563d144cc )
+	rom ( name "NoSecondPrize_v1.2_3059.lha" size 762811 crc 48B75BD4 sha1 3527c27a798b9a3641c0c0e11e3a4f1d4dc6a6d6 )
 )
 
 game (
-	name "Not Very Festive Fodder (Europe)"
-	rom ( name "NotVeryFestiveFodder_v1.0.lha" size 351785 crc 395B9781 sha1 d9c1a0e93e651b5510100ff12d31c742507d7233 )
+	name "Not Very Festive Fodder (Europe) (Coverdisk -  Amiga Format #68)"
+	rom ( name "NotVeryFepstiveFodder_v1.0.lha" size 351785 crc 395B9781 sha1 d9c1a0e93e651b5510100ff12d31c742507d7233 )
 )
 
 game (
@@ -10396,23 +11745,28 @@ game (
 )
 
 game (
-	name "Nuxelia (Europe) (Demo)"
-	rom ( name "NuxeliaDemo_v1.0.lha" size 643865 crc DAA9F8B7 sha1 c1379078324c745bb11641d82dc5af6061630f70 )
+	name "Nuxelia (Europe) (AGA) (Demo)"
+	rom ( name "NuxeliaDemo_v1.0_AGA.lha" size 644276 crc 085D99F7 sha1 4e93fb1d54d56a64948c9ec4f6c6a09b2bac2928 )
 )
 
 game (
 	name "Oath, The (Europe)"
-	rom ( name "Oath_v1.1.lha" size 757704 crc A5687CA5 sha1 dae1f1317470ab02a32c7744c2d26e473e77e8bd )
+	rom ( name "Oath_v2.1.lha" size 756235 crc C14A6FAC sha1 e91f5397caa27189753cd3b808623554d8121c63 )
 )
 
 game (
-	name "Obitus (Europe, Australia)"
-	rom ( name "Obitus_v1.2.lha" size 2532073 crc 6F9AC61C sha1 28f510d8b647a3c4f2443721f863a990c8b468ea )
+	name "Obitus (Europe)"
+	rom ( name "Obitus_v1.5.lha" size 2908962 crc D2E331EB sha1 5d0aead14b7b1ddab62dc50d50267ee1b9596afe )
+)
+
+game (
+	name "Obitus (USA)"
+	rom ( name "Obitus_v1.5_NTSC.lha" size 2909293 crc 0B62A1E8 sha1 3c4e23522110ee36c682e8ed4f5ca2b2ce36e8b9 )
 )
 
 game (
 	name "Obliterator (Europe)"
-	rom ( name "Obliterator_v1.2_0706.lha" size 435107 crc 150A2180 sha1 fbf4148bc64e8c970cafe540f013d31fec1d5cce )
+	rom ( name "Obliterator_v1.3_0706.lha" size 436082 crc 0CCAD496 sha1 767579f1a0e7fb927c7427ed3331909f8b265c0e )
 )
 
 game (
@@ -10432,7 +11786,7 @@ game (
 
 game (
 	name "Off Shore Warrior (Europe)"
-	rom ( name "OffShoreWarrior_v1.1_2968.lha" size 553185 crc AE8D6A8C sha1 62719c63885ef25cb3641550163dd789672746dc )
+	rom ( name "OffShoreWarrior_v1.1a_2968.lha" size 555080 crc B248E555 sha1 8a222526bc3b0759d10692a09784f20581323760 )
 )
 
 game (
@@ -10497,7 +11851,7 @@ game (
 
 game (
 	name "One Step Beyond (Europe)"
-	rom ( name "OneStepBeyond_v1.1_2580.lha" size 1574415 crc C0648CE5 sha1 8883dc9758851cb7a0a8c6457801bd3c1f7e3a75 )
+	rom ( name "OneStepBeyond_v1.2_2580.lha" size 1576229 crc 7A99B850 sha1 3f813608c9018e9997241b9e73f1b4fbfa7533ec )
 )
 
 game (
@@ -10511,8 +11865,28 @@ game (
 )
 
 game (
+	name "On the Ball - League Edition (Europe)"
+	rom ( name "OnTheBallLeagueEdition_v2.0_1067.lha" size 2317824 crc 499CD3C9 sha1 82f347d3ba53de455a33793e4a4f42520c0162c4 )
+)
+
+game (
+	name "On the Ball - League Edition (Europe) (AGA)"
+	rom ( name "OnTheBallLeagueEdition_v2.0_AGA_2110.lha" size 3036449 crc E0F89682 sha1 66d58853f1c7c1dd16023c888f950ad8b25a78a2 )
+)
+
+game (
+	name "On the Ball - World Cup Edition (Europe)"
+	rom ( name "OnTheBallWorldCupEdition_v1.0_2138.lha" size 3118205 crc 05554E3D sha1 372948924e122e65480d08920470339349ab334b )
+)
+
+game (
+	name "On the Ball - World Cup Edition (Europe) (AGA)"
+	rom ( name "OnTheBallWorldCupEdition_v1.0_AGA_2595.lha" size 4420989 crc 1B14CC26 sha1 e4de7c5b1bee2f0c36430fef8ead227152e32031 )
+)
+
+game (
 	name "Ooops Up (Europe)"
-	rom ( name "OoopsUp_v1.1.lha" size 343823 crc 756A00F7 sha1 cb99047184bf88d106d0465f2f5687a761a27544 )
+	rom ( name "OoopsUp_v2.1_1283.lha" size 344230 crc 8F93E64C sha1 ba8594d61b569e29e6c685d89ec8c43a9f995cc2 )
 )
 
 game (
@@ -10526,8 +11900,8 @@ game (
 )
 
 game (
-	name "Operation - Cleanstreets (Europe)"
-	rom ( name "OperationCleanstreets_v1.2.lha" size 373657 crc 44878CCB sha1 26ffaffb315d4ee9accfa5f3d2f4aa02042cea98 )
+	name "Operation - Cleanstreets (USA)"
+	rom ( name "OperationCleanstreets_v2.1_NTSC.lha" size 374228 crc 931A2538 sha1 4614a4446ce02acdd888a5823ee604462717d666 )
 )
 
 game (
@@ -10547,12 +11921,12 @@ game (
 
 game (
 	name "Operation Harrier (Europe)"
-	rom ( name "OperationHarrier_v1.1_1051.lha" size 582545 crc 843DACAE sha1 22c8589d3c3a81dbce8feb6a8f059eba4557200f )
+	rom ( name "OperationHarrier_v1.3_1051.lha" size 583984 crc B0D8A6B9 sha1 6564158fd39fe43f733f678b0245d90d74cc63f3 )
 )
 
 game (
 	name "Operation Jupiter (France)"
-	rom ( name "OperationJupiter_v1.1_Fr_0374.lha" size 483025 crc EFE19B06 sha1 cb14de75f6c463419a2dc68bd2c94922cbc3e868 )
+	rom ( name "OperationJupiter_v1.2_Fr_0374.lha" size 433542 crc A3144BDF sha1 83a8b2b67571b99283b33f769976d5080ba6c28f )
 )
 
 game (
@@ -10562,47 +11936,47 @@ game (
 
 game (
 	name "Operation Stealth (Europe)"
-	rom ( name "OperationStealth_v2.0_1052.lha" size 2109481 crc 0CCB5D42 sha1 f7399c5de44885716bb61e29022836f0eb88f71a )
+	rom ( name "OperationStealth_v2.1_1052.lha" size 2111091 crc 1610E97E sha1 bd35ee039e570bc9bc48e3d0718b10e17eef07c3 )
 )
 
 game (
 	name "Operation Stealth (Germany)"
-	rom ( name "OperationStealth_v2.0_De_0375.lha" size 2115440 crc 09FE5195 sha1 4cee017249fd900a241f35c90bd09e5ceb112446 )
+	rom ( name "OperationStealth_v2.1_De_0375.lha" size 2117047 crc 16C6BD76 sha1 03de18d59b3ad11fc8a6d7c176416452b71b468f )
 )
 
 game (
 	name "Operation Stealth (Spain)"
-	rom ( name "OperationStealth_v2.0_Es.lha" size 2112355 crc 131DFB11 sha1 61a220cbdde5488cc4c9a20ea07b3811f5f1eee3 )
+	rom ( name "OperationStealth_v2.1_Es.lha" size 2112356 crc EB4F3CE6 sha1 430be9dfd2c9a1c5da074b33d11feec14dada0b3 )
 )
 
 game (
 	name "Operation Stealth (France)"
-	rom ( name "OperationStealth_v2.0_Fr_1654.lha" size 2112098 crc B75D91F4 sha1 7b3605ca7d6a918ac08fdef89cfbb45d2b1d6681 )
+	rom ( name "OperationStealth_v2.1_Fr_1654.lha" size 2113704 crc 88E01B7F sha1 519ebde11e82ebd79188210bb59fe6fb760de682 )
 )
 
 game (
 	name "Operation Stealth (Italy)"
-	rom ( name "OperationStealth_v2.0_It.lha" size 2103619 crc C3521F07 sha1 eb3ae7411c574a12c542862243168f7e24b15ddd )
+	rom ( name "OperationStealth_v2.1_It.lha" size 2105227 crc 6787BB34 sha1 b75239549df9840a492e43b5e57988d01d211606 )
 )
 
 game (
 	name "Operation Thunderbolt (Europe)"
-	rom ( name "OperationThunderbolt_v1.3a_0547.lha" size 1169865 crc 72966D77 sha1 710271e462e256c529fb1943ff91074d22be909b )
+	rom ( name "OperationThunderbolt_v1.4a_0547.lha" size 1169412 crc 7D9EC1B4 sha1 081843b8d0018b52ae59e19d8a5d0cd716a8e312 )
 )
 
 game (
 	name "Operation Wolf (Europe)"
-	rom ( name "OperationWolf_v1.3_1128.lha" size 986669 crc ED1BDB83 sha1 a42ab9af674150e0a0c5fca6481bf1e5cca8cb5f )
+	rom ( name "OperationWolf_v1.4_1128.lha" size 990115 crc 0C95BA03 sha1 c55e9c649c8385d55b50d02c38d1b9bc2cbe8073 )
 )
 
 game (
 	name "Orbital Destroyer (Europe)"
-	rom ( name "OrbitalDestroyer_v1.1_2230.lha" size 207915 crc E49F8BE0 sha1 b717f17c42fc4ed1abcbd78f4f3322e80204cb48 )
+	rom ( name "OrbitalDestroyer_v2.0_2230.lha" size 208678 crc FE310E2C sha1 3be0205caba3c56f728da03224742b10768cc513 )
 )
 
 game (
 	name "Oriental Games (Europe)"
-	rom ( name "OrientalGames_v1.1_2263.lha" size 313988 crc 501F43CF sha1 d52c3e1d2e560b204b737beee8c988c7f19c0e20 )
+	rom ( name "OrientalGames_v2.0_2263.lha" size 314200 crc D1D4A7AA sha1 aaecbd8eb18381d746c629c88d092507eb33777b )
 )
 
 game (
@@ -10626,8 +12000,13 @@ game (
 )
 
 game (
+	name "Oscar (Europe)"
+	rom ( name "Oscar_v2.5_1228.lha" size 1334314 crc B2E06769 sha1 ccffc3127018957157291e2f09b26982585e2bca )
+)
+
+game (
 	name "Oscar (Europe) (AGA)"
-	rom ( name "Oscar_v1.8_AGA_1095.lha" size 1822772 crc FAC049E7 sha1 a3cd86a256bc5dc2204c7cc323fffad6c9f71bb4 )
+	rom ( name "Oscar_v2.5_AGA_1095.lha" size 1824585 crc 9603856A sha1 51331fd4bfca6f2792d17e9e4e7eed4c979c29eb )
 )
 
 game (
@@ -10637,17 +12016,32 @@ game (
 
 game (
 	name "Oscar (USA) (CD32)"
-	rom ( name "Oscar_v1.8_CD32_NTSC.lha" size 2073959 crc FC9A4B05 sha1 3d81999ac1af841847a5850fd6bf460b4fe19e3c )
+	rom ( name "Oscar_v2.5_CD32.lha" size 2002165 crc 05D1F6A0 sha1 bd09446c432ee97fc74096d61c847afecce1a30d )
+)
+
+game (
+	name "OsWALD of the Ice Floes (Denmark)"
+	rom ( name "Oswald_v1.1_Dk.lha" size 223452 crc 23ABD3A7 sha1 05d69de05618fae662eaa7290bfbdb4bf32a0c5d )
 )
 
 game (
 	name "OsWALD of the Ice Floes (USA)"
-	rom ( name "OsWALDOfTheIceFloes_v1.0_NTSC.lha" size 194649 crc 97329B7D sha1 5342e72f9ab85b635bc771e17e66b5edde1e0d1a )
+	rom ( name "Oswald_v1.1_NTSC.lha" size 192071 crc 132EF017 sha1 373a48268c9fb90d92ed0fb0eee1951afd31f48f )
+)
+
+game (
+	name "Outlands & Dizzy Dice (Europe)" 
+	rom ( name "Outlands&DizzyDice_v1.0.lha" size 620376 crc C514AA71 sha1 8c5b3ffb822b3443f4e25788cf30d998d65e05b0 )
+)
+
+game (
+	name "Outlands (Europe)"
+	rom ( name "Outlands_v1.0.lha" size 570781 crc AE0865E1 sha1 995e6d1e7cedb6502741b6adcb3350b67bfbb4de )
 )
 
 game (
 	name "Out of This World (USA)"
-	rom ( name "OutOfThisWorld_v2.4_NTSC_1556.lha" size 1005265 crc B4361FE3 sha1 955dd553d587ed39e77c2173b7f866fbd5aed931 )
+	rom ( name "OutOfThisWorld_v2.8_NTSC_1556.lha" size 1005952 crc ED85894D sha1 f0ecbd4d4849eaae5fbc70feb28b1e9c613be82a )
 )
 
 game (
@@ -10662,7 +12056,7 @@ game (
 
 game (
 	name "OutRun Europa (Europe)"
-	rom ( name "OutRunEuropa_v1.1.lha" size 1430808 crc 775F1B6D sha1 6be7a12382506748590020bd916660b68b0dcc0a )
+	rom ( name "OutRunEuropa_v1.3.lha" size 1431583 crc 50B0CA9C sha1 2664a68854689762a8f05846290f84bca58d977b )
 )
 
 game (
@@ -10671,12 +12065,12 @@ game (
 )
 
 game (
-	name "Overdrive (Infacto) (Europe)"
+	name "Overdrive (Europe) (Infacto)"
 	rom ( name "Overdrive_v1.0_Infacto.lha" size 1902630 crc 6E73F30D sha1 f6a19e0fc10a732ef7e9b8e43581edb91d702ebe )
 )
 
 game (
-	name "Overdrive (Europe)"
+	name "Overdrive (Europe) (Team 17)"
 	rom ( name "Overdrive_v2.0_Team17_1149.lha" size 1906069 crc 5BB95368 sha1 2abce6d93a1bb647d71e5a09e8c94636a0beec85 )
 )
 
@@ -10702,7 +12096,7 @@ game (
 
 game (
 	name "Over the Net (USA)"
-	rom ( name "OverTheNet_v1.0_NTSC_2439.lha" size 500777 crc 8CF3F9E2 sha1 953d93afba2527347dd3122ed7d6a4bfd776add5 )
+	rom ( name "OverTheNet_v1.1_NTSC_2439.lha" size 501154 crc 0BFB610B sha1 f52e17f7b7e73300c02d0920420b80fbec2cdb33 )
 )
 
 game (
@@ -10727,12 +12121,12 @@ game (
 
 game (
 	name "Pacman 87 (Europe)"
-	rom ( name "Pacman87_v1.1.lha" size 95970 crc F358EECE sha1 febff67edb9366e28b2bc89cb27507cae23d18f0 )
+	rom ( name "Pacman87_v1.2.lha" size 102936 crc C004DAF7 sha1 4ad7ed8267ca0f41b971bac74c291178d3b84dc2 )
 )
 
 game (
 	name "Pac-Mania (Europe)"
-	rom ( name "PacMania_v1.0_1117.lha" size 307718 crc 848A2792 sha1 27e8d4fdfc44d806bac705673b494d6d7f5b32be )
+	rom ( name "PacMania_v1.1_1117.lha" size 309154 crc 6572C9E8 sha1 f3eab17157a4cecac7bd639e2c42ef9fefbf5c8c )
 )
 
 game (
@@ -10742,7 +12136,12 @@ game (
 
 game (
 	name "Paladin (Europe)"
-	rom ( name "Paladin_v1.0_2982.lha" size 280861 crc D307816C sha1 6ac2907ffd23a8bda0e01138ff90505b6fb7c58a )
+	rom ( name "Paladin_v1.1_2982.lha" size 282101 crc F9DD3D73 sha1 5821e1cf106443912e33f58dd5acc9def63cf96d )
+)
+
+game (
+	name "Paladin (USA)"
+	rom ( name "Paladin_v1.1_NTSC.lha" size 282059 crc E78C9D32 sha1 98991b4065c3aadaa907b672c88e60c199dcc30d )
 )
 
 game (
@@ -10777,7 +12176,7 @@ game (
 
 game (
 	name "Paperboy (Europe)"
-	rom ( name "Paperboy_v1.3.lha" size 341560 crc 8C70A6A5 sha1 5df64d54be5eb804067c71f90cd45d3ed0168b3e )
+	rom ( name "Paperboy_v1.4.lha" size 341670 crc A9287626 sha1 ca8932e1bcf18698c56e2c547dd84c53b1fefa72 )
 )
 
 game (
@@ -10787,12 +12186,12 @@ game (
 
 game (
 	name "Paradroid 90 (Europe)"
-	rom ( name "Paradroid90_v0401.1_1MB_0692.lha" size 534797 crc B787A3BF sha1 a9832df1c2879d676eb4af98f10b3fde138e2445 )
+	rom ( name "Paradroid90_v3.0.0_1MB_0692.lha" size 531300 crc FC145C45 sha1 a2e6b7693e3124691e072e86e706238b0855ff8e )
 )
 
 game (
-	name "Paradroid 90 (512 KB) (Europe)"
-	rom ( name "Paradroid90_v0401.1_512KB_0692.lha" size 534745 crc 855DA4D1 sha1 e752c920acf74b9176d76fc8c295e39db61ca87b )
+	name "Paradroid 90 (Europe) (512 kB)"
+	rom ( name "Paradroid90_v3.0.0_512KB_0692.lha" size 531317 crc 18B7A933 sha1 6a7625d5d1affac871ca32a674e653905bc945cd )
 )
 
 game (
@@ -10802,7 +12201,7 @@ game (
 
 game (
 	name "Paramax (Europe)"
-	rom ( name "Paramax_v1.1.lha" size 679066 crc 8E89B778 sha1 f453c156cdd1424db7c1627165c030c597c49f4a )
+	rom ( name "Paramax_v2.1_2184.lha" size 680390 crc F6E575F4 sha1 45408695a798380b8a85778739a7cd1b1719de26 )
 )
 
 game (
@@ -10821,23 +12220,53 @@ game (
 )
 
 game (
+	name "Paris Dakar 1990 (Europe)"
+	rom ( name "ParisDakar90_v1.0.lha" size 353487 crc 08839B00 sha1 12d5de65ab70a4c961f1324420b1daa5dc9dd2df )
+)
+
+game (
+	name "Passagers Du Vent II, Les - L'Heure Du Serpent (France)"
+	rom ( name "PassagersDuVent2_v1.0_Fr.lha" size 977693 crc CCD561AD sha1 bec96638553225b72f4f14fac69115289af7d875 )
+)
+
+game (
+	name "Passagers Du Vent, Les (France)"
+	rom ( name "PassagersDuVent_v1.0_Fr.lha" size 539892 crc 3A00A7F8 sha1 8135a42580b04e4fbf91ef3b89cd5298348e6317 )
+)
+
+game (
+	name "Passeggeri Del Vento, I (Italy)"
+	rom ( name "PasseggeriDelVento_v1.0_It.lha" size 539228 crc 1EAAAB13 sha1 78d6bebf88d683e1d340aa5fd1b3e828cd283d8b )
+)
+
+game (
+	name "Passengers on the Wind II (Europe)"
+	rom ( name "PassengersOnTheWind2_v1.0.lha" size 954950 crc 55c66b08 sha1 1b55e4df1017b01e1b729914418dee2121c94848 )
+)
+
+game (
+	name "Passengers on the Wind (Europe)"
+	rom ( name "PassengersOnTheWind_v1.0.lha" size 539514 crc 37986D95 sha1 26df6e4b111a6db44665a677720fd957dda1d20e )
+)
+
+game (
 	name "Passing Shot (Europe)"
-	rom ( name "PassingShot_v1.1_0708.lha" size 269187 crc 6B2AF762 sha1 cb15f2ea3f18f638154f5291fd1a0204e26f8c7d )
+	rom ( name "PassingShot_v1.2_0708.lha" size 258845 crc D245EE4B sha1 28fba5f9ce68b3ff1ba41bcaed26d34e808f3db8 )
 )
 
 game (
 	name "Patrician, The (Europe)"
-	rom ( name "Patrician_v1.3_1802.lha" size 1306146 crc 516AB0A8 sha1 f9888a7c3e40135007b53f539a1f1e0521ef46f7 )
+	rom ( name "Patrician_v1.5_1802.lha" size 1306534 crc 119CE78F sha1 7379f44f8530fe5023c28e4a3aff9828a0c33238 )
 )
 
 game (
 	name "Patrician, The (France)"
-	rom ( name "Patrician_v1.3_Fr.lha" size 1289097 crc 458E7E8F sha1 eaf7fc3b3c9a86d913652cc524dfea5b4f1f2286 )
+	rom ( name "Patrician_v1.5_Fr.lha" size 1289485 crc B642EF63 sha1 266ebf0f4184c6bceb1616cdd49bc99d7b2cbb02 )
 )
 
 game (
 	name "Patrizier, Der (Germany)"
-	rom ( name "Patrizier_v1.3_De_0376.lha" size 1314013 crc 3E1B8E5F sha1 d0b38e23e3fe1821af2b9ca085e69fd13ff16114 )
+	rom ( name "Patrizier_v1.5_De_0376.lha" size 1314401 crc 9FC74466 sha1 ff3bbd0a31d441eacb73a42b5138082939cad31e )
 )
 
 game (
@@ -10886,6 +12315,16 @@ game (
 )
 
 game (
+	name "Peter Pan (Germany)"
+	rom ( name "PeterPan_v1.0_De_0078.lha" size 338739 crc C3C23E8C sha1 2635b7daea17b0205c52f26e1615a3b037f6feaa )
+)
+
+game (
+	name "Peter Pan (France)"
+	rom ( name "PeterPan_v1.0_Fr.lha" size 378808 crc 4076AD48 sha1 a7b4c7aceff75a9ccab5ef12fa801f5f3ea274aa )
+)
+
+game (
 	name "Peter Schmeichel Soccer (Europe)"
 	rom ( name "PeterSchmeichelSoccer_v1.0.lha" size 284353 crc 43A5640C sha1 2f9780c4413dbfb8f786d7f8906401163d72b2d2 )
 )
@@ -10907,17 +12346,22 @@ game (
 
 game (
 	name "PGA Tour Golf & Tournament Course Disk (Europe)"
-	rom ( name "PGATourGolf&TournamentCourseDisk_v1.01_0891.lha" size 744421 crc 55491898 sha1 dc7377e9c118edbd128ce184e82e5dec2181c25c )
+	rom ( name "PGATourGolf&TournamentCourseDisk_v1.02_0891&0892.lha" size 785710 crc 1DC64C0D sha1 63f7b5575e70864cc37dda462cbc7d08bc825f2c )
 )
 
 game (
 	name "PGA Tour Golf (Europe)"
-	rom ( name "PGATourGolf_v1.01_0891.lha" size 601948 crc 2DEF7663 sha1 102f1850a720a9e66f70b634aba22745f439a552 )
+	rom ( name "PGATourGolf_v1.02_0891.lha" size 643222 crc 7D0C044D sha1 aab4ad7352a419713cd06f008237c7e647d68810 )
+)
+
+game (
+	name "Phalanx II - The Return (Europe)"
+	rom ( name "Phalanx2_v1.0_2709.lha" size 262992 crc BCC240F9 sha1 63651d30477f4b049df14f2724c01e9f5bfc2d14 )
 )
 
 game (
 	name "Phalanx (Europe)"
-	rom ( name "Phalanx_v1.1.lha" size 380492 crc 6649F751 sha1 0ffbd3787aabd1c0536fde064e4615414f0ebc44 )
+	rom ( name "Phalanx_v1.2_2708.lha" size 381658 crc 72F4040E sha1 1cd6e6a80d4e52dbf996d84d9e6c415a6db229be )
 )
 
 game (
@@ -10931,6 +12375,11 @@ game (
 )
 
 game (
+	name "Phantasm (Europe)"
+	rom ( name "Phantasm_v1.1_2972.lha" size 193604 crc 6438D3C0 sha1 4ac5215b80d5901f4b48f02b3a9f51b1ddee8aea )
+)
+
+game (
 	name "Phantom Fighter (Europe)"
 	rom ( name "PhantomFighter_v1.0.lha" size 567818 crc 9BC6092E sha1 25313f405c6c325977e71079f34c938da6ca4878 )
 )
@@ -10941,7 +12390,7 @@ game (
 )
 
 game (
-	name "Pharaoh's Match (Arcadia) (Europe)"
+	name "Pharaoh's Match (Europe) (Arcadia)"
 	rom ( name "PharaohsMatch_v0.1_Arcadia.lha" size 191102 crc D7CC3A7B sha1 f6b019c144c4dd7c69ba2b1fe5cdf0bdcf29e908 )
 )
 
@@ -10961,6 +12410,11 @@ game (
 )
 
 game (
+	name "Picsou - Chasseur De Trésor (France)"
+	rom ( name "PicsouChasseurDeTresor_v1.1_Fr.lha" size 140943 crc 7B2F0CF7 sha1 0b55c9b51ce55a81ad5f4c01599cd0e7c0b2ced6 )
+)
+
+game (
 	name "Pierre le Chef Is... Out to Lunch (Europe) (AGA)"
 	rom ( name "PierreLeChefIsOutToLunch_v2.3_AGA_0548.lha" size 1287632 crc 84B25A26 sha1 26e613a3ce89c143d264ff56f25490976335e2df )
 )
@@ -10977,12 +12431,12 @@ game (
 
 game (
 	name "Pinball Dreams (USA)"
-	rom ( name "PinballDreams_v1.5_NTSC.lha" size 1169134 crc 88C56F2A sha1 0bc22bfd7942ac7971ee56f28198b9430a1e084d )
+	rom ( name "PinballDreams_v1.9_NTSC.lha" size 1170214 crc 7E85896E sha1 4f852bc2ce65a3bcea3ece1efe636227eada2320 )
 )
 
 game (
 	name "Pinball Fantasies (Europe)"
-	rom ( name "PinballFantasies_v2.7_0025.lha" size 1574787 crc CC5CA1DB sha1 eadf2a43d35c45cce9fec9df56cf1aada8ca6d8a )
+	rom ( name "PinballFantasies_v3.2_0025.lha" size 1575884 crc B72A2DCD sha1 d4525231b2a076b30fa33435d15f5f3a77d52d31 )
 )
 
 game (
@@ -10991,28 +12445,28 @@ game (
 )
 
 game (
-	name "Pinball Fantasies (Chip) (Europe) (AGA)"
-	rom ( name "PinballFantasies_v2.7_AGA_Chip_0047.lha" size 1269176 crc 69907620 sha1 193df42a15a413f9b5525080bcc24bee5fc24791 )
+	name "Pinball Fantasies (Europe) (AGA) (Chip)"
+	rom ( name "PinballFantasies_v3.2_AGA_Chip_0047.lha" size 1272948 crc 9D583184 sha1 83e6280d8e92836718fd209ff6098788b08d26db )
 )
 
 game (
 	name "Pinball Fantasies (USA) (AGA)"
-	rom ( name "PinballFantasies_v2.7_AGA_NTSC_2025.lha" size 1269589 crc 67165C0E sha1 8cacb45395b7d68670d8a1e03c2d2ee1c3b1181d )
+	rom ( name "PinballFantasies_v3.2_AGA_NTSC_2025.lha" size 1273263 crc 2882F8F9 sha1 c3629c00d90cff7583c5e1b85ceb957696afc86e )
 )
 
 game (
-	name "Pinball Fantasies (USA) (Chip) (AGA)"
-	rom ( name "PinballFantasies_v2.7_AGA_NTSC_Chip_2025.lha" size 1269167 crc 5509B343 sha1 8fb5a1227ebad5a2d12573108fb40fc3ed1e5a32 )
+	name "Pinball Fantasies (USA) (AGA) (Chip)"
+	rom ( name "PinballFantasies_v3.2_AGA_NTSC_Chip_2025.lha" size 1272939 crc C632E457 sha1 72ce46494bb8c124b54c010adb42dbca56cab5bc )
 )
 
 game (
 	name "Pinball Fantasies (Europe) (CD32)"
-	rom ( name "PinballFantasies_v2.7_CD32.lha" size 1592484 crc D2F6B93F sha1 8053b0c9a7cb52a0cec45000d791e3f8c5e3c880 )
+	rom ( name "PinballFantasies_v3.2_CD32.lha" size 1596158 crc 68AC137E sha1 837691b4a5143bd900c7efa7e68be421ba7b31ef )
 )
 
 game (
-	name "Pinball Fantasies (Chip) (Europe) (CD32)"
-	rom ( name "PinballFantasies_v2.7_CD32_Chip.lha" size 1592086 crc 12C6B71C sha1 3a5c3fae2a5b733ce31db2768de423309227257c )
+	name "Pinball Fantasies (Europe) (CD32) (Chip)"
+	rom ( name "PinballFantasies_v3.2_CD32_Chip.lha" size 1595858 crc 8D34CAAF sha1 7e581f31e1779364e2df42ff3d64825b20929cc6 )
 )
 
 game (
@@ -11027,7 +12481,7 @@ game (
 
 game (
 	name "Pinball Illusions (Europe) (CD32)"
-	rom ( name "PinballIllusions_v2.2_CD32.lha" size 2968309 crc 619C2281 sha1 c6168996b3dbe32345c5f248b62afe60a03f5bd2 )
+	rom ( name "PinballIllusions_v2.3_CD32.lha" size 2969157 crc 83238BA4 sha1 7db1e0167dc77a56d7cb7727be75af86f871e4a6 )
 )
 
 game (
@@ -11037,7 +12491,7 @@ game (
 
 game (
 	name "Pinball Magic (Europe)"
-	rom ( name "PinballMagic_v1.0_2003.lha" size 414677 crc 23E6F5A9 sha1 6c22a0d0a6474928e35a61ed21f8f1e57466a8ea )
+	rom ( name "PinballMagic_v1.1_2003.lha" size 378245 crc 328237F3 sha1 fffa2b8075e84e2301ea43bce4a31c8ea5377457 )
 )
 
 game (
@@ -11061,7 +12515,7 @@ game (
 )
 
 game (
-	name "Pinball Wizard (Prerelease) (Europe)"
+	name "Pinball Wizard (Europe) (Pre-release)"
 	rom ( name "PinballWizard_v1.0_Prerelease.lha" size 279124 crc 66503816 sha1 b700e67ac6334f9b5fafb3a6b0c5f881e1ac866e )
 )
 
@@ -11072,7 +12526,7 @@ game (
 
 game (
 	name "Pink Panther (Europe)"
-	rom ( name "PinkPanther_v1.0_0236.lha" size 207064 crc B2895292 sha1 33ef1a7107d1897a814f56b064a66b5e809d494b )
+	rom ( name "PinkPanther_v1.1_0236.lha" size 211064 crc 229572FC sha1 45b3b0cd4a4a8bfd179cdbc2972cc0fafed5926c )
 )
 
 game (
@@ -11086,12 +12540,12 @@ game (
 )
 
 game (
-	name "Pipeline (Nomad) (Europe)"
+	name "Pipeline (Europe) (Nomad)"
 	rom ( name "Pipeline_v1.1_Nomad.lha" size 157947 crc 634AB481 sha1 7bfe7549ea8710df0712d11f8f4a3e3e1c80b10d )
 )
 
 game (
-	name "Pipeline (Oracle) (Europe)"
+	name "Pipeline (Europe) (Oracle)"
 	rom ( name "Pipeline_v1.1_Oracle.lha" size 142712 crc 064B89EA sha1 cb84800e70d8fd5bae10f0953e2fb022fc352bb8 )
 )
 
@@ -11102,12 +12556,22 @@ game (
 
 game (
 	name "Pirates! (Europe)"
-	rom ( name "Pirates_v1.4_0552.lha" size 1172623 crc 73EABEFA sha1 69971ee7dacb522ec7d20e246416d1c22ff556ff )
+	rom ( name "Pirates_v1.5_0552.lha" size 1245963 crc 2AC4C2A7 sha1 993c7a1bda6c8213072c648051e37e6c9ee4def3 )
 )
 
 game (
 	name "Pirates! Gold (Europe) (CD32)"
-	rom ( name "PiratesGold_v2.2_CD32.lha" size 1088474 crc 1D1A88D5 sha1 a69f0434d4cde63b645a6f9062b28f82576605c9 )
+	rom ( name "PiratesGold_v1.5_CD32.lha" size 1164663 crc 9EEAC879 sha1 f82133d5fcb04b1e3ac982b54b73886d18b74351 )
+)
+
+game (
+	name "Pirates! Gold (Germany) (CD32)"
+	rom ( name "PiratesGold_v1.5_CD32_De.lha" size 913959 crc 59E18AA0 sha1 74ffeb05c126c6d6a8b8ecdd1308d9caae7ecced )
+)
+
+game (
+	name "Pirates! Gold (France) (CD32)"
+	rom ( name "PiratesGold_v1.5_CD32_Fr.lha" size 913947 crc F8B60396 sha1 3204a01b420625f35d01665972d4b363d904a806 )
 )
 
 game (
@@ -11121,23 +12585,43 @@ game (
 )
 
 game (
+	name "Pizza Connection (Europe)"
+	rom ( name "PizzaConnection_v1.0.lha" size 2436937 crc 48491961 sha1 dc87a9cd69edd155b18a8114c1b5f680d1c5780a )
+)
+
+game (
 	name "Pizza Connection (Germany)"
 	rom ( name "PizzaConnection_v1.0_De.lha" size 2572935 crc FCA27F39 sha1 dff013b8a88841a7d607cdd8406d8ba689695d69 )
 )
 
 game (
 	name "Plague, The (Europe)"
-	rom ( name "Plague_v1.0.lha" size 905872 crc E20FA788 sha1 239214bc73e46f847659e4a565dc3226465ec225 )
+	rom ( name "Plague_v1.2.lha" size 907975 crc E1139FA3 sha1 243c7776646ae6bcea8cbf0f58ba74238bc2c9c2 )
+)
+
+game (
+	name "Plague, The (USA)"
+	rom ( name "Plague_v1.2_NTSC.lha" size 908695 crc 3E80DB08 sha1 902d55f30ae2ed2690ce0d69851e60f955fbb688 )
 )
 
 game (
 	name "Plan 9 from Outer Space (Europe)"
-	rom ( name "Plan9FromOuterSpace_v1.2a.lha" size 2653246 crc F6013BAD sha1 55be624ea57436191a16b87d280fb40c1c514056 )
+	rom ( name "Plan9FromOuterSpace_v1.3_3023.lha" size 2610390 crc 91111149 sha1 b9cb049291bf157ec6017761d4bb5c61ce9d2a36 )
+)
+
+game (
+	name "Plan 9 from Outer Space (USA)"
+	rom ( name "Plan9FromOuterSpace_v1.3_NTSC.lha" size 2513549 crc E0CB1971 sha1 0299b5060b79096f579e1e5703ad665561ebbdc2 )
 )
 
 game (
 	name "Platoon (USA)"
 	rom ( name "Platoon_v1.1_NTSC_1483.lha" size 462965 crc 56E2FC43 sha1 dfb830999a1c6a95f36714b5d311a311a4ddaa0f )
+)
+
+game (
+	name "Playdays (Europe)"
+	rom ( name "Playdays_v1.0_1577.lha" size 831397 crc 7168064F sha1 a3691a7532b878582068face1b2525f241387af6 )
 )
 
 game (
@@ -11152,26 +12636,31 @@ game (
 
 game (
 	name "Player Manager (Europe)"
-	rom ( name "PlayerManager_v1.02_0171.lha" size 311450 crc 68F326DD sha1 471c3453cc9d9c1ccb59f77cb44546dbcdcd7ce1 )
+	rom ( name "PlayerManager_v1.03_0171.lha" size 311843 crc 04E19674 sha1 371e6eaf8431027e0cc51cddf9c09cb03b0becc8 )
 )
 
 game (
 	name "Player Manager (Germany)"
-	rom ( name "PlayerManager_v1.02_De_2772.lha" size 313423 crc 7E010621 sha1 694c470925cf649a3220599f724072a0163a9b02 )
+	rom ( name "PlayerManager_v1.03_De_2772.lha" size 313816 crc 91B94D28 sha1 baf52956486bf5546e27cbf10d3dec5f04c73511 )
 )
 
 game (
 	name "Player Manager (France)"
-	rom ( name "PlayerManager_v1.02_Fr.lha" size 312579 crc 5013FA6F sha1 b6c54f82ff4892253ccbfa5882bf948d6f6770fe )
+	rom ( name "PlayerManager_v1.03_Fr.lha" size 312972 crc D695D8DF sha1 71195731bd895cf1ba4d00532e78ff3ce7300a2e )
 )
 
 game (
 	name "Player Manager (Italy)"
-	rom ( name "PlayerManager_v1.02_It_2572.lha" size 313891 crc 26D9FA8F sha1 1536d331a1ad1a85d3f9dc2021a3cf191537148b )
+	rom ( name "PlayerManager_v1.03_It_2572.lha" size 314284 crc 60D80F8E sha1 48373d3653c90e3c61bfccc5d51f78d0f2937b13 )
 )
 
 game (
-	name "Playroom, The - La Chambre de Peppy (France) (Europe)"
+	name "Playhouse Strip Poker (Europe)"
+	rom ( name "PlayhouseStripPoker_v1.0.lha" size 599756 crc 8C45333D sha1 ea120dc77fd7ea9082601754139d793f7b0d3261 )
+)
+
+game (
+	name "Playroom, The - La Chambre de Peppy (France)"
 	rom ( name "Playroom_v1.0_Fr.lha" size 723272 crc B74EE91D sha1 a02f6e39fa482988ee13ea278a33f4786042b849 )
 )
 
@@ -11196,8 +12685,13 @@ game (
 )
 
 game (
-	name "Poker Nights - Teresa Personally (Germany)"
-	rom ( name "PokerNights_v1.0_De.lha" size 1141436 crc 9DEFA55D sha1 89b8b8f40ef2e0c204bd3a31f6bd7854335e9ccb )
+	name "Poker Nights & Data Disks (Europe) (En,De)"
+	rom ( name "PokerNights&DataDisks_v1.2.lha" size 8436692 crc 8E637EF0 sha1 5387b44b3de4ee96287cb89f0cb677fbd3c8f37f )
+)
+
+game (
+	name "Poker Nights - Teresa Personally (Europe) (En,De)"
+	rom ( name "PokerNights_v1.2.lha" size 1196190 crc 1F1A9F64 sha1 b66355b1cd096c5e452a279a08c9e4fb27be31e4 )
 )
 
 game (
@@ -11211,7 +12705,7 @@ game (
 )
 
 game (
-	name "Police Quest 3 - The Kindred (MT32) (Germany)"
+	name "Police Quest 3 - The Kindred (Germany) (MT32)"
 	rom ( name "PoliceQuest3_v1.4_De_MT32.lha" size 4118168 crc D77E8FFD sha1 7f82ed312895aad285370ca36f376a6bb1b4be04 )
 )
 
@@ -11247,11 +12741,16 @@ game (
 
 game (
 	name "Advanced Dungeons & Dragons - Pool of Radiance - A Forgotten Realms Fantasy Role-Playing Epic, Vol.I (Europe) (v1.0)"
-	rom ( name "PoolOfRadiance_v1.2_0555.lha" size 1143482 crc 6F19464B sha1 fb3dfd047da19b99a699de66178e9ec9eef952d6 )
+	rom ( name "PoolOfRadiance_v1.3_0555.lha" size 1143904 crc 6AB330D8 sha1 8df5646e0769e438276083bf970277dfc744a7db )
 )
 
 game (
 	name "Advanced Dungeons & Dragons - Pools of Darkness - A Forgotten Realms Fantasy Role-Playing Epic, Vol.IV (Europe) (v1.0 March 9,1992)"
+	rom ( name "PoolsOfDarkness_v1.1.lha" size 1759279 crc 9BC8EC36 sha1 25242ab6c96eb0c6da3e398e381918de4b7c185c )
+)
+
+game (
+	name "Advanced Dungeons & Dragons - Pools of Darkness - A Forgotten Realms Fantasy Role-Playing Epic, Vol.IV (Europe)"
 	rom ( name "PoolsOfDarkness_v1.1.lha" size 1759279 crc 9BC8EC36 sha1 25242ab6c96eb0c6da3e398e381918de4b7c185c )
 )
 
@@ -11262,32 +12761,32 @@ game (
 
 game (
 	name "Popeye 2 (Europe)"
-	rom ( name "Popeye2_v1.1.lha" size 653839 crc 641F20D7 sha1 5bc04a935687686150940abcf7f09f440adba89e )
+	rom ( name "Popeye2_v1.2.lha" size 649851 crc 77337B14 sha1 cd06e0b76cbb3071e27f84da41e785bb3cb0f3a0 )
 )
 
 game (
-	name "Populous+ (Europe)"
-	rom ( name "Populous&DataDisks_v1.1_0069&1217.lha" size 532555 crc 2573EBF6 sha1 fe8d8cf06ea220d2626493302f857598224fc4e2 )
+	name "Populous & Data Disks (Europe)"
+	rom ( name "Populous&DataDisks_v1.3_0069&1217.lha" size 538412 crc 989A9CA4 sha1 0c5eb3a422ff0595aea7aa4effb4f0dc50f6c5a0 )
 )
 
 game (
 	name "Populous II & The Challenge Games (Europe)"
-	rom ( name "Populous2&ChallengeGames_v1.3_0079.lha" size 1263314 crc C1280B24 sha1 e6fd3a5dd4f3b24eaf22197fcad37f9dd69d73bd )
+	rom ( name "Populous2&ChallengeGames_v2.0_0079.lha" size 1244004 crc 90E65393 sha1 fb687cfec135a51e6c5b61c1ec08617d56b7bce1 )
 )
 
 game (
 	name "Populous II - Trials of the Olympian Gods (Europe)"
-	rom ( name "Populous2_v1.3_0079.lha" size 749637 crc FFE48C9E sha1 7cc1ee4443fdfcda096014f564a394542373b700 )
+	rom ( name "Populous2_v2.0_0079.lha" size 736108 crc DBD1A590 sha1 6c2176c3bc5e506d259a465aded936524b19b13b )
 )
 
 game (
 	name "Populous (Europe)"
-	rom ( name "Populous_v1.1_0069.lha" size 396100 crc BB26B425 sha1 058d001367f9b43b7ddec1adb198ee744d58d964 )
+	rom ( name "Populous_v1.3_0069.lha" size 420920 crc D64D955D sha1 3c38508d3ae7f61a4d6fa0a13a26dd486c182ed2 )
 )
 
 game (
 	name "Populous (USA)"
-	rom ( name "Populous_v1.1_NTSC_0070.lha" size 397313 crc 07D11C06 sha1 56ac941d6d8e9cd453a94be10a721559bc99b1ae )
+	rom ( name "Populous_v1.3_NTSC_0070.lha" size 421061 crc CE4358AF sha1 e0ca8b9d0490f1190ef4475e737d311a5070fa39 )
 )
 
 game (
@@ -11296,8 +12795,13 @@ game (
 )
 
 game (
-	name "Portal (Europe)"
-	rom ( name "Portal_v1.1.lha" size 746678 crc 8EF6E03D sha1 ce02e21f6789a801ec8039fdec2fca21c945cd9d )
+	name "Pop-Up (Europe)"
+	rom ( name "PopUp_v1.0a.lha" size 234979 crc 9DCDF6BE sha1 4afd94192406f81ea117681d5642360122330cce )
+)
+
+game (
+	name "Portal (USA)"
+	rom ( name "Portal_v2.0_NTSC_1971.lha" size 660246 crc B4ED3EE0 sha1 38cb63d79e7c146b888a7779e776e4174cc933b0 )
 )
 
 game (
@@ -11307,17 +12811,22 @@ game (
 
 game (
 	name "Ports of Call (Europe)"
-	rom ( name "PortsOfCall_v1.1_2489.lha" size 463363 crc B1C6FAF5 sha1 a8a79ec9257d1fdc5db7979e1d5d46f70aa05790 )
+	rom ( name "PortsOfCall_v1.5_2489.lha" size 464821 crc 14CBA9E2 sha1 f6d94b3499056e0b06c4107b2a2d6be7fdd36cb5 )
 )
 
 game (
 	name "Ports of Call (Germany)"
-	rom ( name "PortsOfCall_v1.1_De.lha" size 465283 crc 616C2057 sha1 eb134f6f8ae37ce21c5636d52dbc4cea8b0983b4 )
+	rom ( name "PortsOfCall_v1.5_De.lha" size 466549 crc 21783793 sha1 bbcd543582a68793aca45ead596a665d8a6e741c )
 )
 
 game (
 	name "Ports of Call (France)"
-	rom ( name "PortsOfCall_v1.1_Fr.lha" size 464004 crc 4F437A97 sha1 5e65abda89d380dc279ede6ab33522031bf5ae56 )
+	rom ( name "PortsOfCall_v1.5_Fr.lha" size 467076 crc 8949C32D sha1 7b1f420cc54e4d24ad615a285e317ac86f9a451e )
+)
+
+game (
+	name "Postman Pat III (Europe)"
+	rom ( name "PostmanPat3_v1.0_2614.lha" size 169392 crc AA3859F5 sha1 e5f4b7f852fc878963684a8eda349015a7273def )
 )
 
 game (
@@ -11326,18 +12835,23 @@ game (
 )
 
 game (
+	name "Pot Panic (Europe)"
+	rom ( name "PotPanic_v1.0_1776.lha" size 161784 crc 2D6F95D9 sha1 4e96b2d8022177ea2cb4865f5519ef8d103f1529 )
+)
+
+game (
 	name "P.O.W. (Europe)"
-	rom ( name "POW_v1.1.lha" size 533223 crc 3F21BDED sha1 6fb9e278902fb070924c1021bf0ce5068e16d38d )
+	rom ( name "POW_v1.2_0080.lha" size 539197 crc 97B9351A sha1 6b34b8493852db7e733e15b8ad7a45ee6d316999 )
 )
 
 game (
 	name "Power, The (Europe)"
-	rom ( name "Power_v1.1_1284.lha" size 455047 crc 0867F189 sha1 bd0a671c2135156acef21db13afa873b6f433244 )
+	rom ( name "Power_v1.2a_1284.lha" size 473681 crc 72C0270A sha1 b76bce5bc0dd12e2faac30ec6bd95f9c017a8855 )
 )
 
 game (
 	name "Power Drift (Europe)"
-	rom ( name "PowerDrift_v1.3_1444.lha" size 618716 crc 76927CD2 sha1 bc6d3232ef28ac11390becb288b2fa22667b0dba )
+	rom ( name "PowerDrift_v1.4_1444.lha" size 618965 crc FF4304B9 sha1 a562a779c7590404b4eb8be9c97e6235328743c8 )
 )
 
 game (
@@ -11352,7 +12866,7 @@ game (
 
 game (
 	name "PowerMonger (Europe)"
-	rom ( name "Powermonger_v1.3_0081.lha" size 742691 crc 0B179872 sha1 7e30df93679f008bf73bfb2c0d9311a20f32f3e7 )
+	rom ( name "Powermonger_v1.4.1_0081.lha" size 1710163 crc 02155F45 sha1 525251a05b58b87e768a09da43449a548629a0b6 )
 )
 
 game (
@@ -11371,27 +12885,27 @@ game (
 )
 
 game (
-	name "Powerplay - The Game of the Gods (Enhanced) (Europe)"
+	name "Powerplay - The Game of the Gods (Europe) (Enhanced)"
 	rom ( name "Powerplay_v1.1_0856.lha" size 533355 crc 4476CD83 sha1 88096cae4df9aae451e3cea47a70acd0c010c5f2 )
 )
 
 game (
-	name "Powerplay - Das Spiel Der Götter (Enhanced) (Germany)"
+	name "Powerplay - Das Spiel Der Götter (Germany) (Enhanced)"
 	rom ( name "Powerplay_v1.1_De.lha" size 512017 crc 2662DF44 sha1 b94fe13d45a6b27ec7f019eb49c25297e731af3a )
 )
 
 game (
-	name "Powerplay - El Juego De Los Dioses (Enhanced) (Spain)"
+	name "Powerplay - El Juego De Los Dioses (Spain) (Enhanced)"
 	rom ( name "Powerplay_v1.1_Es.lha" size 534605 crc D3064A14 sha1 52b2d53fdba05c220f0f1c5a6dc367e58837ad25 )
 )
 
 game (
-	name "Powerplay - Le Jeu Des Dieux (Enhanced) (France)"
+	name "Powerplay - Le Jeu Des Dieux (France) (Enhanced)"
 	rom ( name "Powerplay_v1.1_Fr.lha" size 511249 crc B63FA82B sha1 e486ec785543c570beb782379a9de585fc4bf206 )
 )
 
 game (
-	name "Powerplay - The Game of the Gods (Enhanced) (Gr) (Europe)"
+	name "Powerplay - The Game of the Gods (Greece) (Enhanced)"
 	rom ( name "Powerplay_v1.1_Gr.lha" size 529736 crc 4721834F sha1 ef7e2474d989a001e263db5c0433a6adac35fcea )
 )
 
@@ -11407,12 +12921,17 @@ game (
 
 game (
 	name "Prawo Krwi (Poland) (AGA)"
-	rom ( name "PrawoKrwi_v1.0_AGA_Pl.lha" size 3219383 crc 5B881E5B sha1 42a5299e847f323bf53fbe78220c9399b658d629 )
+	rom ( name "PrawoKrwi_v2.1_AGA_Pl.lha" size 3218106 crc 02BABC23 sha1 3837eda9e0adcef417b0b46d251a92f98662f2e5 )
 )
 
 game (
 	name "Predator 2 (Europe)"
-	rom ( name "Predator2_v1.1.lha" size 1245318 crc 8C98BB5B sha1 05d7f61530d34f455ce8df31ac4c42b247a9e2ba )
+	rom ( name "Predator2_v1.2_0274.lha" size 1252130 crc 68693009 sha1 1b1e0937cafd31f6f2cdae22a6f13cf820b74de0 )
+)
+
+game (
+	name "Predator 2 (USA)"
+	rom ( name "Predator2_v1.2_NTSC.lha" size 1258231 crc 508F6CA7 sha1 8425a737382fb69309f46233fbb95a4adf1ee9c9 )
 )
 
 game (
@@ -11471,6 +12990,11 @@ game (
 )
 
 game (
+	name "Prey - An Alien Encounter (Europe) (CD32)"
+	rom ( name "Prey_v1.0_CD32.lha" size 49011493 crc CB25C1DF sha1 7e5ea8f144c7d83759c733169dcd0a3e8d3e381d )
+)
+
+game (
 	name "Primal Rage (Europe) (AGA)"
 	rom ( name "PrimalRage_v1.1_AGA.lha" size 3156149 crc 0BFF98A5 sha1 86eecdff65aba88bd8c1a4b8e690cc6ff896cba5 )
 )
@@ -11487,37 +13011,37 @@ game (
 
 game (
 	name "Prince of Persia (France)"
-	rom ( name "PrinceDePerse_v3.1_Fr_2290.lha" size 333625 crc 87367765 sha1 dc63a900ef2213caf96328041c8fca35828cd904 )
+	rom ( name "PrinceDePerse_v4.4_Fr_2290.lha" size 340987 crc B76DCB9C sha1 9f022a67a782c31345fb71302026721374c6de9d )
 )
 
 game (
 	name "Prince of Persia (Europe)"
-	rom ( name "PrinceOfPersia_v3.1_1823.lha" size 334395 crc 2E3FCAC6 sha1 19eacb3b01fd7b7643850bc1b7ec8e0462e43f32 )
+	rom ( name "PrinceOfPersia_v4.4_1823.lha" size 341740 crc 0A4ABC82 sha1 a98baa1f8b51d594764b3050f56dbceb8ff13f94 )
 )
 
 game (
 	name "Prince of Persia (Germany)"
-	rom ( name "PrinceOfPersia_v3.1_De_0082.lha" size 334007 crc E249B086 sha1 ec9783d430724624de9a8f63948cbec9e2f9f3cd )
+	rom ( name "PrinceOfPersia_v4.4_De_0082.lha" size 341352 crc 5AB5B2B5 sha1 50f1f799e3de96e719e9f57b83b55761f182dee6 )
 )
 
 game (
 	name "Prince of Persia (USA)"
-	rom ( name "PrinceOfPersia_v3.1_NTSC_1407.lha" size 333190 crc 23D699AC sha1 74fe1436edfaaade974dcad99c687e3081d67f81 )
+	rom ( name "PrinceOfPersia_v4.4_NTSC_1407.lha" size 340530 crc F4CACF19 sha1 65d0d0ebe23fd32e512308ba0b8113808ae39f31 )
 )
 
 game (
 	name "Prison (Europe)"
-	rom ( name "Prison_v1.0_0416.lha" size 515793 crc 556ACD0C sha1 73dc5452de1debb9798db1f7774d604b88f43495 )
+	rom ( name "Prison_v2.0_0416.lha" size 516003 crc 0E611C82 sha1 775eb71fc1a586784cf63d7695474662b383f8ec )
 )
 
 game (
 	name "Prison (USA)"
-	rom ( name "Prison_v1.0_NTSC.lha" size 700439 crc 5E99BBA2 sha1 df5b33bb5108920fc5608111994e92c3d1fe2fac )
+	rom ( name "Prison_v2.0_NTSC.lha" size 515060 crc 8F4B788C sha1 e8592540c453e0c0b52418cdb52e5dfe5ebf610d )
 )
 
 game (
 	name "Pro Boxing Simulator (Europe)"
-	rom ( name "ProBoxingSimulator_v1.1_1663.lha" size 411957 crc 61B5A0BB sha1 96d10d4f3cdc1b279e60f2cc98ac4e37c521d465 )
+	rom ( name "ProBoxingSimulator_v1.2_1663.lha" size 412652 crc F6BC729F sha1 3ac23879e234b66dae2f99c09ed008c871202a7b )
 )
 
 game (
@@ -11531,18 +13055,18 @@ game (
 )
 
 game (
-	name "Project-X (Bonus Level) (Europe)"
+	name "Project-X (Europe) (Bonus Level)"
 	rom ( name "ProjectXBonusLevel_v1.0.lha" size 220090 crc 9BBEFC95 sha1 6debaf96dab2e41832a4b80a21d55c18bde82b8f )
 )
 
 game (
 	name "Project-X - Special Edition '93 (Europe)"
-	rom ( name "ProjectXSE_v1.5_0927.lha" size 2780892 crc 923E0EA4 sha1 8db83d225a60a6966535fe3dc5365630f97f09f6 )
+	rom ( name "ProjectXSE_v1.6_0927.lha" size 2782245 crc 28E682E3 sha1 f2ff5a38b2a0f921c27d2f4ee9c5e5153d8046b1 )
 )
 
 game (
 	name "Project-X - Special Edition (Europe) (CD32)"
-	rom ( name "ProjectXSE_v1.5_CD32.lha" size 2299598 crc D70BB451 sha1 fbea7e2844a378fc0b86f7429c2b9d7c1233cbb6 )
+	rom ( name "ProjectXSE_v1.6_CD32.lha" size 2300957 crc 55AE715C sha1 a846694123a1be378c03d252771adb133f6e1200 )
 )
 
 game (
@@ -11552,7 +13076,7 @@ game (
 
 game (
 	name "Projectyle (Europe)"
-	rom ( name "Projectyle_v1.11_0379.lha" size 487940 crc 733D3E16 sha1 af5adbd041c27174e52aeec05b01db73cd15551d )
+	rom ( name "Projectyle_v2.0_0379.lha" size 495600 crc 003B7AAC sha1 c5fe76dc060c702c14bddbdf8775784116924ec6 )
 )
 
 game (
@@ -11577,12 +13101,12 @@ game (
 
 game (
 	name "Pro Tennis Simulator (Europe)"
-	rom ( name "ProTennisSimulator_v1.3_Files.lha" size 263884 crc 01CCF302 sha1 ca5cc5da22c6bc5ac4be8a562c316810ebb672f4 )
+	rom ( name "ProTennisSimulator_v1.3a_Files.lha" size 264142 crc 2AD2F625 sha1 ebf5e2f4b00ab83a8aa4d44a156efca8968fa4b8 )
 )
 
 game (
-	name "Pro Tennis Simulator (Image) (Europe)"
-	rom ( name "ProTennisSimulator_v1.3_Image.lha" size 204313 crc 844C2D4C sha1 dd720dd8ef364906668ac7063fe31b455e292c94 )
+	name "Pro Tennis Simulator (Europe) (Image)"
+	rom ( name "ProTennisSimulator_v1.3a_Image.lha" size 204571 crc CC4464BC sha1 e30a9bc512b5784f2baccad7ee1d252e1cc6b307 )
 )
 
 game (
@@ -11591,7 +13115,7 @@ game (
 )
 
 game (
-	name "Pro Tennis Tour 2 (512 KB) (Europe)"
+	name "Pro Tennis Tour 2 (Europe) (512 kB)"
 	rom ( name "ProTennisTour2_v1.5_512KB_3077.lha" size 646317 crc F5C8BD78 sha1 4f316fe6754796e771a09007919cf6383ea98b3e )
 )
 
@@ -11627,27 +13151,37 @@ game (
 
 game (
 	name "Puggsy (Europe)"
-	rom ( name "Puggsy_v1.0_1113.lha" size 2165534 crc 81061461 sha1 cc98acee1583713c323b214e49aa23b8ac30ce7c )
+	rom ( name "Puggsy_v2.0_1113.lha" size 2172606 crc FA978B3C sha1 5e101523a7734bcfb0be868693383b0f46ce6db7 )
+)
+
+game (
+	name "Pulsator (Europe) (AGA) (Demo)"
+	rom ( name "PulsatorDemo_v1.1_AGA.lha" size 1971334 crc 3CDE0211 sha1 74badb9967841b3eeb35ea8c270c821c21318256 )
 )
 
 game (
 	name "Purple Saturn Day (Europe)"
-	rom ( name "PurpleSaturnDay_v1.1_0562.lha" size 485268 crc 8748C95B sha1 de6eebd23ccdb02df3b4d5d91877571870fd9438 )
+	rom ( name "PurpleSaturnDay_v2.1_0562.lha" size 491673 crc 138CA9AD sha1 f8fb866ad1afba86361ea88dd0479fec6d1032df )
+)
+
+game (
+	name "Purple Saturn Day (USA)"
+	rom ( name "PurpleSaturnDay_v2.1_NTSC_0945.lha" size 526635 crc 50F6A419 sha1 21d05e92d686ca9132f4b7eeb25a29a571d4082c )
 )
 
 game (
 	name "Push-Over (Europe)"
-	rom ( name "PushOver_v1.23_1267.lha" size 1315574 crc 357B5971 sha1 a41d1726e2ce57ba255afb657d059f3d19c31ad9 )
+	rom ( name "PushOver_v1.23_1267.lha" size 1315848 crc EE11C18D sha1 18f7c2db408158955600b11fbf1b286f20cb7180 )
 )
 
 game (
 	name "Putty (Europe)"
-	rom ( name "Putty_v1.2a_0197.lha" size 1664163 crc 3564465D sha1 543b775272b985af90f025f9414dec61a5beea87 )
+	rom ( name "Putty_v1.2b_0197.lha" size 1670327 crc 2F4C5802 sha1 c1f1b504cc1ebdbdccd736fd0dc35d5f98fe1089 )
 )
 
 game (
 	name "Putty Squad (Europe) (AGA)"
-	rom ( name "PuttySquad_v1.2_AGA.lha" size 1661432 crc 7463A8AD sha1 67bdcb407a1833e2a8a1cd0b13560361aa49e704 )
+	rom ( name "PuttySquad_v1.3_AGA.lha" size 1662064 crc 4E5B8988 sha1 e0c60e1e928b6d114e6a2d1498184f3bedc5574f )
 )
 
 game (
@@ -11657,7 +13191,7 @@ game (
 
 game (
 	name "Puzznic (Europe)"
-	rom ( name "Puzznic_v1.3_0041.lha" size 146904 crc 3A33DFF8 sha1 58b036658bfbf34fac8c326f10d318429023edfd )
+	rom ( name "Puzznic_v1.3_0041.lha" size 147022 crc CA8DDB9B sha1 ed293ac09e61d500049eb57ee3e640f996db993d )
 )
 
 game (
@@ -11677,7 +13211,7 @@ game (
 
 game (
 	name "Quadralien (Europe)"
-	rom ( name "Quadralien_v1.0_0918.lha" size 178206 crc 4ABB8509 sha1 78b16a67235b86ad82f132bbe78a52b053d8943f )
+	rom ( name "Quadralien_v1.1_0918.lha" size 173546 crc 70f7bed6 sha1 5d1eb1d22e1d8a7e51825e9e1be94bf5a72be6b0 )
 )
 
 game (
@@ -11691,28 +13225,33 @@ game (
 )
 
 game (
+	name "Quasar Wars (Europe)"
+	rom ( name "QuasarWars_v1.2.lha" size 1321884 crc 731A5AD1 sha1 2b01e6799669c1f3bda9ca1dd98939d4db486369 )
+)
+
+game (
 	name "Quest for Glory II - Trial By Fire (Europe)"
 	rom ( name "QuestForGlory2_v1.3_1868.lha" size 4425104 crc 67C81CAE sha1 95fdd21ee98b506260a55241b2b9367b978aae00 )
 )
 
 game (
-	name "Quest for Glory II - Trial By Fire (MT32) (Europe)"
+	name "Quest for Glory II - Trial By Fire (Europe) (MT32)"
 	rom ( name "QuestForGlory2_v1.3_MT32_1868.lha" size 4429934 crc EB978252 sha1 65e0e0826138f137d6da97404f6cd90bb5b0f597 )
 )
 
 game (
-	name "Hero's Quest - So You Want To Be A Hero (Europe)"
-	rom ( name "QuestForGlory_v1.3_0795.lha" size 3012449 crc ACFDA286 sha1 f627c438fac207fdf568dd46f0f16ca0dd3007f1 )
-)
-
-game (
-	name "Auf Der Suche Nach Dem Vogel Der Zeit (Europe)"
-	rom ( name "QuestForTheTimeBird_v1.2_Files_0564.lha" size 1708981 crc C92FCD2A sha1 7cd29304101a09ac81869a528e2c9b298fe9ec28 )
+	name "Hero's Quest - So You Want to Be a Hero (Europe)"
+	rom ( name "QuestForGlory_v1.4b.lha" size 3051268 crc 4D26496F sha1 16609f82690147cb0148bd4580debbdf0893efed )
 )
 
 game (
 	name "Quest for the Time-Bird, The (Europe)"
-	rom ( name "QuestForTheTimeBird_v1.2_Image_0564.lha" size 1906001 crc CFD7EC16 sha1 0fa509c3605345e662d7dfc21a6665149c8a6099 )
+	rom ( name "QuestForTheTimeBird_v1.5_Files_0564.lha" size 1710808 crc 9AD59582 sha1 c9612fc1f8d40d039da55fe7be60a8eaf1043c98 )
+)
+
+game (
+	name "Quest for the Time-Bird, The (Europe) (Image)"
+	rom ( name "QuestForTheTimeBird_v1.5_Image_0564.lha" size 1907830 crc F40CCA97 sha1 5fc6bef6822f680ba3bf92601d2814b6c39ca0d4 )
 )
 
 game (
@@ -11732,12 +13271,17 @@ game (
 
 game (
 	name "Quete de l'Oiseau du Temps, La (France)"
-	rom ( name "QueteDeLOiseauDuTemp_v1.2_Fr_Files_2343.lha" size 1168913 crc 56CE5E87 sha1 1ccc38441b14cb611018733be168688ad06a1121 )
+	rom ( name "QueteDeLOiseauDuTemp_v1.5_Fr_Files_2343.lha" size 1170753 crc C3F9E300 sha1 6bc506e2bc945962ebcaa1908e6930a2027bcf33 )
 )
 
 game (
-	name "Quete de l'Oiseau du Temps, La (Image) (France)"
-	rom ( name "QueteDeLOiseauDuTemp_v1.2_Fr_Image_2343.lha" size 1139249 crc CB2E95D4 sha1 a0ee6c4243fa6655814dac4097b17adc34c6962f )
+	name "Quete de l'Oiseau du Temps, La (France) (Image)"
+	rom ( name "QueteDeLOiseauDuTemp_v1.5_Fr_Image_2343.lha" size 1141081 crc 4D521ADB sha1 54e0e464d53f10d9f11e5c23103c7f491460923d )
+)
+
+game (
+	name "Quicksilva (Europe) (PD/Freeware)"
+	rom ( name "Quicksilva_v1.0.lha" size 1521995 crc B93CE16E sha1 baab858680b613d8c61b47b3896922785f326408 )
 )
 
 game (
@@ -11747,17 +13291,17 @@ game (
 
 game (
 	name "Quik - The Thunder Rabbit (Europe)"
-	rom ( name "QuikTheThunderRabbit_v1.2a.lha" size 2392002 crc 68136164 sha1 5fd5debf6913f701ce2d36c1b77aff93560d4cf3 )
+	rom ( name "QuikTheThunderRabbit_v1.3.lha" size 2394050 crc 5A4EB192 sha1 4916261a8df133c5b32db964524f89588e38b01d )
 )
 
 game (
 	name "Quik - The Thunder Rabbit (Europe) (AGA)"
-	rom ( name "QuikTheThunderRabbit_v1.2a_AGA.lha" size 2392051 crc 84FB8901 sha1 9a0ff6b37ff2c9cd4793359d8d8550c9e1716d28 )
+	rom ( name "QuikTheThunderRabbit_v1.3_AGA.lha" size 2394114 crc C1C3D95D sha1 6be9ef7ff40f2377e79f71a9a5273a062f4ada94 )
 )
 
 game (
 	name "Quik - The Thunder Rabbit (Europe) (CD32)"
-	rom ( name "QuikTheThunderRabbit_v1.2a_CD32.lha" size 4010253 crc CB3049B1 sha1 ed328f7a69f139a0ef943eaaf8be1882233be94e )
+	rom ( name "QuikTheThunderRabbit_v1.3_CD32.lha" size 4008706 crc 8AD556EA sha1 487a78566a2edfe49e608f4b1bc379a0ff38b14c )
 )
 
 game (
@@ -11772,32 +13316,27 @@ game (
 
 game (
 	name "Race Drivin' (Europe)"
-	rom ( name "RaceDrivin_v0601.1.lha" size 1119917 crc C9DCFF0D sha1 ccf047a73afa633dda43c63b52f5f44e1e8665b0 )
-)
-
-game (
-	name "Race Drivin' (No Intro) (Europe)"
-	rom ( name "RaceDrivin_v0601.1_NoIntro.lha" size 557848 crc 65C569CF sha1 e2b58b28eb59f75f4077910bd6f380dfe89bf212 )
+	rom ( name "RaceDrivin_v2.01.lha" size 1113988 crc 573ABB60 sha1 9439eb8a5e02045f3c32de32a89f920c4a0d1576 )
 )
 
 game (
 	name "Rackney's Island (Europe)"
-	rom ( name "RackneysIsland_v1.0.lha" size 770096 crc F67B1AB1 sha1 f261da94bbfe4bcf9c07c069a5489539ee682a5f )
+	rom ( name "RackneysIsland_v1.1.lha" size 771643 crc 0BC10735 sha1 40dc60108496baefded07a21a008450fb31ac58e )
 )
 
 game (
 	name "Racter (Europe)"
-	rom ( name "Racter_v1.0.lha" size 187881 crc 972EE86F sha1 e75f367ff5d4cced7f03fbd8eef04fa6c790c885 )
+	rom ( name "Racter_v1.1.lha" size 188228 crc 990CCEEA sha1 9163f32e1c0d0a138ce3c0299dad26b9d1508cd0 )
 )
 
 game (
 	name "Raffles (Europe)"
-	rom ( name "Raffles_v1.0_0021.lha" size 199895 crc AEBC3C32 sha1 d74da3bbb90ce755ec6fdaa0a5984423fc53b3e4 )
+	rom ( name "Raffles_v1.1_0021.lha" size 204619 crc 7EB9B363 sha1 bf4e39c387436300a001b9b526cce7670d28451b )
 )
 
 game (
 	name "Raffles (Europe) (CDTV)"
-	rom ( name "Raffles_v1.0_CDTV.lha" size 198397 crc C3838456 sha1 ede15f0b75683eb105bc6ab82f778f0209d91de4 )
+	rom ( name "Raffles_v1.1_CDTV.lha" size 203131 crc 29D02EEF sha1 4b50ea9fabd9b66f18a32c5557baa6bf3fe25dfe )
 )
 
 game (
@@ -11806,7 +13345,7 @@ game (
 )
 
 game (
-	name "Rage v2.0 (Unreleased) (Europe)"
+	name "Rage v2.0 (Europe) (Unreleased)"
 	rom ( name "RageV2_v1.0.lha" size 745409 crc 2082DB60 sha1 6e58be715107f878dbfe69c852e78b70d5d1a158 )
 )
 
@@ -11846,7 +13385,7 @@ game (
 )
 
 game (
-	name "Rally Championships (Europe) (En,Fr,De,Es,It,Nl,Pt,Pl) (ECS)"
+	name "Rally Championships (Europe) (En,Fr,De,Es,It,Nl,Pt,Pl)"
 	rom ( name "RallyChampionships_v1.1.lha" size 3159859 crc 6E9D18F1 sha1 554cfa1556aa5241509a42256bd960ffa753b216 )
 )
 
@@ -11862,12 +13401,12 @@ game (
 
 game (
 	name "Rambo III (Europe)"
-	rom ( name "Rambo3_v1.1_2433.lha" size 488698 crc 84F5D3B1 sha1 ae1bb53d901c7de1dbc41d4fadd1ea738ce003ab )
+	rom ( name "Rambo3_v2.0_2433.lha" size 493449 crc B74B221A sha1 622a4400c8de6c56dd0bf2944d998f9392f169fd )
 )
 
 game (
 	name "Rambo III (USA)"
-	rom ( name "Rambo3_v1.1_NTSC_2432.lha" size 507159 crc 2C91C39B sha1 7b65f82a876f97a5a2c90b26527f504e908e3bee )
+	rom ( name "Rambo3_v2.0_NTSC_2432.lha" size 512391 crc 5397BE03 sha1 d417e8e514f2fab4055616f8abdc196ab48c385f )
 )
 
 game (
@@ -11916,6 +13455,16 @@ game (
 )
 
 game (
+	name "Realm of the Trolls (Europe) (Compilations)"
+	rom ( name "RealmOfTheTrolls_v1.2_1Disk_3010.lha" size 226680 crc 1633AB24 sha1 634201a6b4a449d149e83faf27e93ea6d5788f26 )
+)
+
+game (
+	name "Realm of the Trolls (Europe)"
+	rom ( name "RealmOfTheTrolls_v1.2_2Disk.lha" size 267789 crc DA596EDE sha1 593eb39a74caed5fa5433212a08ad85ef27d22ea )
+)
+
+game (
 	name "Realms (Europe)"
 	rom ( name "Realms_v1.3_1497.lha" size 572746 crc 91E57FE6 sha1 ed916d108f334689f242b0cc2eb9f46002b041cc )
 )
@@ -11936,8 +13485,18 @@ game (
 )
 
 game (
+	name "Rectangle (Europe)"
+	rom ( name "Rectangle_v1.0.lha" size 816940 crc A2DE5FBA sha1 301a3ab0d1219f4d7469869442db4a45d32137c9 )
+)
+
+game (
+	name "Red 41 - The Silent Death (Europe) (Demo)"
+	rom ( name "Red41Demo_v1.0.lha" size 1104411 crc 0BDDD3D5 sha1 373185af8f23da2956912e3571e34c1a51e2d6a5 )
+)
+
+game (
 	name "Red Baron (Europe)"
-	rom ( name "RedBaron_v2.1_1595.lha" size 1742691 crc F458D859 sha1 e556bad7006ec64cd6cd4d072386d8eaf5939926 )
+	rom ( name "RedBaron_v2.1.lha" size 1723216 crc 51C0E78C sha1 b0e4007018ccf1dc3d213d5af656023881d9d8ca )
 )
 
 game (
@@ -11962,7 +13521,12 @@ game (
 
 game (
 	name "Red Zone (Europe)"
-	rom ( name "RedZone_v2.0.lha" size 925594 crc 67E8229D sha1 849e92d1d5427ab02c80e43eff32d9c3931aa983 )
+	rom ( name "RedZone_v3.1.lha" size 1061002 crc FCE6B557 sha1 b962bf2f167f182028f433f4f62d61e408a146ce )
+)
+
+game (
+	name "Red Zone (USA)"
+	rom ( name "RedZone_v3.1_NTSC.lha" size 1061300 crc 74AF3CDF sha1 0cc876318703fefc1cbfd7a34467750bfd649d3a )
 )
 
 game (
@@ -11971,18 +13535,43 @@ game (
 )
 
 game (
+	name "Regent (Germany)"
+	rom ( name "Regent_v1.0_De.lha" size 2692996 crc 05BCA416 sha1 f01a853f849c310bb06b6012697cd54b0a00779d )
+)
+
+game (
+	name "Reise ins Land des Big Ben (Germany)"
+	rom ( name "ReiseInsLandDesBigBen_v1.1_De.lha" size 323081 crc 76ED91C4 sha1 750b844faf45b76cfce68b38c850734918b45760 )
+)
+
+game (
+	name "Reisende im Wind II (Germany)"
+	rom ( name "ReisendeImWind2_v1.0_De.lha" size 980793 crc C16A078B sha1 3283a5093b2a414a1346429993a269d54657156b )
+)
+
+game (
+	name "Reisende im Wind (Germany)"
+	rom ( name "ReisendeImWind_v1.0_De.lha" size 541820 crc 045EF0B5 sha1 922f34b8e3022051e83a9e93cd9cf57e49dfd282 )
+)
+
+game (
+	name "Reise zum Mittelpunkt der Erde (Germany)"
+	rom ( name "ReiseZumMittelpunktDerErde_v1.0_De_0781.lha" size 855206 crc D9A0AD98 sha1 6ffd6d3298c214ae3808a26f697e855644576ea1 )
+)
+
+game (
 	name "Renaissance (Europe)"
 	rom ( name "Renaissance_v1.01_2415.lha" size 640827 crc C06557BE sha1 2a64a54c0ddb93eaacb4affb7cb72e007d5dec1c )
 )
 
 game (
-	name "Renegade III (Unreleased) (Europe)"
+	name "Renegade III (Europe) (Unreleased)"
 	rom ( name "Renegade3_v1.0b.lha" size 185271 crc 88CD6448 sha1 1249f240712c03e5130a45324efdf4ab8b7d2c42 )
 )
 
 game (
 	name "Renegade (Europe)"
-	rom ( name "Renegade_v1.2.lha" size 368942 crc 4E6238A6 sha1 524c75c32671b79dca842ff5c2e67586c55f4ffa )
+	rom ( name "Renegade_v1.2_1966.lha" size 360395 crc DD6B176E sha1 e419f2f67f7bffb7482a4d35aff342164b688c36 )
 )
 
 game (
@@ -11992,12 +13581,12 @@ game (
 
 game (
 	name "Resolution 101 (Europe)"
-	rom ( name "Resolution101_v1.0.lha" size 486764 crc A1D71D26 sha1 5d9d829a6fa94b13fadb6e08d653ade5195051ce )
+	rom ( name "Resolution101_v2.1_0221.lha" size 296049 crc BB2FCAB1 sha1 9fb7aba609aa9acdcb0736baa3702a0be712e52e )
 )
 
 game (
 	name "Star Wars - Return of the Jedi (Europe)"
-	rom ( name "ReturnOfTheJedi_v1.2_2153.lha" size 351465 crc 8E122128 sha1 2b1f2f9a23d17c3e7af7b496d5fe1c423e2fe3c6 )
+	rom ( name "ReturnOfTheJedi_v2.0_2152.lha" size 369617 crc DB50A688 sha1 edb720d45edabc2cc94d6558218a4afb6963e2c3 )
 )
 
 game (
@@ -12036,8 +13625,8 @@ game (
 )
 
 game (
-	name "Revenge of Defender (Europe)"
-	rom ( name "RevengeOfDefender_v1.0.lha" size 973629 crc 49E36D33 sha1 baab4b4d9010e1cc321a9818fdee43601f5b1457 )
+	name "Revenge of Defender (USA)"
+	rom ( name "RevengeOfDefender_v1.0_NTSC.lha" size 973823 crc A9C17197 sha1 95dca3fb6f0a48def49ccbd13ce48bd54497888d )
 )
 
 game (
@@ -12053,6 +13642,16 @@ game (
 game (
 	name "Revenge of the Mutant Camels (USA)"
 	rom ( name "RevengeOfTheMutantCamels_v1.0_NTSC.lha" size 111900 crc 9824C977 sha1 0641fce950ec3553a81c6166df1f0f284401d41c )
+)
+
+game (
+	name "La ricerca dell'uccello del tempo (Italy) (Files)"
+	rom ( name "RicercaDellAugelloDelTempo_v1.5_It_Files.lha" size 1098818 crc 4E343D20 sha1 44ca1229cbd3436cf7cc32209acac14408856c24 )
+)
+
+game (
+	name "La ricerca dell'uccello del tempo (Italy)"
+	rom ( name "RicercaDellAugelloDelTempo_v1.5_It_Image.lha" size 1194205 crc 62B1B39F sha1 43b4017406bf798320484cf99d32a4e426ff2661 )
 )
 
 game (
@@ -12107,17 +13706,17 @@ game (
 
 game (
 	name "Rise of the Robots (Europe) (AGA)"
-	rom ( name "RiseOfTheRobots_v1.3_AGA_1763.lha" size 7494978 crc 4F07C047 sha1 609cb7a786f540389fca031fccbaccc8a1e22167 )
+	rom ( name "RiseOfTheRobots_v1.3_AGA_1763.lha" size 7495015 crc 3CB67D5F sha1 a90b11b681e66d383339c2a1f1eec820aa15473c )
 )
 
 game (
 	name "Rise of the Robots (Europe) (CD32)"
-	rom ( name "RiseOfTheRobots_v1.3_CD32.lha" size 8166457 crc D3D6315E sha1 93ddbf01e7fbf5f68249ab36e3b7f34049a0b3f3 )
+	rom ( name "RiseOfTheRobots_v1.3_CD32.lha" size 8166495 crc C382967B sha1 88a7dc75efc087e68f7ad7ecf77c94c00cf88eb5 )
 )
 
 game (
 	name "Rise of the Robots (Europe)"
-	rom ( name "RiseOfTheRobots_v1.4-B_1365.lha" size 4641570 crc A668D342 sha1 68dffcd130abef445591fb82192ecbf125264ae8 )
+	rom ( name "RiseOfTheRobots_v1.4-C_1365.lha" size 4641771 crc 2C9F1AD5 sha1 21737c2f332cb02c1448479ba37b8556caed5061 )
 )
 
 game (
@@ -12137,17 +13736,17 @@ game (
 
 game (
 	name "Roadkill (Europe) (AGA)"
-	rom ( name "Roadkill_v2.2_AGA_1108.lha" size 2322081 crc 3CDBDACD sha1 7900ed25969987f4f59851480c6d9a8526d118b7 )
+	rom ( name "Roadkill_v2.2-B_AGA_1108.lha" size 2333994 crc 344A4ADF sha1 76fbf2b5a0e325d5db4a9e282490ddde05fa77b6 )
 )
 
 game (
 	name "Roadkill (Europe) (CD32)"
-	rom ( name "Roadkill_v2.2_CD32.lha" size 25610307 crc EF486F28 sha1 512f87c196f679e54b6901f1e674ed562d526fa7 )
+	rom ( name "Roadkill_v2.2-B_CD32.lha" size 25622232 crc 3C079BC8 sha1 8a55ae379fd92b66b9fb0a5cc2538583b7f4066c )
 )
 
 game (
-	name "Roadkill (No Intro) (Europe) (CD32)"
-	rom ( name "Roadkill_v2.2_CD32_NoIntro.lha" size 6345313 crc 5BE33747 sha1 30cad44e7ead8ea9c520cd8b213f91e074aab569 )
+	name "Roadkill (Europe) (CD32) (No Intro)"
+	rom ( name "Roadkill_v2.2-B_CD32_NoIntro.lha" size 6357226 crc A1B0B885 sha1 85c310e3a5ef0dc0a7c4b9384bd348f8dd5af842 )
 )
 
 game (
@@ -12157,11 +13756,11 @@ game (
 
 game (
 	name "Roadwar Europa (Europe)"
-	rom ( name "RoadwarEuropa_v1.0_2510.lha" size 149178 crc 45C7CAE4 sha1 6373b0128fefc3c9c37de4f941d194aa7f95c51e )
+	rom ( name "RoadwarEuropa_v1.1_2510.lha" size 151118 crc 35A08F40 sha1 d3158533a081ece80ce21e46c2653b2c107f65a2 )
 )
 
 game (
-	name "Roadwars (Arcadia) (Europe)"
+	name "Roadwars (Europe) (Arcadia)"
 	rom ( name "RoadWars_v0.1_Arcadia.lha" size 301301 crc 23122B25 sha1 a2c836cf0bb9183145807324d2e66a4dc4a7f113 )
 )
 
@@ -12192,7 +13791,12 @@ game (
 
 game (
 	name "RoboCop 2 (Europe)"
-	rom ( name "RoboCop2_v1.2_1220.lha" size 1075377 crc F7C4661B sha1 d19e4b7ff617162856c5c1151661d39c06291bcd )
+	rom ( name "RoboCop2_v1.2_1220.lha" size 1105285 crc C2D9E964 sha1 0014de6b38e11e81534a1269754c45d457922d45 )
+)
+
+game (
+	name "RoboCop 2 (USA)"
+	rom ( name "RoboCop2_v1.2_NTSC.lha" size 1100950 crc 448A1EAD sha1 51309047e24aac3e14e4d098cd51cc66b2e283ab )
 )
 
 game (
@@ -12207,7 +13811,12 @@ game (
 
 game (
 	name "RoboCop (Europe)"
-	rom ( name "RoboCop_v1.2_2066.lha" size 430148 crc 119FF015 sha1 f0fbf663ef8477c79f184cca2de3d74cb43884f6 )
+	rom ( name "RoboCop_v1.3_2066.lha" size 430601 crc ADE9FB65 sha1 4fb6ae889da23e3c0e489eaf0ca2b1a3b1ce5655 )
+)
+
+game (
+	name "RoboCop (NTSC)"
+	rom ( name "RoboCop_v1.3_NTSC.lha" size 431575 crc E58E24B3 sha1 2d57d49224fe1f2b22eca858712c4db9479fbb92 )
 )
 
 game (
@@ -12246,12 +13855,17 @@ game (
 )
 
 game (
+	name "Rocket Attack (Europe)"
+	rom ( name "RocketAttack_v1.0.lha" size 283307 crc 7492810D sha1 fa347b008819081c14d41789bd6c09e68de09d4b )
+)
+
+game (
 	name "Rocket Ranger (Europe)"
 	rom ( name "RocketRanger_v1.5b_1641.lha" size 1147196 crc B628E3A6 sha1 55f88fd065bd72c1286039c253a6ecc43f143955 )
 )
 
 game (
-	name "Rocket Ranger (Censored) (Europe)"
+	name "Rocket Ranger (Europe) (Censored)"
 	rom ( name "RocketRanger_v1.5b_Censored_1533.lha" size 1148860 crc 99760552 sha1 c5ee32a268f1002e0901f7b4b05f0232610da3c3 )
 )
 
@@ -12267,7 +13881,7 @@ game (
 
 game (
 	name "Rock 'n Roll (Europe)"
-	rom ( name "RockNRoll_v2.0_0801.lha" size 753803 crc 780BEA53 sha1 03f1e86d3d303fbb008ff75eb76f2f7853aed6af )
+	rom ( name "RockNRoll_v2.1_0801.lha" size 756558 crc 7C7484FF sha1 0ce56f43cc59927c6db8c4aa7144239c32acc477 )
 )
 
 game (
@@ -12332,7 +13946,7 @@ game (
 
 game (
 	name "Rogue Trooper (Europe)"
-	rom ( name "RogueTrooper_v1.1_1441.lha" size 826436 crc FDF0EDCB sha1 f667dd55a37cf62afc3523c128dc516888645b7e )
+	rom ( name "RogueTrooper_v1.2_1441.lha" size 828225 crc AA40179C sha1 caf4d27ee92528e75da85630e29d6c789bb09fb9 )
 )
 
 game (
@@ -12348,6 +13962,11 @@ game (
 game (
 	name "Rolling Ronny (Europe)"
 	rom ( name "RollingRonny_v1.0.lha" size 767463 crc E3E6E520 sha1 170f4b9181485997e4444cfb138a6768909d8278 )
+)
+
+game (
+	name "Rolling Thunder (Europe)"
+	rom ( name "RollingThunder_v1.1_2639.lha" size 137492 crc 55BC99CA sha1 d370e0125b3a32c19ec5322dea7f0580b076b5fe )
 )
 
 game (
@@ -12372,17 +13991,17 @@ game (
 
 game (
 	name "Round the Bend! (Europe)"
-	rom ( name "RoundTheBend_v1.0.lha" size 262585 crc FFB2D668 sha1 e04591e1384d5deaf8cc0acab15b7b24cb733bed )
+	rom ( name "RoundTheBend_v1.1_1442.lha" size 267017 crc 3BD735EE sha1 2446b27f7af223e2f9399562d47f392375f48c08 )
 )
 
 game (
 	name "R-Type II (Europe)"
-	rom ( name "RType2_v1.1_2065.lha" size 579793 crc 26F9CB18 sha1 012165cf78adfd06984d0a379885538f656cdebd )
+	rom ( name "RType2_v2.1_2065.lha" size 583651 crc 0FB0A7FF sha1 3522c479498ee2bca48133d24f928b81a2cb8d5f )
 )
 
 game (
 	name "R-Type (Europe)"
-	rom ( name "RType_v1.4.1_0940.lha" size 711375 crc A7F65831 sha1 df846665456db0c24f16f20f68dc0160e7f13ddb )
+	rom ( name "RType_v1.6_0940.lha" size 703000 crc C91386B9 sha1 cdc18cc895d48c863a94f368c6df70bcfd13a04d )
 )
 
 game (
@@ -12392,12 +14011,12 @@ game (
 
 game (
 	name "Rüsselsheim (Germany) (AGA)"
-	rom ( name "Ruesselsheim_v1.0_AGA_De_2215.lha" size 1190805 crc 2BC2B7EE sha1 4ec00a153a0669ad75d407e879f009af7376f6f7 )
+	rom ( name "Ruesselsheim_v1.1_AGA_De_2215.lha" size 1191125 crc 48C42B84 sha1 6c0a348efa299400b7250a7ee5899ed7ba451b48 )
 )
 
 game (
 	name "Rüsselsheim (Germany)"
-	rom ( name "Ruesselsheim_v1.0_De.lha" size 1097887 crc CF180981 sha1 b5cad94f3565cc6ee40415620031485832a8b8aa )
+	rom ( name "Ruesselsheim_v1.1_De.lha" size 1098262 crc 1D9265F0 sha1 e6e0bd7faeb90868c744d3c03f8c6cb8a6e7a532 )
 )
 
 game (
@@ -12407,7 +14026,7 @@ game (
 
 game (
 	name "Ruffian (Europe)"
-	rom ( name "Ruffian_v1.1_2411.lha" size 1863028 crc 55794FC5 sha1 45fd7c516bc10ea5f17063a4fcb892e808823f11 )
+	rom ( name "Ruffian_v2.0_2411.lha" size 1864840 crc 63724E0B sha1 e7f35254a1ed61d029d953de7e7fb1232e1dd51f )
 )
 
 game (
@@ -12416,18 +14035,23 @@ game (
 )
 
 game (
+	name "Ruff 'n' Tumble (Europe) (512 kB)"
+	rom ( name "RuffNTumble_v2.8_512k_0199.lha" size 1535245 crc 0CA472E5 sha1 4b4153127383e5f9983ceb00271fac3a065923c3 )
+)
+
+game (
 	name "Rugby - The World Cup (Europe)"
 	rom ( name "RugbyTheWorldCup_v1.2_0258.lha" size 638912 crc C835DEAE sha1 d54b4437cc63a3a8f18e341f0467377f1677b47b )
 )
 
 game (
-	name "Rugby - The World Cup (Early Build) (Europe)"
+	name "Rugby - The World Cup (Europe) (Early Build)"
 	rom ( name "RugbyTheWorldCup_v1.2_EarlyBuild_3730.lha" size 638103 crc CD33F1A4 sha1 17b30d99b2469cbc1160e827323f906af8b7cd28 )
 )
 
 game (
 	name "Running Man, The (Europe)"
-	rom ( name "RunningMan_v1.0_0382.lha" size 850033 crc 69800992 sha1 3d456e10f262e73931a3aab459455ab86d9c1230 )
+	rom ( name "RunningMan_v1.1_0382.lha" size 853834 crc 28EC9533 sha1 0962abdab946bc4e25748e5bca6e84ed0960dfd8 )
 )
 
 game (
@@ -12447,12 +14071,12 @@ game (
 
 game (
 	name "Rygar - The Legendary Warrior (Europe) (AGA)"
-	rom ( name "Rygar_v2.0_AGA.lha" size 809051 crc 3EA5018D sha1 800ad6255e760c4608cce3c2270c05d21c5f97f0 )
+	rom ( name "Rygar_v2.1_AGA.lha" size 809692 crc B973ECA4 sha1 eefa169f2ad7845420efe620c4ec1184d35fca2f )
 )
 
 game (
-	name "Rygar - The Legendary Warrior (Chip) (Europe) (AGA)"
-	rom ( name "Rygar_v2.0_AGA_Chip.lha" size 809503 crc D6662866 sha1 8b329bbbf656fcfdb69adf9275f172c6794b382b )
+	name "Rygar - The Legendary Warrior (Europe) (AGA) (Chip)"
+	rom ( name "Rygar_v2.1_AGA_Chip.lha" size 81015 crc 37150e20 sha1 bebf069777e2820f8ddf3aa2e6ecfeb95f74651e )
 )
 
 game (
@@ -12471,7 +14095,7 @@ game (
 )
 
 game (
-	name "On Safari (Europe)"
+	name "Safari Guns (Europe)"
 	rom ( name "SafariGuns_v1.0.lha" size 679550 crc 140FFCB6 sha1 30f992001af6920c1d829530d1c63c055ba990c7 )
 )
 
@@ -12517,12 +14141,7 @@ game (
 
 game (
 	name "SAS Combat Simulator (Europe)"
-	rom ( name "SASCombatSimulator_v1.2_QuattroArcade.lha" size 490863 crc E419D9C8 sha1 b20f56b670476031f56af1845d076d5f0c3a82c6 )
-)
-
-game (
-	name "SAS Combat Simulator (Quattro Fighters) (Europe)"
-	rom ( name "SASCombatSimulator_v1.2_QuattroFighters_2205.lha" size 261616 crc 563C8735 sha1 5085838b01569d7220fcb60d3b3e5d25a8428271 )
+	rom ( name "SASCombatSimulator_v1.4_2205.lha" size 263631 crc B22638C4 sha1 7efac72e907b2e8525ce1f884b6d6a00de72c4d1 )
 )
 
 game (
@@ -12532,12 +14151,17 @@ game (
 
 game (
 	name "Savage (Europe)"
-	rom ( name "Savage_v1.0_0028.lha" size 855751 crc 492A0C78 sha1 3ee2944e169e5b592bff9b22de0d34b0bdcc8558 )
+	rom ( name "Savage_v1.1_0028.lha" size 812381 crc F1D1D4C2 sha1 9d27023b3059546124fa869b20b9c37b4f8ecedf )
 )
 
 game (
 	name "Scapeghost (Europe)"
 	rom ( name "Scapeghost_v1.0.lha" size 395437 crc 354CA5FA sha1 2f5e19aab9decf2246aa3fab4760201b6bf82779 )
+)
+
+game (
+	name "Scary Mutant Space Aliens From Mars (Europe)"
+	rom ( name "ScaryMutantSpaceAliensFromMars_v1.0_1549.lha" size 759300 crc 9B0F5633 sha1 96e1f73c964446b582eef1ad95c879a047461c8c )
 )
 
 game (
@@ -12548,6 +14172,11 @@ game (
 game (
 	name "Schwarze Auge, Das - Die Schicksalsklinge (Germany)"
 	rom ( name "SchwarzeAuge_v1.2_De_0806.lha" size 4912995 crc 551C7FBA sha1 d15b9c2d0c0c75936dd9b1484e45dba64c9b407e )
+)
+
+game (
+	name "Sci-Fi (Europe)"
+	rom ( name "SciFi_v1.0_2464.lha" size 362653 crc ED02C37B sha1 ff23c4edd2fb9d25045950da91a9161545eaa02a )
 )
 
 game (
@@ -12562,7 +14191,7 @@ game (
 
 game (
 	name "Scorpion (Europe)"
-	rom ( name "Scorpion_v1.2.lha" size 430528 crc 9B03E147 sha1 f771651f0649188bb4cb2a1b5ebde93dbcf44849 )
+	rom ( name "Scorpion_v1.3_2615.lha" size 429712 crc C79F0896 sha1 6107d931b4f43c8143a0e306c4c015ea3ef9d5d2 )
 )
 
 game (
@@ -12576,23 +14205,43 @@ game (
 )
 
 game (
+	name "Screaming Wings (Europe)"
+	rom ( name "ScreamingWings_v1.1_Files_3021.lha" size 248284 crc 3356B4C2 sha1 38dd87623efa9e9fcd8ff632c79fce16e0b0cc75 )
+)
+
+game (
+	name "Screaming Wings (Europe) (Image)"
+	rom ( name "ScreamingWings_v1.1_Image_3021.lha" size 248683 crc 9B0B7AA0 sha1 2ab7cc36e55eaaf50ff10b1a5f105b4c927b01d0 )
+)
+
+game (
 	name "Scrolling Walls (Europe)"
 	rom ( name "ScrollingWalls_v1.0.lha" size 474863 crc 16622340 sha1 04bae7be2f34ebb21527c6068bf942da25eee287 )
 )
 
 game (
+	name "Scuba Diver (Europe) (AGA) (PD/Freeware)"
+	rom ( name "ScubaDiver_v1.0_AGA.lha" size 1404926 crc E95379C9 sha1 b1227c1d25bd5dca9cfe9c3a6e39c3da1869720b )
+)
+
+game (
+	name "S.D.I. (Europe)"
+	rom ( name "SDI_v1.1_Cinemaware_0720.lha" size 378291 crc 2BE42E2E sha1 711e57860916b90281914276a6f0db90dc38cd04 )
+)
+
+game (
 	name "S.D.I. (USA)"
-	rom ( name "SDI_v1.0_Cinemaware_NTSC_1266.lha" size 364730 crc 2629F624 sha1 79a906da60f442614fc00525c838e4d331c59242 )
+	rom ( name "SDI_v1.1_Cinemaware_NTSC_1266.lha" size 365869 crc 515C193C sha1 bf0271f2a41fa7eea537399e9203f55c74512883 )
 )
 
 game (
 	name "Second Samurai (Europe)"
-	rom ( name "SecondSamurai_v1.1_0721.lha" size 1348510 crc 96AD4C94 sha1 a85e7ebb0c855f68f307f5930e6a0dce7fc632bf )
+	rom ( name "SecondSamurai_v1.3a_0721.lha" size 1455528 crc 01409332 sha1 c4a052e11363d8e18f645a4bd6f97a94f761cf2f )
 )
 
 game (
 	name "Second Samurai (Europe) (AGA)"
-	rom ( name "SecondSamurai_v1.1_AGA_1624.lha" size 1442998 crc 24A99B64 sha1 5058f45d7500dee24c5d0e06618ed768d0812c1e )
+	rom ( name "SecondSamurai_v1.3a_AGA_1624.lha" size 1563027 crc 4F0FBCB5 sha1 d12a917460351b908b6f385a5b32d1e91250a6f3 )
 )
 
 game (
@@ -12602,32 +14251,32 @@ game (
 
 game (
 	name "Secret of Monkey Island, The (Europe)"
-	rom ( name "SecretOfMonkeyIsland_v3.5_1625.lha" size 2097474 crc 41C6A3E5 sha1 9e99715520538a96476b9092f57a20a062c54120 )
+	rom ( name "SecretOfMonkeyIsland_v3.7_1625.lha" size 2097675 crc 9524A7CB sha1 871e1cc2bbaf7992ef5786a0893e941049c1905c )
 )
 
 game (
 	name "Secret of Monkey Island, The (Germany)"
-	rom ( name "SecretOfMonkeyIsland_v3.5_De_0359.lha" size 2054898 crc 938DB95C sha1 bfd96e7709eea53afea541d0712bc0790e4b4cc4 )
+	rom ( name "SecretOfMonkeyIsland_v3.7_De_0359.lha" size 2055101 crc F7972754 sha1 6cbef57a6dfaafdf25ba2afb7ffdf0d6486487a4 )
 )
 
 game (
 	name "Secret of Monkey Island, The (Spain)"
-	rom ( name "SecretOfMonkeyIsland_v3.5_Es.lha" size 2051234 crc 51BBD890 sha1 9571569af96fb3f28bb15c1f4a693bba823da3da )
+	rom ( name "SecretOfMonkeyIsland_v3.7_Es.lha" size 2051438 crc 6DCE12F2 sha1 b6420a350e0710c3541f55c5236da2802987abdb )
 )
 
 game (
 	name "Secret of Monkey Island, The (France)"
-	rom ( name "SecretOfMonkeyIsland_v3.5_Fr_1750.lha" size 1990209 crc 69CDF84C sha1 17e468d3c709c0080099ecc8cc72c4fd453553ac )
+	rom ( name "SecretOfMonkeyIsland_v3.7_Fr_1750.lha" size 1990412 crc 8B5CF4B7 sha1 a4da3b8f7d4b7350ca8bd3394f75365c3e787d09 )
 )
 
 game (
 	name "Secret of Monkey Island, The (Italy)"
-	rom ( name "SecretOfMonkeyIsland_v3.5_It.lha" size 2050651 crc 7B8DF5E7 sha1 fda70e24dade38dc87d190130c8aa25129a37ee4 )
+	rom ( name "SecretOfMonkeyIsland_v3.7_It.lha" size 2050856 crc 3C6B7EA5 sha1 548647f784076676edf8f4eacebf51b3d1adb743 )
 )
 
 game (
 	name "Advanced Dungeons & Dragons - Secret of the Silver Blades - A Forgotten Realms Fantasy Role-Playing Epic, Vol.III (Europe) (v1.0 June 12,1991)"
-	rom ( name "SecretOfTheSilverBlades_v1.0.lha" size 849950 crc D4D843B0 sha1 fbd6dca01fdecf98970b95d3fdd8efbee895308f )
+	rom ( name "SecretOfTheSilverBlades_v1.1.lha" size 850057 crc 66B6ECBC sha1 efd5d2937511206959eef0c4145c0ea6b0842948 )
 )
 
 game (
@@ -12642,12 +14291,12 @@ game (
 
 game (
 	name "Seelenturm, Der (Germany) (AGA)"
-	rom ( name "Seelenturm_v1.0_AGA_De.lha" size 2490677 crc 444B3020 sha1 da81bd7d57d46f7c45c804f5d0b0ec7f228c9c79 )
+	rom ( name "Seelenturm_v1.0_AGA_De.lha" size 2490496 crc C1DF371E sha1 c9e0220791789d3d2fac52a619f321d205db9eb5 )
 )
 
 game (
 	name "Sensible Golf (Europe)"
-	rom ( name "SensibleGolf_v1.2_0200.lha" size 1138764 crc 2023165C sha1 5fb12a931809c1ce98fc9697fa3a17298349c28d )
+	rom ( name "SensibleGolf_v1.4_0200.lha" size 1140610 crc DB9F6980 sha1 6dc895315a2b04e69c4e7185288e7d0f87a4a6a3 )
 )
 
 game (
@@ -12656,22 +14305,22 @@ game (
 )
 
 game (
-	name "Sensible Soccer - European Champions 92 (Europe)"
+	name "Sensible Soccer - European Champions 92 (Europe) (512 kB)"
 	rom ( name "SensibleSoccer9293_v1.2_512KB_2391.lha" size 1044785 crc ACF26D9E sha1 8be16754eff71c16c6a72045a08ff06a32cc9d80 )
 )
 
 game (
-	name "Sensible Soccer (Europe) (En,Fr,De,It) (v1.0)"
+	name "Sensible Soccer (Europe) (En,Fr,De,It)"
 	rom ( name "SensibleSoccer_v1.2_1MB_0384.lha" size 1019996 crc 378DCC4B sha1 3e9cb3e225349df9510579794042cc1dd809776b )
 )
 
 game (
-	name "Sensible Soccer (Europe) (En,Fr,De,It) (v1.0) (512 KB)"
+	name "Sensible Soccer (Europe) (En,Fr,De,It) (512 kB)"
 	rom ( name "SensibleSoccer_v1.2_512KB_0384.lha" size 1020089 crc A75894AE sha1 a31b3009904f64341e954b8e1924b9ec5b34f927 )
 )
 
 game (
-	name "Sensible Soccer - England vs Germany (Europe)"
+	name "Sensible Soccer - England vs Germany (Europe) (Coverdisk - Amiga Power #21)"
 	rom ( name "SensibleSoccerBulldogBlighty_v1.0.lha" size 170770 crc 0E2FCBAC sha1 09ac167621361bfab892f8edc17c2275df3f315d )
 )
 
@@ -12681,12 +14330,12 @@ game (
 )
 
 game (
-	name "Sensible Soccer - European Champions (Europe) (En,Fr,De,It) (v1.1) (512 KB)"
+	name "Sensible Soccer - European Champions (Europe) (En,Fr,De,It) (512 kB) (v1.1)"
 	rom ( name "SensibleSoccerEuropeanChampions_v1.2_512KB_0722.lha" size 1042767 crc 63B137FD sha1 c92e90438b191f0ede163e2cd9123f967560d2dd )
 )
 
 game (
-	name "Sensible Soccer - International Edition - World Champions (Europe) (En,Fr,De,It) (v1.2) (CD32)"
+	name "Sensible Soccer - International Edition - World Champions (Europe) (En,Fr,De,It) (CD32) (v1.2)"
 	rom ( name "SensibleSoccerInternationalEdition_v1.0_CD32.lha" size 572341 crc 5E91C818 sha1 07ac6dc10d2f50fd5443a885d80a0a8b7fe538ff )
 )
 
@@ -12696,12 +14345,12 @@ game (
 )
 
 game (
-	name "Sensible Soccer - International Edition - World Champions (Europe) (En,Fr,De,It) (v1.2) (512 KB)"
+	name "Sensible Soccer - International Edition - World Champions (Europe) (En,Fr,De,It) (v1.2) (512 kB)"
 	rom ( name "SensibleSoccerInternationalEdition_v1.2_512KB_1681.lha" size 950289 crc CF4213CD sha1 a82b3035e955bd5e60f7f185e9d668239d17fa62 )
 )
 
 game (
-	name "Sensible Train-spotting (Europe)"
+	name "Sensible Train-spotting (Europe) (Coverdisk - Amiga Power #53)"
 	rom ( name "SensibleTrainSpotting_v1.0.lha" size 115413 crc CEBE8923 sha1 03b64c90f739f4a7b187fc6f472b8c06b07ecaf4 )
 )
 
@@ -12711,23 +14360,48 @@ game (
 )
 
 game (
-	name "Sensible World of Soccer (Europe) (v1.1)"
-	rom ( name "SensibleWorldOfSoccer11_v1.7_0201.lha" size 1325153 crc BF1571D6 sha1 b14dcbea6b5c1c5c6f09f8c5faa55bb0f83f1a9c )
+	name "Sensible World of Soccer '16-'17 (Europe)"
+	rom ( name "SensibleWorldOfSoccer1617_v2.3.lha" size 1340905 crc 8636AC3C sha1 74b7d40a615cd70ce1e9a6541eb4bac596a146b4 )
 )
 
 game (
-	name "Sensible World of Soccer '16 (Europe)"
-	rom ( name "SensibleWorldOfSoccer1617_v1.7.lha" size 1341293 crc AD430C1E sha1 e3f4f2e5e041c3fe0776dc2214dabf343746de1f )
+	name "Sensible World of Soccer '20 (Europe)"
+	rom ( name "SensibleWorldOfSoccer2020_v2.3.lha" size 1353728 crc 1B4C93BF sha1 43dc317e9e667bf7dfd6b5a5da7e5d142fa6fc24 )
+)
+
+game (
+	name "Sensible World of Soccer '21 (Europe)"
+	rom ( name "SensibleWorldOfSoccer2021_v2.3.lha" size 1353312 crc 2ACD988E sha1 547acd2003a1dd85f4c7026c23c0508b506e9b3b )
+)
+
+game (
+	name "Sensible World of Soccer '21-'22 (Europe)"
+	rom ( name "SensibleWorldOfSoccer2122_v2.3.lha" size 1557688 crc B84C8E23 sha1 2c2199520870c0293d5149e2130062beb04beb1d )
+)
+
+game (
+	name "Sensible World of Soccer '22-'23 (Europe)"
+	rom ( name "SensibleWorldOfSoccer2223_v2.3.lha" size 1554276 crc 5F7396B6 sha1 78f215aacd7d4cbb70ec8f233d0d6eb4bdae4fac )
+)
+
+game (
+	name "Sensible World of Soccer '23-'24 (Europe)"
+	rom ( name "SensibleWorldOfSoccer2324_v2.3.lha" size 1557800 crc F8554A34 sha1 3752cda35d5bc7405a37826cd6b526471fe36bf8 )
+)
+
+game (
+	name "Sensible World of Soccer '24-'25 (Europe)"
+	rom ( name "SensibleWorldOfSoccer2425_v2.3.lha" size 1568183 crc 192E6797 sha1 da344b98bf01ca31ffbc645557acc3173c3a12fe )
 )
 
 game (
 	name "Sensible World of Soccer '95-'96 (Europe)"
-	rom ( name "SensibleWorldOfSoccer9596_v1.7_1755.lha" size 1314131 crc 353B6CC5 sha1 98ba3e110f84760c7be71a1ad4294cf664e9df22 )
+	rom ( name "SensibleWorldOfSoccer9596_v2.3_1755.lha" size 1313753 crc 3998DC95 sha1 d3b0be8c972d509a51f1e765dd22e923bfb33b2c )
 )
 
 game (
 	name "Sensible World of Soccer '95-'96 - European Championship Edition (Europe)"
-	rom ( name "SensibleWorldOfSoccer9596EuropeanChampions_v1.7_1825.lha" size 1314513 crc 8DEA351B sha1 99a36b09d4c537acf085a3f296621bb9274cef98 )
+	rom ( name "SensibleWorldOfSoccer9596EuropeanChampionsEdition_v2.3_1825.lha" size 1314426 crc F206D69C sha1 d03d48980afd666823269e0dd08a76873a18c7e7 )
 )
 
 game (
@@ -12737,17 +14411,27 @@ game (
 
 game (
 	name "Sensible World of Soccer '97-'98 (Europe)"
-	rom ( name "SensibleWorldOfSoccer9798_v1.7.lha" size 1349916 crc BA6D0899 sha1 a7c9402ea9d8fa234f7c45d4bc8dbac386f2866f )
-)
-
-game (
-	name "Sensible World of Soccer (Europe)"
-	rom ( name "SensibleWorldOfSoccer_v1.7_0840.lha" size 1329074 crc 1EEA9562 sha1 1fd106fa992dbee00d1e12272ca2a56ad39fc833 )
+	rom ( name "SensibleWorldOfSoccer9798_v2.3.lha" size 1349504 crc 7216F6FC sha1 7c67bd4210fedb4bb17bda4eeaf78dfa1c3a0d67 )
 )
 
 game (
 	name "Sensible World of Soccer World Cup '98 (Europe)"
-	rom ( name "SensibleWorldOfSoccerWorldCup98_v1.7.lha" size 1327343 crc 86B51453 sha1 537aa2277b109214486dd1660b57687dd111cc87 )
+	rom ( name "SensibleWorldOfSoccer98_v2.3.lha" size 1326669 crc A5978518 sha1 91d0a5088db3f84c6156cbbada37f555a0edb77e )
+)
+
+game (
+	name "Sensible World of Soccer '94-'95 (Europe)"
+	rom ( name "SensibleWorldOfSoccer_v2.3_0840.lha" size 1328722 crc 7F70B6BD sha1 0a3eb07ec24b9406a5fea0d70b41e1ae9bc40be3 )
+)
+
+game (
+	name "Sensible World of Soccer '94-'95 (Germany)"
+	rom ( name "SensibleWorldOfSoccer_v2.3_De.lha" size 1329838 crc 9E79EC02 sha1 9d1d1726936984a7ba7e29b5f568eec2aece6b36 )
+)
+
+game (
+	name "Sensible World of Soccer '94-'95 (Europe) (v1.1)"
+	rom ( name "SensibleWorldOfSoccerv11_v2.3_0201.lha" size 1324934 crc 0F2B2C0D sha1 bb938dd672abf33f701c4cb2c63b921682e8cc13 )
 )
 
 game (
@@ -12757,32 +14441,42 @@ game (
 
 game (
 	name "Settlers, The (Europe)"
-	rom ( name "Settlers_v1.6_0143.lha" size 1924152 crc DA6F93B3 sha1 2502e091885b207fbfe333b16ab141006ab41875 )
+	rom ( name "Settlers_v1.7_0143.lha" size 1926306 crc C06B8B33 sha1 7abe790fe03c23c1b01d3cd4afe6f448da0d897b )
 )
 
 game (
 	name "Settlers, The (France)"
-	rom ( name "Settlers_v1.6_Fr_2378.lha" size 1924329 crc 9B831885 sha1 245977fb5b94f516ee6ef303a5a87aa92c1e705f )
+	rom ( name "Settlers_v1.7_Fr_2378.lha" size 1926474 crc 2A5FF518 sha1 becb97740a19e2a1e474afe8b7447425ed0e3d23 )
+)
+
+game (
+	name "Settlers, The (Europe) (Low Mem)"
+	rom ( name "Settlers_v1.7_LowMem_0143.lha" size 1926734 crc 1FDBB5F9 sha1 c170295a9fd318d0e638037f90262d2e92995cda )
+)
+
+game (
+	name "Settlers, The (France) (Low Mem)"
+	rom ( name "Settlers_v1.7_LowMem_Fr_2378.lha" size 1926912 crc 9C02B939 sha1 8bba163f03bac9b646019eb53e5636d5e127d310 )
 )
 
 game (
 	name "Seven Cities of Gold (USA)"
-	rom ( name "SevenCitiesOfGold_v1.1_NTSC_0908.lha" size 253753 crc 6C334409 sha1 1b33a3fdc6afba4fa011c3468bfc4cf8d1cfd4ea )
+	rom ( name "SevenCitiesOfGold_v2.1b_NTSC_0908.lha" size 254862 crc BB14B2B6 sha1 72d4075cfa080540ffb3908feae640fca43784c0 )
 )
 
 game (
 	name "Seven Gates of Jambala, The (Europe)"
-	rom ( name "SevenGatesOfJambala_v1.1_Files.lha" size 663631 crc 0C40A347 sha1 0ac05b35686f5fad49828d76d1fa2e7ad565f609 )
-)
-
-game (
-	name "Seven Gates of Jambala, The (Image) (Europe)"
-	rom ( name "SevenGatesOfJambala_v1.1_Image.lha" size 663633 crc C212DF4F sha1 a854dabb70937aa800c0ae9e11f79e2c7b2a1d6b )
+	rom ( name "SevenGatesOfJambala_v1.2_3052.lha" size 667291 crc A3786860 sha1 3371600f8d4a751edb963bef757b34012d0b17a1 )
 )
 
 game (
 	name "Sextimates (Europe)"
 	rom ( name "Sextimates_v1.0.lha" size 126155 crc 62EE7DAD sha1 b2cdc892f6763056e2f86d2f6cfc52522daa36c0 )
+)
+
+game (
+	name "Sexy Droids (Europe)"
+	rom ( name "SexyDroids_v1.0.lha" size 571527 crc 82BB9959 sha1 932dc38bb423492965b82ec47b17527c1bae8206 )
 )
 
 game (
@@ -12812,7 +14506,7 @@ game (
 
 game (
 	name "Shadowgate (Europe)"
-	rom ( name "Shadowgate_v1.0_0290.lha" size 574799 crc 1B10FB12 sha1 d0d782fca92799738976ba95a9579282ecb96379 )
+	rom ( name "Shadowgate_v1.1_0290.lha" size 575533 crc E9A7FBEC sha1 2047e7d8a7ab29231e4f379f377b0034c1804d1c )
 )
 
 game (
@@ -12837,17 +14531,22 @@ game (
 
 game (
 	name "Shadow of the Beast III (Europe)"
-	rom ( name "ShadowOfTheBeast3_v1.6_0016.lha" size 2135109 crc F9E561D5 sha1 c13deeb6d3d25f64bec94800446aa4f46b31ebe6 )
+	rom ( name "ShadowOfTheBeast3_v2.1_0016.lha" size 2141751 crc 853C8210 sha1 aa8ee5c823c632586530c2a4a8bdf30ab9ee602e )
 )
 
 game (
 	name "Shadow of the Beast III (USA)"
-	rom ( name "ShadowOfTheBeast3_v1.6_NTSC_1176.lha" size 2136843 crc DE81E64E sha1 0059c3f12ea009ca5aaf7baea4f910f5bbe28e60 )
+	rom ( name "ShadowOfTheBeast3_v2.1_NTSC_1176.lha" size 2143479 crc 82F2E14D sha1 69f408dcdcaad78522f270e8597ac85af03fc489 )
 )
 
 game (
 	name "Shadow of the Beast (Europe)"
-	rom ( name "ShadowOfTheBeast_v2.4_1357.lha" size 1438315 crc DBE4A341 sha1 2cd317077b4bd4551f352ccd5c190556eea36252 )
+	rom ( name "ShadowOfTheBeast_v2.6_1357.lha" size 1438458 crc A31AA8C1 sha1 24ec6f7ff71b6d3ff1f34bea0b2b0294145b749b )
+)
+
+game (
+	name "Shadow of the Beast (USA)"
+	rom ( name "ShadowOfTheBeast_v2.6_NTSC.lha" size 1515547 crc D5A9027C sha1 b91929ad3ff8487d9ef793de3de054a0ed46b1d4 )
 )
 
 game (
@@ -12861,13 +14560,23 @@ game (
 )
 
 game (
+	name "Shadow Sorcerer (Europe)"
+	rom ( name "ShadowSorcerer_v1.2_0275.lha" size 531485 crc 7301967C sha1 0ae98fe671e9f6c59617977e882cec27d087f5de )
+)
+
+game (
 	name "Shadow Sorcerer (Germany) (France) (Italy)"
-	rom ( name "ShadowSorcerer_v1.0_DeFrIt.lha" size 518268 crc 7C28A91F sha1 07dea2b63576a80b0a01437f392130608a5682a7 )
+	rom ( name "ShadowSorcerer_v1.2_DeFrIt.lha" size 577960 crc EA772770 sha1 8ebcb460b4e2d2a4dfd4fd5e6b09b64a07780cfe )
+)
+
+game (
+	name "Shadow Sorcerer (Spain)"
+	rom ( name "ShadowSorcerer_v1.2_Es.lha" size 530495 crc 2DEDD952 sha1 2395521341aec002b287da823a11e58406f610ec )
 )
 
 game (
 	name "Shadow Warriors (Europe)"
-	rom ( name "ShadowWarriors_v1.1_0830.lha" size 1459787 crc 1A0E46EB sha1 53e76bf210336546631787f428d77d2fb680651d )
+	rom ( name "ShadowWarriors_v2.1a_0830.lha" size 1457408 crc 4756693E sha1 7fd6a2c5a6ec2a68ac9a75e8ad6951a2ce1d5c4a )
 )
 
 game (
@@ -12897,12 +14606,12 @@ game (
 
 game (
 	name "Sharkey's Moll (Europe)"
-	rom ( name "SharkeysMoll_v1.2_2133.lha" size 414905 crc 4F8A513E sha1 2563852ab6ddeb740c85c0c26c2a34706b2ef289 )
+	rom ( name "SharkeysMoll_v1.3_2133.lha" size 418707 crc C517793A sha1 3e790ba042fa5c356466429df91b49aebe411439 )
 )
 
 game (
 	name "She Fox (Europe)"
-	rom ( name "SheFox_v1.3_0383.lha" size 164212 crc D03E74C9 sha1 172fcf244af6f29679bd3f1d697751d3853e95e6 )
+	rom ( name "SheFox_v1.4_0383.lha" size 164517 crc 9853C652 sha1 2419b300d20e9f5b72b25cbdb86f174203aeae75 )
 )
 
 game (
@@ -12923,6 +14632,11 @@ game (
 game (
 	name "ShockWave (Europe)"
 	rom ( name "ShockWave_v1.0_0723.lha" size 609604 crc E2878947 sha1 410b48865ce816f72d44124bcccc41aed1267a55 )
+)
+
+game (
+	name "Shootout (Europe) (PD/Freeware)"
+	rom ( name "Shootout_v1.0.lha" size 19864 crc 27B15E22 sha1 f03ee341a38d3d549f1ddecad651d4ad35c22096 )
 )
 
 game (
@@ -12947,7 +14661,7 @@ game (
 
 game (
 	name "Shuttle - The Space Flight Simulator (Europe)"
-	rom ( name "Shuttle_v0.9_1906.lha" size 1132799 crc B9FFA9E4 sha1 b9b9ee4b7db08c49c9c585972742e79d7888bebf )
+	rom ( name "Shuttle_v1.0_1906.lha" size 1119520 crc 7BB011E3 sha1 93d7a4e835bdb78bb2e434eab08e9da655201bdb )
 )
 
 game (
@@ -12957,7 +14671,7 @@ game (
 
 game (
 	name "SideShow (Europe)"
-	rom ( name "SideShow_v1.1_0779.lha" size 1026089 crc 25C80FE3 sha1 ec74f4951491417bb7e8356f09eee523d35615db )
+	rom ( name "SideShow_v1.2_0779.lha" size 1026410 crc F41D0EEA sha1 02274c1811678e5bbb1b5ebe724da59b4ae368d5 )
 )
 
 game (
@@ -12966,7 +14680,7 @@ game (
 )
 
 game (
-	name "SideWinder (Arcadia) (Europe)"
+	name "SideWinder (Europe) (Arcadia)"
 	rom ( name "SideWinder_v0.1_Arcadia.lha" size 426004 crc EFA605F5 sha1 af803679430a5ec169ea0aca6429773c02e2e6ab )
 )
 
@@ -12977,7 +14691,12 @@ game (
 
 game (
 	name "Siedler, Die (Germany)"
-	rom ( name "Siedler_v1.6_De_0401.lha" size 1925281 crc DB79FDD3 sha1 ee26320939fc241552395530e3593af603150503 )
+	rom ( name "Siedler_v1.7_De_0401.lha" size 1927426 crc A1593F25 sha1 8ad4b18b692e88e84c95e60aca77f6fb4a8808f7 )
+)
+
+game (
+	name "Siedler, Die (Germany) (Low Mem)"
+	rom ( name "Siedler_v1.7_LowMem_De_0401.lha" size 1927858 crc 813E5D31 sha1 4b23dbfd9321f162a83216bbd16951890c57d6ec )
 )
 
 game (
@@ -13007,36 +14726,36 @@ game (
 
 game (
 	name "Silly Putty (Europe)"
-	rom ( name "SillyPutty_v1.2a_1336.lha" size 1582293 crc 27E7DDEC sha1 77eeb538a8cce204fd7377b06a614bf63516094c )
+	rom ( name "SillyPutty_v1.2b_1336.lha" size 1588476 crc B245CBFA sha1 2f840b334b3c3e57b331f5a85131c32f1e61671e )
 )
 
 game (
-	name "SimAnt (HiRes) (Europe)"
+	name "SimAnt (Europe) (HiRes)"
 	rom ( name "SimAnt_v1.01a_HiRes_2221.lha" size 816949 crc C8AAEB59 sha1 7d72e47d8c6c07f57687fcc69718da48b4be5088 )
 )
 
 game (
-	name "SimAnt (HiRes) (Germany)"
+	name "SimAnt (Germany) (HiRes)"
 	rom ( name "SimAnt_v1.01a_HiRes_De_0084.lha" size 817929 crc 41F7A366 sha1 7f4f5f866d24cdec7ac10a96b21c64cd5b344b88 )
 )
 
 game (
-	name "SimAnt (HiRes) (France)"
+	name "SimAnt (France) (HiRes)"
 	rom ( name "SimAnt_v1.01a_HiRes_Fr_2665.lha" size 817783 crc AFF5D0BE sha1 5d892e4ad91da3ba4388cfeffe83a57a579967e3 )
 )
 
 game (
-	name "SimAnt (LoRes) (Europe)"
+	name "SimAnt (Europe) (LoRes)"
 	rom ( name "SimAnt_v1.01a_LoRes_2221.lha" size 576111 crc BF3BC50A sha1 2d9e114ec61a7ba0cc7a9b244812dba8cfb44414 )
 )
 
 game (
-	name "SimAnt (LoRes) (Germany)"
+	name "SimAnt (Germany) (LoRes)"
 	rom ( name "SimAnt_v1.01a_LoRes_De_0084.lha" size 577207 crc FD78119A sha1 27d2ca30e982b00226160fd7e58b27dde82beb9a )
 )
 
 game (
-	name "SimAnt (LoRes) (France)"
+	name "SimAnt (France) (LoRes)"
 	rom ( name "SimAnt_v1.01a_LoRes_Fr_2665.lha" size 577120 crc D7C2295D sha1 c1907f8f08fac4f7e1e4aa6cbd390776ee5cd7bb )
 )
 
@@ -13046,7 +14765,7 @@ game (
 )
 
 game (
-	name "SimCity (512 KB) (Europe)"
+	name "SimCity (Europe) (512 kB)"
 	rom ( name "SimCity_v1.0_512KB_0888.lha" size 280985 crc E4FCEBAB sha1 d2d2163656538b06a2da1cd70544ffaf1da2e0f6 )
 )
 
@@ -13061,32 +14780,32 @@ game (
 )
 
 game (
-	name "SimEarth - The Living Planet (HiRes) (Europe)"
+	name "SimEarth - The Living Planet (Europe) (HiRes)"
 	rom ( name "SimEarth_v1.0_HiRes_1066.lha" size 554014 crc B3AB6A1F sha1 2a57d8829d409d99463be0bdf85d5a4ef290ef75 )
 )
 
 game (
-	name "SimEarth - The Living Planet (HiRes) (Germany)"
+	name "SimEarth - The Living Planet (Germany) (HiRes)"
 	rom ( name "SimEarth_v1.0_HiRes_De.lha" size 560429 crc 9633FCD6 sha1 5904f556c6c35598e75bdf9b9fbe09005e10200f )
 )
 
 game (
-	name "SimEarth - The Living Planet (HiRes) (France)"
+	name "SimEarth - The Living Planet (France) (HiRes)"
 	rom ( name "SimEarth_v1.0_HiRes_Fr_2645.lha" size 558669 crc 67E2B883 sha1 448223a4f75b15fa060bc3119ece58d4b22f93bd )
 )
 
 game (
-	name "SimEarth - The Living Planet (LoRes) (Europe)"
+	name "SimEarth - The Living Planet (Europe) (LoRes)"
 	rom ( name "SimEarth_v1.0_LoRes_1066.lha" size 450918 crc 11474CE0 sha1 948255e3449f7900fc6b83d50fb2f24f5dd52992 )
 )
 
 game (
-	name "SimEarth - The Living Planet (LoRes) (Germany)"
+	name "SimEarth - The Living Planet (Germany) (LoRes)"
 	rom ( name "SimEarth_v1.0_LoRes_De.lha" size 419246 crc 98B4A5C7 sha1 1efa398f57d6a5cba24c5fa0e88a9bb30f8a5eed )
 )
 
 game (
-	name "SimEarth - The Living Planet (LoRes) (France)"
+	name "SimEarth - The Living Planet (France) (LoRes)"
 	rom ( name "SimEarth_v1.0_LoRes_Fr_2645.lha" size 417030 crc F2A34367 sha1 94fcf045580049428126be905a22bdbd39c81dbb )
 )
 
@@ -13107,37 +14826,102 @@ game (
 
 game (
 	name "Simon the Sorcerer (Europe)"
-	rom ( name "SimonTheSorcerer_v1.3.lha" size 5819565 crc 8C823E9F sha1 59c0915cc9e03e9c5b224908d6ed091af9fb1c32 )
+	rom ( name "SimonTheSorcerer_v1.5_2865.lha" size 5820246 crc 95A29575 sha1 69719a5c81621a3ea7dbcc4107d4e28de95c77f0 )
 )
 
 game (
 	name "Simon the Sorcerer (Europe) (AGA)"
-	rom ( name "SimonTheSorcerer_v1.3_AGA_0898.lha" size 6004291 crc 86FDE188 sha1 f30bc266e0300476de2b8e591357e7e56a39dde5 )
+	rom ( name "SimonTheSorcerer_v1.5_AGA_0898.lha" size 6005293 crc 7BF9532E sha1 8ccde031250c1a3049a60cb6ded69f7c8dedc7d7 )
 )
 
 game (
 	name "Simon the Sorcerer (Germany) (AGA)"
-	rom ( name "SimonTheSorcerer_v1.3_AGA_De_0726.lha" size 6010830 crc 526EA4C4 sha1 348a67899bd429fbceb894471c83e532c1e54bd6 )
+	rom ( name "SimonTheSorcerer_v1.5_AGA_De_0726.lha" size 6011828 crc 0C9839E2 sha1 a51f846156449b916bf67689abbebec5260753d0 )
 )
 
 game (
 	name "Simon the Sorcerer (France) (AGA)"
-	rom ( name "SimonTheSorcerer_v1.3_AGA_Fr_2692.lha" size 6010609 crc 2B470C71 sha1 92c585e70510e68a314823f4aac97cf39687fbc5 )
+	rom ( name "SimonTheSorcerer_v1.5_AGA_Fr_2692.lha" size 6011603 crc 4B62D73B sha1 11065c7fb082134c03291101b953edf20acd32db )
+)
+
+game (
+	name "Simon the Sorcerer (Italy) (AGA)"
+	rom ( name "SimonTheSorcerer_v1.5_AGA_It.lha" size 6008819 crc DDA1A10F sha1 d12a3721082784db790f9b33b47b24d64cdb8468 )
 )
 
 game (
 	name "Simon the Sorcerer (Germany)"
-	rom ( name "SimonTheSorcerer_v1.3_De_1434.lha" size 5826326 crc AC132576 sha1 4f81c94e703d57dd75ac9ca2a954b797f9a88baf )
+	rom ( name "SimonTheSorcerer_v1.5_De_1434.lha" size 5827013 crc 7614F16A sha1 68f4146d34c6186b2ce7cb1003a271480091c41e )
 )
 
 game (
 	name "Simon the Sorcerer (France)"
-	rom ( name "SimonTheSorcerer_v1.3_Fr_2370.lha" size 5825878 crc 3361DEDB sha1 c736119decb266ca2ee597997c940c1e862e4545 )
+	rom ( name "SimonTheSorcerer_v1.5_Fr_2370.lha" size 5826565 crc ABA3E181 sha1 1f3f9fb8e5c6792c4f984840dcbdf6b7f378ca89 )
+)
+
+game (
+	name "Simon the Sorcerer (Italy)"
+	rom ( name "SimonTheSorcerer_v1.5_It.lha" size 5823963 crc F4BA5BDA sha1 b56bd3f4f057b81fc397faf23274967ecfa1df14 )
 )
 
 game (
 	name "Simulcra (Europe)"
 	rom ( name "Simulcra_v1.1.1.lha" size 277184 crc F72E8E39 sha1 7aef56b14637c7e2781f1ce08de227b0c94be9d6 )
+)
+
+game (
+	name "Simulman 01 - Simulman! (Italy)"
+	rom ( name "Simulman01_v1.0_It.lha" size 677578 crc 135DCE6F sha1 260d69ea3b3877eb3ae4370963729448edf93a12 )
+)
+
+game (
+	name "Simulman 02 - Nella morsa di SS-DOS (Italy)"
+	rom ( name "Simulman02_v1.0_It.lha" size 652616 crc DFB524F2 sha1 6a6c2ee703544f296b7de9a5fe455063441426f0 )
+)
+
+game (
+	name "Simulman 03 - Nel Regno di Doors (Italy)"
+	rom ( name "Simulman03_v1.0_It.lha" size 479221 crc 9A7E7D44 sha1 a0d9933badeb36f26a95379cc3df3d95750f987e )
+)
+
+game (
+	name "Simulman 04 - Il mondo simulato (Italy)"
+	rom ( name "Simulman04_v1.0_It.lha" size 524677 crc F98A429B sha1 99bf495bf66babb7b41abba15d1cc1f7f865c886 )
+)
+
+game (
+	name "Simulman 05 - I rapitori di sogni (Italy)"
+	rom ( name "Simulman05_v1.0_It.lha" size 464360 crc E54567AA sha1 d830b675a0f83137e19fdb930cb2a400617a5e83 )
+)
+
+game (
+	name "Simulman 06 - Luna park (Italy)"
+	rom ( name "Simulman06_v1.0_It.lha" size 252900 crc 288E3C33 sha1 d818d79937555c3c86a9d1803d4fb8127332d423 )
+)
+
+game (
+	name "Simulman 07 - Il grande freddo (Italy)"
+	rom ( name "Simulman07_v1.0_It.lha" size 247906 crc 0DBC2F7D sha1 a29307112c68336f99106f09b8a3ae7d58092c36 )
+)
+
+game (
+	name "Simulman 08 - Il giardino virtuale (Italy)"
+	rom ( name "Simulman08_v1.0_It.lha" size 302294 crc ECFFFF87 sha1 135ee40a914dbc99cf6440ba21320b8fa2e3924a )
+)
+
+game (
+	name "Simulman 09 - Il giocattolaio (Italy)"
+	rom ( name "Simulman09_v1.0_It.lha" size 268427 crc 5C1C8A2E sha1 b51a506812f9e47f15aaaab7cd83c56484864082 )
+)
+
+game (
+	name "Simulman 10 - Pentagram (Italy)"
+	rom ( name "Simulman10_v1.0_It.lha" size 256327 crc 088A6FDA sha1 f8459306fa117fd77f00f03390560f510813e78a )
+)
+
+game (
+	name "Simulman 12 - Jailhouse Rock (Italy)"
+	rom ( name "Simulman11_v1.0_It.lha" size 300024 crc CC98B074 sha1 c31d158dbcfbabc216e74b9d89dbbe5263bbebb0 )
 )
 
 game (
@@ -13147,27 +14931,32 @@ game (
 
 game (
 	name "Sink or Swim (Europe)"
-	rom ( name "SinkOrSwim_v1.1_1MB.lha" size 590219 crc E48B7E2C sha1 e7cb6288a8ab74a0053131b4938c10d7f6684e3f )
+	rom ( name "SinkOrSwim_v1.2_1065.lha" size 578499 crc A787065F sha1 4ff9d2b19ce814877c664c6d44a59272f06d0b58 )
 )
 
 game (
-	name "Sink or Swim (512 KB) (Europe)"
-	rom ( name "SinkOrSwim_v1.1_512KB.lha" size 590238 crc 0D3D850A sha1 89dcccb5731bba696ca4d7140fdf00944e165bbb )
+	name "Sink or Swim (Europe) (512 kB)"
+	rom ( name "SinkOrSwim_v1.2_512k_1065.lha" size 578644 crc 5D10410D sha1 39a0ab45c3af26b6fc36983955a16cdc672aad0b )
 )
 
 game (
-	name "Sir Fred (Europe)"
-	rom ( name "SirFredTheLegend_v1.0_1652.lha" size 679352 crc 9F77E8C1 sha1 6fe7e90cb90e7a780fb69ad0d1b48d0ce421b9e9 )
+	name "Sir Fred - The Legend (Europe)"
+	rom ( name "SirFred_v1.3_1652.lha" size 677725 crc 64148E0E sha1 e73faeeb9f05821a10c20f2a5f18f5f347080a14 )
 )
 
 game (
 	name "Sixiang (Europe)"
-	rom ( name "Sixiang_v1.0_2757.lha" size 120126 crc 2610C6C9 sha1 d69d518b759ad8ceb9d8d779ac3954986809db8b )
+	rom ( name "Sixiang_v1.1_2757.lha" size 121197 crc 8709AECF sha1 62331f20608172334cfeee8fbe5d712e8d5bf85c )
+)
+
+game (
+	name "Sixiang (Europe) (Alt)"
+	rom ( name "Sixiang_v1.1_AltVersion.lha" size 180429 crc C8032D24 sha1 9cdfaea6de21bfdbe94c7d212a6b3b8c1a81c6d1 )
 )
 
 game (
 	name "Skaermtrolden Hugo (Denmark)"
-	rom ( name "SkaermtroldenHugo_v1.1_Dk.lha" size 1911320 crc 38BA45A1 sha1 27283a18b8b4d8aaca5b0650d5eb73dcfe13f539 )
+	rom ( name "SkaermtroldenHugo_v1.2_Dk.lha" size 1911091 crc 1EACB71F sha1 2a2afbf30c2b7a338c28841389b82a46b6f33e3b )
 )
 
 game (
@@ -13176,13 +14965,13 @@ game (
 )
 
 game (
-	name "Kwatermaster (Poland)"
+	name "Skaut Kwatermaster (Poland)"
 	rom ( name "SkautKwatermaster_v1.0a_Pl.lha" size 1320584 crc 33CF6877 sha1 e9c87c1e41cb2ff39e2ed8f63e80b78118ec5505 )
 )
 
 game (
 	name "Skeet Shoot (Europe)"
-	rom ( name "SkeetShoot_v1.1_2231.lha" size 530801 crc F462D2D1 sha1 f7288971da5a980e166e3796483dd225ade766be )
+	rom ( name "SkeetShoot_v2.1_2231.lha" size 478066 crc E9DD1A22 sha1 df4b7a70d3beef9fd9dd973ccd9b06cac0fbf70f )
 )
 
 game (
@@ -13196,13 +14985,18 @@ game (
 )
 
 game (
-	name "Skidmarks (Europe) (v1.06) (OCS)"
-	rom ( name "Skidmarks_v1.0_0204.lha" size 2867325 crc 5B617441 sha1 d77e5a55eeb93c3bbc4d477e4c3c7affdf3d4de7 )
+	name "Skidmarks (Europe)"
+	rom ( name "Skidmarks_v1.2_0204.lha" size 2864186 crc C234E68F sha1 3a782efb51843526fdb8723b300223f2f5fe66bc )
 )
 
 game (
-	name "Skidmarks (Europe) (v1.06) (AGA)"
-	rom ( name "Skidmarks_v1.0_AGA_0204.lha" size 2867550 crc DDD68FBF sha1 79de65a2e6438384e25d4992762dd4d5ad0d3bca )
+	name "Skidmarks (Europe) (AGA)"
+	rom ( name "Skidmarks_v1.2_AGA_0204.lha" size 2864414 crc CCE6C4CC sha1 722f4eff4f5c7a223ddf971ccd2f0b5679de5105 )
+)
+
+game (
+	name "Skidoo 9Europe)"
+	rom ( name "Skidoo_v1.0.lha" size 308251 crc 703BE2E1 sha1 a5ae8a3ff747edd82974041a9a7e01acfa86fd51 )
 )
 
 game (
@@ -13212,7 +15006,7 @@ game (
 
 game (
 	name "Ski or Die (Europe)"
-	rom ( name "SkiOrDie_v1.0_1258.lha" size 737522 crc F17C0B45 sha1 61fa84553999388bbb9c820c7790afa6e52f2d54 )
+	rom ( name "SkiOrDie_v1.1_1258.lha" size 712903 crc C3B1B586 sha1 1b514b7c680a709e68823c4e5cf90edbe0fc9285 )
 )
 
 game (
@@ -13222,7 +15016,7 @@ game (
 
 game (
 	name "Skull & Crossbones (Europe)"
-	rom ( name "Skull&Crossbones_v1.3_0285.lha" size 636342 crc 4D24C623 sha1 d3487714d30e80d6aa593888067c38048eeafa58 )
+	rom ( name "Skull&Crossbones_v1.3_0385.lha" size 636342 crc 4D24C623 sha1 d3487714d30e80d6aa593888067c38048eeafa58 )
 )
 
 game (
@@ -13231,13 +15025,23 @@ game (
 )
 
 game (
+	name "Skyblaster (Europe)"
+	rom ( name "Skyblaster_v1.0_2047.lha" size 553780 crc 9671977A sha1 f886cecd33315fe05d7c413577ced64ad079174c )
+)
+
+game (
 	name "SkyChase (Europe)"
 	rom ( name "SkyChase_v1.2_2610.lha" size 120808 crc 4FAB42AC sha1 2e211376e0dae3228411c6b1f161be84cacb6777 )
 )
 
 game (
-	name "SkyChase (Fast) (Europe)"
+	name "SkyChase (Europe) (Fast)"
 	rom ( name "SkyChase_v1.2_Fast_2610.lha" size 120888 crc F53247DD sha1 b36715cf2ebf3df65c8ae06d8ac3ee91483cd5ae )
+)
+
+game (
+	name "Sky Fighter (Europe)"
+	rom ( name "SkyFighter_v1.0_2117.lha" size 187724 crc 1E4CB092 sha1 a8f30f515bd69783f5f2614482d9d67d395a9e3e )
 )
 
 game (
@@ -13266,7 +15070,7 @@ game (
 )
 
 game (
-	name "Slamtilt (2 MB) (Europe) (AGA)"
+	name "Slamtilt (Europe) (AGA) (2 MB)"
 	rom ( name "SlamTilt_v3.6_AGA_2MB_1151.lha" size 3597634 crc 72FB5FE1 sha1 a937918d267a5a1c2517fc98ba9f7448c4694606 )
 )
 
@@ -13296,7 +15100,7 @@ game (
 )
 
 game (
-	name "Sleepwalker (Europe) (A1200 Bundle - Comic Relief Pack) (AGA)"
+	name "Sleepwalker (Europe) (AGA) (A1200 Bundle - Comic Relief Pack)"
 	rom ( name "Sleepwalker_v1.2_AGA_ComicRelief_1880.lha" size 3157174 crc 5F29143C sha1 e5ea89ac59a8a16bbfeaffbaaec227e34542187b )
 )
 
@@ -13326,6 +15130,16 @@ game (
 )
 
 game (
+	name "Smarty and the Nasty Gluttons (Europe) (PD/Freeware)"
+	rom ( name "Smarty&TheNastyGluttons_v1.1.lha" size 918614 crc E215B866 sha1 c03825c551f473a58090b3edb0d274c97b616f1c )
+)
+
+game (
+	name "Smash (Europe)"
+	rom ( name "Smash_v1.0.lha" size 779040 crc 4A8976A9 sha1 4ffc4e68d975324e1090580c7b5a41c04f682063 )
+)
+
+game (
 	name "Smash T.V. (Europe)"
 	rom ( name "SmashTV_v1.0_2293.lha" size 689378 crc B3D14DF8 sha1 bff8404f416336cca844571c8a250576c24cdc8d )
 )
@@ -13341,13 +15155,8 @@ game (
 )
 
 game (
-	name "Snoopy - The Cool Computer Game (Europe)"
-	rom ( name "Snoopy&Peanuts_v1.0.lha" size 198856 crc 13F4B9AE sha1 7c9e1c4d8d3dac96738358bf12ef7eb3bcec9b46 )
-)
-
-game (
-	name "Snoopy - The Cool Computer Game (No Sounds) (Europe)"
-	rom ( name "Snoopy&Peanuts_v1.0_NoSounds.lha" size 203219 crc F21147AB sha1 e9278cd6db3e765f82f10dd07bc3f4160bf7037f )
+	name "Snoopy and Peanuts (Europe)"
+	rom ( name "Snoopy&Peanuts_v1.0_2929.lha" size 225769 crc C1BD54D1 sha1 71cf6866fe83699a6861632ded92754e9c88db09 )
 )
 
 game (
@@ -13356,7 +15165,7 @@ game (
 )
 
 game (
-	name "Snow Bros. (Image) (Europe)"
+	name "Snow Bros. (Europe) (Image)"
 	rom ( name "SnowBros_v1.4_Image_2601.lha" size 903379 crc 7AC557FA sha1 89cbfaa805b40642253fce6a13e30f362445675b )
 )
 
@@ -13371,7 +15180,7 @@ game (
 )
 
 game (
-	name "Soccer Kid (1 MB) (Chip) (Europe)"
+	name "Soccer Kid (Europe) (En,Fr,De,Es,It) (Chip) (1 MB)"
 	rom ( name "SoccerKid_v2.1_1MbChip_1129.lha" size 3196145 crc 9578D6FD sha1 d5dd5f612e7e96d94a22765804b3038f8b79a264 )
 )
 
@@ -13417,7 +15226,12 @@ game (
 
 game (
 	name "Solid Gold (Europe)"
-	rom ( name "SolidGold_v1.01.lha" size 831747 crc 93A43BB6 sha1 ab41c623bbce8ac23fcc5516dd19fc7530d42e60 )
+	rom ( name "SolidGold_v1.03.lha" size 837225 crc CAD60289 sha1 6a10ead9d6adbfcecfdc9ef075166a9634ee5731 )
+)
+
+game (
+	name "Sol Negro (Europe)"
+	rom ( name "SolNegro_v1.1.lha" size 314502 crc B1D3E3BD sha1 b96bce613164f93f792d33c6cd172d1f44edc5b2 )
 )
 
 game (
@@ -13476,13 +15290,18 @@ game (
 )
 
 game (
+	name "Soul Crystal (Germany)"
+	rom ( name "SoulCrystal_v1.0_De_2832.lha" size 2523149 crc 3EA5AAB1 sha1 3815755dfa57cc8a6eff65b5f58fb0fb8360b185 )
+)
+
+game (
 	name "Space Ace II - Borf's Revenge (Europe)"
 	rom ( name "SpaceAce2_v1.1_0931.lha" size 3694754 crc 37557217 sha1 7caa75dee21bd12a3d2e6be496e27ea9ae6642ed )
 )
 
 game (
 	name "Space Ace (Europe)"
-	rom ( name "SpaceAce_v1.1_0085.lha" size 3113963 crc 3826F875 sha1 81d674a67e6f73dcc83ec67086a6cfa47efc56ff )
+	rom ( name "SpaceAce_v1.3_0085.lha" size 3114161 crc 12FE4818 sha1 644b4b265ccc00116c85012b944c0a306552a0b6 )
 )
 
 game (
@@ -13497,17 +15316,17 @@ game (
 
 game (
 	name "Spaceball (Europe)"
-	rom ( name "Spaceball_v1.1_2675.lha" size 349044 crc E8FAB0AE sha1 ea2eaa248ebbcd8550b1ca1c3fa17e33bfed71f9 )
+	rom ( name "Spaceball_v1.3_2675.lha" size 348519 crc 3E8C6C2A sha1 9c00da1d35e891aef4d4a0b9e0e0e0b19aa26e36 )
 )
 
 game (
 	name "Space Crusade - The Voyage Beyond (Europe)"
-	rom ( name "SpaceCrusade&TheVoyageBeyond_v2.2_1535.lha" size 1685285 crc B1886195 sha1 b43afe008784d2e0e578499f1e05046f8c2beb66 )
+	rom ( name "SpaceCrusade&TheVoyageBeyond_v3.1_1535.lha" size 1680607 crc 04E41BF0 sha1 9f068b186c7559b6e84f6120b0646923175c7e23 )
 )
 
 game (
 	name "Space Crusade (Europe)"
-	rom ( name "SpaceCrusade_v2.2_1535.lha" size 955160 crc 393404D8 sha1 6668570af11b5e7af5574178b7461552c188f754 )
+	rom ( name "SpaceCrusade_v3.1_1535.lha" size 958389 crc 3D2EE120 sha1 9a0b2538aef67b1ed73361b7282771e7fbf1503e )
 )
 
 game (
@@ -13517,17 +15336,17 @@ game (
 
 game (
 	name "Space Gun (Europe)"
-	rom ( name "SpaceGun_v1.1.lha" size 1563126 crc E4D98732 sha1 67b8a4147fb45078ee75c7ee3b48aeb751daca21 )
+	rom ( name "SpaceGun_v1.2_2004.lha" size 1561604 crc FAC65766 sha1 29ebafb20634067c8038efe57461f2be4eb19911 )
 )
 
 game (
-	name "Space Harrier + Space Harrier - Return to the Fantasy Zone (Europe)"
+	name "Space Harrier & Return to the Fantasy Zone (Europe)"
 	rom ( name "SpaceHarrier&ReturnToFantasyZone_v1.3.lha" size 697343 crc F1B1D50B sha1 ce0c09a4bd35b6f33892e3d68d86a763ef151399 )
 )
 
 game (
 	name "Space Harrier II (Europe)"
-	rom ( name "SpaceHarrier2_v1.0_1121.lha" size 381549 crc E7E4A0BA sha1 4790bce8554b76e552b8cfcb8573b2f87349f83d )
+	rom ( name "SpaceHarrier2_v2.1_1121.lha" size 396919 crc 759CDC44 sha1 8575d08c25c4b00f7eb0166b512623013475a3d1 )
 )
 
 game (
@@ -13542,12 +15361,22 @@ game (
 
 game (
 	name "Space Hulk (Europe)"
-	rom ( name "SpaceHulk_v1.0_1279.lha" size 2099683 crc 1C968840 sha1 9fc2f11130f65ce658d068f900fed0c3a422d5f6 )
+	rom ( name "SpaceHulk_v2.0_1279.lha" size 2096005 crc B656C6DA sha1 a87cd3fcff0f93721ace0c16704ca99320480b01 )
 )
 
 game (
 	name "Space MAX (Germany)"
 	rom ( name "SpaceMAX_v1.1_De.lha" size 1536586 crc AB21E51A sha1 80ec0d091da3da23e2b573534209e94f7d2f6c16 )
+)
+
+game (
+	name "Space Panic (Germany) (PD/Freeware)"
+	rom ( name "SpacePanic_v1.0_De.lha" size 401288 crc 03B0674E sha1 0b1577745ef094fad199cc9800ec9f007c02f9a0 )
+)
+
+game (
+	name "Space Panic (Germany) (PD/Freeware) (Demo)"
+	rom ( name "SpacePanicDemo_v1.1_De.lha" size 137353 crc A74818BC sha1 789c55d8b636960342004da60410855342b6eb3f )
 )
 
 game (
@@ -13557,7 +15386,7 @@ game (
 
 game (
 	name "Spaceport (Europe)"
-	rom ( name "Spaceport_v1.0.lha" size 333191 crc D0B0B6D3 sha1 f3de8bc13d80e52b3bd9d7ffa132254905abb3cc )
+	rom ( name "Spaceport_v1.0_0578.lha" size 346289 crc A2C727AE sha1 34731673cac1b73670f15302d20bc5925ef98682 )
 )
 
 game (
@@ -13567,17 +15396,12 @@ game (
 
 game (
 	name "Space Quest III - The Pirates of Pestulon (Europe)"
-	rom ( name "SpaceQuest3_v1.2b_0292.lha" size 2633097 crc 73BD9EAB sha1 7a3087afa7f5db4442d5d1565b4d477efe2bc8fb )
+	rom ( name "SpaceQuest3_v2.1_0292.lha" size 2635336 crc 759538CE sha1 7e184f4dc6c677755c1707760ae725c12a15c62f )
 )
 
 game (
 	name "Space Quest III - The Pirates of Pestulon (Germany)"
-	rom ( name "SpaceQuest3_v1.2b_De_0579.lha" size 2963865 crc CC8F4D85 sha1 09047df1ff18625a8839eefb78b0595ccb193b74 )
-)
-
-game (
-	name "Space Quest III - The Pirates of Pestulon (MT32) (Germany)"
-	rom ( name "SpaceQuest3_v1.2b_De_MT32_0579.lha" size 2965366 crc 2734EB93 sha1 5633712289528a6a9695b3cabca519cd5554c1fb )
+	rom ( name "SpaceQuest3_v2.1_De_0579.lha" size 2966164 crc E947BC99 sha1 2f476bb33c6bb7a0aa1ae002447f2729979f0850 )
 )
 
 game (
@@ -13586,7 +15410,7 @@ game (
 )
 
 game (
-	name "Space Quest IV - Roger Wilco and the Time Rippers (MT32) (Germany)"
+	name "Space Quest IV - Roger Wilco and the Time Rippers (Germany) (MT32)"
 	rom ( name "SpaceQuest4_v1.1_De_MT32_2369.lha" size 5373815 crc 2B5287D5 sha1 40448ab469bcd6cf0ef674cf470effdb11840c4b )
 )
 
@@ -13602,31 +15426,31 @@ game (
 
 game (
 	name "Space Quest Chapter 1 - The Sarien Encounter (USA)"
-	rom ( name "SpaceQuest_v1.2_NTSC_1484.lha" size 341364 crc AEDECD59 sha1 a79bf3e030e212010227a2d265bb721fb0a01e7a )
+	rom ( name "SpaceQuest_v1.3a_NTSC_1484.lha" size 342153 crc 2511916C sha1 4994ce86ba794fd403cfc89d3d0896b980350b43 )
 )
 
 game (
-	name "Space Quest 1 - Roger Wilco In The Sarien Encounter (Europe) (v1.000) (Enhanced)"
-	rom ( name "SpaceQuestEnhanced_v1.3_2222.lha" size 4616051 crc FE1178FC sha1 e32738fa07041261c83c8d913366a3f03e18a053 )
+	name "Space Quest 1 - Roger Wilco In The Sarien Encounter (Europe) (Enhanced)"
+	rom ( name "SpaceQuestEnhanced_v2.2_2222.lha" size 4621615 crc 0B9781B5 sha1 48c82a6ddd50a3331c584dc1e994bbf7e17f0c5d )
 )
 
 game (
-	name "Space Quest 1 - Roger Wilco In The Sarien Encounter (Europe) (v1.000) (Enhanced) (MT32)"
-	rom ( name "SpaceQuestEnhanced_v1.3_MT32_2222.lha" size 4622269 crc 5970BFF2 sha1 11a79a0be78d68cdd43c4b1215a5dae6f123f73a )
+	name "Space Quest 1 - Roger Wilco In The Sarien Encounter (Europe) (Enhanced) (512 kB)"
+	rom ( name "SpaceQuestEnhanced_v2.2_512k_2222.lha" size 4621814 crc 0E2B25E4 sha1 8161ea556afa0e0ad6a163b3df263e59ffcccc78 )
 )
 
 game (
 	name "Space Racer (Europe)"
-	rom ( name "SpaceRacer_v1.0_0580.lha" size 386692 crc 808C457E sha1 956848f2d167638f1d1a94df2d0eb1565713865e )
+	rom ( name "SpaceRacer_v1.1_0580.lha" size 386849 crc 85E8CE11 sha1 7b0c594990fe2e506537e6b9efab748b922f21ae )
 )
 
 game (
 	name "Space Racer (France)"
-	rom ( name "SpaceRacer_v1.0_Fr_2408.lha" size 321194 crc A98750E9 sha1 1d8cafb6f0823ef825e91dce7980a7b4725f600e )
+	rom ( name "SpaceRacer_v1.1_Fr_2408.lha" size 321350 crc 782B0A03 sha1 33ec38cf732a44a7ceec2f2644ae4e76a5d45a5c )
 )
 
 game (
-	name "Space Ranger (Arcadia) (Europe)"
+	name "Space Ranger (Europe) (Arcadia)"
 	rom ( name "SpaceRanger_v0.1_Arcadia.lha" size 318020 crc 84FCFEE4 sha1 775377279929cf06a58451f51e58ee2554a66c42 )
 )
 
@@ -13686,8 +15510,18 @@ game (
 )
 
 game (
-	name "Spellbound (Europe)"
-	rom ( name "SpellBound_v1.0_0783.lha" size 818308 crc 5E2286B7 sha1 73cd6b50d238759c7895344d68c650e90234344a )
+	name "Spellbound! (Europe) (Lander Software)"
+	rom ( name "Spellbound_v1.1_LanderSoftware.lha" size 657455 crc FE89919C sha1 f647c41e957ff54f78907bfdc15e34ca8b58c6e6 )
+)
+
+game (
+	name "Spellbound (Europe) (Psygnosis)"
+	rom ( name "SpellBound_v1.3_Psygnosis_Files_0783.lha" size 827173 crc 58529B7E sha1 43b051e8d4721ccb0595b7dfead8ef2c5a849521 )
+)
+
+game (
+	name "Spellbound (Europe) (Psygnosis) (Image)"
+	rom ( name "SpellBound_v1.3_Psygnosis_Image_0783.lha" size 818071 crc 333CCEEC sha1 0780f3f6119ac6093cd58cbe9f5ba87f52c11949 )
 )
 
 game (
@@ -13702,12 +15536,12 @@ game (
 
 game (
 	name "Speris Legacy, The (Europe) (AGA)"
-	rom ( name "SperisLegacy_v1.1_AGA_1337.lha" size 3006865 crc FF8C283C sha1 6d11aedb4995aa2848212108aa1de3a5c990998b )
+	rom ( name "SperisLegacy_v2.0_AGA_1337.lha" size 3025919 crc A868B4B8 sha1 e8584bda50a771e50f80a95e9f939b33032ed74b )
 )
 
 game (
 	name "Speris Legacy, The (Europe) (CD32)"
-	rom ( name "SperisLegacy_v1.1_CD32.lha" size 2998055 crc AA351238 sha1 a3e7bcbb44e41df1f1da3d89e32c4c8f7a6dd950 )
+	rom ( name "SperisLegacy_v2.0_CD32.lha" size 3017113 crc 374196E5 sha1 94c0bfdd253fdfb24d3c387de4bdb45e58070369 )
 )
 
 game (
@@ -13721,8 +15555,28 @@ game (
 )
 
 game (
-	name "Spherical Worlds (CD) (Europe)"
+	name "Spherical Worlds (Europe) (CD)"
 	rom ( name "SphericalWorlds_v1.0.1_CD.lha" size 2109747 crc 44D94301 sha1 0a713e23efb320449db2351e1d777958c9f1e438 )
+)
+
+game (
+	name "Spider-man 2 (Europe) (En,De,It)"
+	rom ( name "Spiderman2_v1.0.lha" size 684680 crc 6B694FB2 sha1 edbe1dde4e0dd04bdfd6ea2d7f8e7de098033ee2 )
+)
+
+game (
+	name "Spider-man 3 (Europe) (En,De,It)"
+	rom ( name "Spiderman3_v1.0.lha" size 550532 crc C7362E6D sha1 fc17faa349ef42d2d7b29bdee54d75184edac1c2 )
+)
+
+game (
+	name "Spider-man (Europe) (En,De,It)"
+	rom ( name "Spiderman_v1.0.lha" size 667964 crc F4259E78 sha1 d9a285b020d20bd62d3b45b40b9a1c5b63e1fde6 )
+)
+
+game (
+	name "Spidertronic (Europe)"
+	rom ( name "Spidertronic_v1.0_0873.lha" size 151023 crc 700C847A sha1 8c9ef152092158496b9cb7ccf6244e86c73f768c )
 )
 
 game (
@@ -13736,7 +15590,12 @@ game (
 )
 
 game (
-	name "Spirit of Adventure (1 Disk) (Germany)"
+	name "Spirilon (Europe) (AGA)"
+	rom ( name "Spirilon_v1.0_AGA.lha" size 271042 crc 42FA431D sha1 fce26c37a78ba5eb5828403f48951c6ab5336764 )
+)
+
+game (
+	name "Spirit of Adventure (Germany) (Budget)"
 	rom ( name "SpiritOfAdventure_v1.2_De_1Disk.lha" size 838947 crc 572009C7 sha1 37dd5559d909705c800f6f772c966f3e9fc14474 )
 )
 
@@ -13747,21 +15606,21 @@ game (
 
 game (
 	name "Spirit of Excalibur (Europe)"
-	rom ( name "SpiritOfExcalibur_v1.01_1586.lha" size 1467777 crc 5F52E48E sha1 7134d7cf2427806339f3959be30f7f4fefad5f1e )
+	rom ( name "SpiritOfExcalibur_v1.02_1586.lha" size 1467740 crc F6CCEBA1 sha1 8ccfe20c0da128a9bd1c8737749d8478cbef8493 )
 )
 
 game (
 	name "Spirit of Excalibur (USA)"
-	rom ( name "SpiritOfExcalibur_v1.01_NTSC_2852.lha" size 1107623 crc 1DA883F2 sha1 e0712ee4f2381f2aabd7e12212a823c8f60ed054 )
+	rom ( name "SpiritOfExcalibur_v1.02_NTSC_2852.lha" size 1107518 crc 9F239116 sha1 5ce3e0fb6edd34b51039e90592516d979105f5d3 )
 )
 
 game (
 	name "Spitting Image (Europe)"
-	rom ( name "SpittingImage_v1.0.lha" size 258817 crc 20477D16 sha1 5271fea9c7ba2cf6cbefb24035994f2a66017793 )
+	rom ( name "SpittingImage_v1.1_3026.lha" size 249948 crc AF25031C sha1 e2e420ffb109413feb03a6eb133d722ef5a05251 )
 )
 
 game (
-	name "Spot (Arcadia) (Europe)"
+	name "Spot (Europe) (Arcadia)"
 	rom ( name "Spot_v0.1_Arcadia.lha" size 522889 crc 960713E7 sha1 8d1b36b421c6b3a8b893fc743d436ba215cc3d3d )
 )
 
@@ -13791,6 +15650,21 @@ game (
 )
 
 game (
+	name "Sqrxz 2 - Two Seconds Until Death (Europe)"
+	rom ( name "Sqrxz2_v1.0.lha" size 227824 crc 97E642F1 sha1 5822a4fdb56d42249a701f8a1921a13e4fdc5c57 )
+)
+
+game (
+	name "Sqrxz 3 - Adventure for Love (Europe)"
+	rom ( name "Sqrxz3_v1.0.lha" size 429797 crc 3F389EA8 sha1 006556082928fc2ea9ce476552c91edbb30ac2dc )
+)
+
+game (
+	name "Sqrxz 4 - Cold Cash (Europe)"
+	rom ( name "Sqrxz4_v1.0.lha" size 422466 crc 770379D1 sha1 089a44c857dd341612ddd32e00cd61b50eccba88 )
+)
+
+game (
 	name "Sqrxz (Europe)"
 	rom ( name "Sqrxz_v1.01.lha" size 295214 crc 0C687958 sha1 93e5def3e0af414088cd1074f8be692c362753c4 )
 )
@@ -13798,6 +15672,11 @@ game (
 game (
 	name "Stack Up (Europe)"
 	rom ( name "StackUp_v1.2_0381.lha" size 379307 crc D59FE0E9 sha1 5a48778fd2ebdee425854f213a3bddd33c1b69a8 )
+)
+
+game (
+	name "Starball (Europe)"
+	rom ( name "Starball_v1.3_2674.lha" size 348653 crc AECA0061 sha1 551f1de7c467345bced848d470e25d7a18b4146a )
 )
 
 game (
@@ -13811,7 +15690,7 @@ game (
 )
 
 game (
-	name "Starblade (Fast) (Europe)"
+	name "Starblade (Europe) (Fast)"
 	rom ( name "Starblade_v1.2_Fast.lha" size 455446 crc 30BCDF5C sha1 2134e9300aade0322709f0cda69d96a630f3657e )
 )
 
@@ -13821,7 +15700,7 @@ game (
 )
 
 game (
-	name "Starblade (Fast) (France)"
+	name "Starblade (France) (Fast)"
 	rom ( name "Starblade_v1.2_Fr_Fast.lha" size 447157 crc B6255955 sha1 007e3ad219f5eb21969e713580292450e03a74af )
 )
 
@@ -13832,7 +15711,7 @@ game (
 
 game (
 	name "Star Command (Europe)"
-	rom ( name "StarCommand_v1.0_0989.lha" size 425491 crc 98754D47 sha1 aca1792991ef449986cd5a809a9acfe46a97a98e )
+	rom ( name "StarCommand_v1.1_0989.lha" size 439435 crc 40E7F1DD sha1 7f0a8812bff72e5a348377c36236ac3bcaa93428 )
 )
 
 game (
@@ -13847,21 +15726,21 @@ game (
 
 game (
 	name "Stardust (Europe)"
-	rom ( name "Stardust_v1.5_2102.lha" size 2398136 crc 067741A2 sha1 bdc2dedd9393e8880272abbe8028e2ddfb4264b1 )
+	rom ( name "Stardust_v1.6_2102.lha" size 2398447 crc D3566A22 sha1 64468c191ec800c0ecf78b6a8840ee0d742f02d8 )
 )
 
 game (
 	name "StarFlight (Europe)"
-	rom ( name "Starflight_v1.0_0855.lha" size 372232 crc 4E094A27 sha1 07a5a799942d2dac27b4231e3ad5ae949d1ef5a5 )
+	rom ( name "Starflight_v1.01_0855.lha" size 371512 crc 53627F80 sha1 71fa568b91cd994c1d18931873dc6043812b7e7b )
 )
 
 game (
 	name "Starglider 2 (Europe)"
-	rom ( name "Starglider2_v1.2.1.lha" size 628350 crc B7C8D77E sha1 ea0aad198053749b3ff78c9d925953c85e54c35c )
+	rom ( name "Starglider2_v2.0_3000.lha" size 640321 crc 75D2E8F2 sha1 44b646a21e544ac95c9d6bc337ba8a1644f8a261 )
 )
 
 game (
-	name "StarGlider (Europe)"
+	name "Starglider (Europe)"
 	rom ( name "Starglider_v1.0_0174.lha" size 366499 crc 5364A71A sha1 0502fac88ebaa92147f88c40d26b362f81bb84ed )
 )
 
@@ -13891,13 +15770,18 @@ game (
 )
 
 game (
-	name "StarRay (Europe)"
-	rom ( name "StarRay_v3.1.lha" size 973434 crc 7AC69E0F sha1 f29889a5cfb6b1cc1c78413a6dc3a1f4f61e1105 )
+	name "Starquake (Europe)"
+	rom ( name "Starquake_v1.1.lha" size 850078 crc DA1D52BF sha1 cab6c45133eb0f329ec425c81259edfd7b0254de )
 )
 
 game (
-	name "StarRay (No Intro) (Europe)"
-	rom ( name "StarRay_v3.1_NoIntro_1721.lha" size 536530 crc 668893DE sha1 982fdf392ffbd35ec6642bf1f4069ab4372be1f2 )
+	name "StarRay (Europe)"
+	rom ( name "StarRay_v3.2.lha" size 973706 crc A59F2A47 sha1 56b6f0d9319a6a255c9b3d3e8664949a1482d843 )
+)
+
+game (
+	name "StarRay (Europe) (No Intro)"
+	rom ( name "StarRay_v3.2_NoIntro_1721.lha" size 536640 crc 9414B554 sha1 b986f4fd5a04ba15c09c8d10b722b2c180a8ae7a )
 )
 
 game (
@@ -13926,7 +15810,7 @@ game (
 )
 
 game (
-	name "Starush (Image) (Europe)"
+	name "Starush (Europe) (Image)"
 	rom ( name "Starush_v1.1_Image_2311.lha" size 1603582 crc 52960570 sha1 6c77ce7597d00065852122f7c046f2ddcd8e2eed )
 )
 
@@ -13936,13 +15820,18 @@ game (
 )
 
 game (
+	name "Star Ways (Europe)"
+	rom ( name "StarWays_v1.0_2678.lha" size 177798 crc F1C7A93E sha1 03acddb757ae0424a53b9abc08b2bcd9cbd6a31a )
+)
+
+game (
 	name "Steel (Europe)"
-	rom ( name "Steel_v1.1_1981.lha" size 233969 crc 2B37B430 sha1 c0aa348b85586cd53ca5d48189d7f9fb46007b73 )
+	rom ( name "Steel_v1.2_1981.lha" size 235208 crc 56657D52 sha1 d95ede631c6f17c6d9339c9565935a3d77c022d1 )
 )
 
 game (
 	name "Steel Empire (Europe)"
-	rom ( name "SteelEmpire_v1.1_1659.lha" size 1275759 crc AD4F9FFB sha1 287ca086a1ac972107fc91a76776a1762db7f45f )
+	rom ( name "SteelEmpire_v1.2_1659.lha" size 1286065 crc C5671F45 sha1 1228a983984bfb0d5410c0e146f6986a29882c51 )
 )
 
 game (
@@ -13952,7 +15841,7 @@ game (
 
 game (
 	name "Steigar (Europe)"
-	rom ( name "Steigar_v1.0.lha" size 252184 crc B2642D6D sha1 9dfbf24af9d466554566ecfb470f4031f00be825 )
+	rom ( name "Steigar_v1.1_2120.lha" size 256278 crc EC0994CE sha1 b3777fe8fe0ce7c051d8aa4633f7e17757d733b6 )
 )
 
 game (
@@ -13966,18 +15855,23 @@ game (
 )
 
 game (
-	name "Stir Crazy Featuring Bobo (Europe)"
-	rom ( name "StirCrazyFeaturingBobo_v1.0.lha" size 490581 crc 1CC7EF13 sha1 d406e3204be1b9b249d14d599b984dc81345fb99 )
+	name "Stone Age (Europe)"
+	rom ( name "StoneAge_v1.2_3033.lha" size 800845 crc 57D985D0 sha1 30fa5c4a49617999bc76ea99c8be9a46a268e061 )
 )
 
 game (
-	name "Stone Age (Europe)"
-	rom ( name "StoneAge_v1.1.lha" size 800457 crc 8D2A31CE sha1 3fce0d2c9458498644bca774558a65a0d6c701f6 )
+	name "Storia Ancestrale, La (Italy)"
+	rom ( name "StoriaAncestrale_v1.0.lha" size 3129943 crc 00F59B66 sha1 e8f6608f022b8c3304843a883882167541988972 )
+)
+
+game (
+	name "Storia Infinita II, La (Italy)"
+	rom ( name "StoriaInfinita2_v1.4_It.lha" size 852693 crc 17597840 sha1 a9207b5b432362e800f9e5fc581868e41781b66a )
 )
 
 game (
 	name "Stormball (Europe)"
-	rom ( name "Stormball_v1.1_0404.lha" size 447107 crc D8258E4F sha1 839d289cf35ae89e7e5b19e3124171552254251e )
+	rom ( name "Stormball_v1.2_0404.lha" size 864918 crc 910F84C0 sha1 98548eef78e2fd4cf86b4a3c877718bebb352f9d )
 )
 
 game (
@@ -13991,7 +15885,7 @@ game (
 )
 
 game (
-	name "Stormlord (Prerelease) (Europe)"
+	name "Stormlord (Europe) (Pre-release)"
 	rom ( name "Stormlord_v1.2_Prerelease.lha" size 480737 crc 92156DEC sha1 7bc1e4f19a8a1377eeb0d249bfc1dd29d9c12aa7 )
 )
 
@@ -14006,12 +15900,12 @@ game (
 )
 
 game (
-	name "Storm Master (Fast) (Germany)"
+	name "Storm Master (Germany) (Fast)"
 	rom ( name "StormMaster_v1.7_De_Fast.lha" size 720110 crc 19FA6A60 sha1 8aff3d2ea411e74f709c25ca27a593aec6c25b87 )
 )
 
 game (
-	name "Storm Master (Fast) (Europe)"
+	name "Storm Master (Europe) (Fast)"
 	rom ( name "StormMaster_v1.7_Fast_0620.lha" size 719836 crc 571A71E0 sha1 5451e6b56ab05ed89397fb052417175d98c32cc0 )
 )
 
@@ -14021,7 +15915,7 @@ game (
 )
 
 game (
-	name "Storm Master (Fast) (France)"
+	name "Storm Master (France) (Fast)"
 	rom ( name "StormMaster_v1.7_Fr_Fast_2387.lha" size 722370 crc 7A76C18B sha1 6a0b4de357406f923a1d3403f984d5649793bfd4 )
 )
 
@@ -14031,13 +15925,18 @@ game (
 )
 
 game (
+	name "Street Cat (USA)"
+	rom ( name "StreetCat_v1.0_NTSC.lha" size 468932 crc DDF75E79 sha1 fdfd4bf7d0a2c53ee4b531c0f141fd9b477026fa )
+)
+
+game (
 	name "Street Fighter II - The World Warrior (Europe)"
-	rom ( name "StreetFighter2_v1.1_0882.lha" size 2193102 crc D0B09182 sha1 924331253f0105c1fa3bb082ec0929cb1e7da09a )
+	rom ( name "StreetFighter2_v2.1_0882.lha" size 2204906 crc C76F3966 sha1 1307d56758bac142b400647e67a300e4dfe506fd )
 )
 
 game (
 	name "Street Fighter (Europe)"
-	rom ( name "StreetFighter_v1.0.lha" size 385640 crc C5A53F54 sha1 de673a2b301924ac8f0e00849d1acb641d049a12 )
+	rom ( name "StreetFighter_v1.2_2784.lha" size 384912 crc 816A4A4C sha1 9dfa58ecda06b2f8c2bfb423d290e750528426a8 )
 )
 
 game (
@@ -14046,13 +15945,18 @@ game (
 )
 
 game (
-	name "Street Racer (Europe) (CD32)"
-	rom ( name "StreetRacer_v1.5_CD32.lha" size 737730 crc AA59D397 sha1 b96fbb837a8e4ea5db24031b2f06eef735a839ad )
+	name "Street Hockey (Europe)"
+	rom ( name "StreetHockey_v1.0.lha" size 374444 crc F1DC1E25 sha1 f6d223330e633d95b4e1cc73854888cd686c328a )
+)
+
+game (
+	name "Street Racer (Europe) (AGA) (CD)"
+	rom ( name "StreetRacer_v2.0_AGA_CD.lha" size 738963 crc 6D2230BE sha1 0cd427bb2bd84f09e755363c17aae7165db4e471 )
 )
 
 game (
 	name "Street Rod 2 (Europe)"
-	rom ( name "StreetRod2_v1.1.lha" size 1002450 crc DE6FBADC sha1 639a1b0338183d12594a71ce44f1e40b0aaec8aa )
+	rom ( name "StreetRod2_v1.2.lha" size 1002549 crc A42FA74E sha1 0574c0575229f4ae04c48d955602d12474707336 )
 )
 
 game (
@@ -14086,6 +15990,11 @@ game (
 )
 
 game (
+	name "Strike Force Harrier (Europe)"
+	rom ( name "StrikeForceHarrier_v1.01_2312.lha" size 279856 crc BC2FF6ED sha1 ddbbe998b08a4832be47fc098e59b3c31b9f243d )
+)
+
+game (
 	name "Striker (Europe)"
 	rom ( name "Striker_v1.0_1075.lha" size 388012 crc 86870F89 sha1 d139d845b1662cc1059a7646cb8dc002eced28ad )
 )
@@ -14106,6 +16015,16 @@ game (
 )
 
 game (
+	name "Strip Poker 3 & Data Disks (Europe)"
+	rom ( name "StripPoker3&DataDisks_v1.1.lha" size 5820579 crc 371F13D3 sha1 445b3da901a75653b476fc0a53b9c4b6d70ebe36 )
+)
+
+game (
+	name "Strip Poker 3 (Europe)"
+	rom ( name "StripPoker3_v1.1.lha" size 1434760 crc 4EC5A27C sha1 1ce2cd35a913b716db1433fb5cd3624e1b8cc3d1 )
+)
+
+game (
 	name "Strip Poker - A Sizzling Game of Chance (Europe)"
 	rom ( name "StripPoker_v1.2.lha" size 473800 crc 7091F707 sha1 49367747a66943e1a27e2ee3a1f976fcc8afb1bd )
 )
@@ -14122,7 +16041,7 @@ game (
 
 game (
 	name "Stryx (Europe)"
-	rom ( name "Stryx_v1.1_0733.lha" size 779024 crc 9F0312EA sha1 339dc3de2403ffb756054201e185321b11bdaab4 )
+	rom ( name "Stryx_v1.2_0733.lha" size 780050 crc A1C9F885 sha1 8ca185d7faa7e08172e44956ee62ef196fc8de3e )
 )
 
 game (
@@ -14132,12 +16051,17 @@ game (
 
 game (
 	name "Stunt Car Racer (Europe)"
-	rom ( name "StuntCarRacer_v1.3_0222.lha" size 487537 crc 8DF4E1CA sha1 b4f9c924df2030dd591e4fd8c1d6ec75f521fdab )
+	rom ( name "StuntCarRacer_v1.4_0222.lha" size 487880 crc A6C694A4 sha1 1f0d272cb6f02efa7b2c9f41b804dfc1846b989d )
 )
 
 game (
-	name "Stunt Car Racer TNT (The New Tracks) (Europe)"
-	rom ( name "StuntCarRacerTNT_v1.3.lha" size 266709 crc 65FC949F sha1 b7d3ba1993d408a10cfd9034f6dbccaac1642554 )
+	name "Stunt Car Racer TNT (Europe)"
+	rom ( name "StuntCarRacerTNT_v1.4.lha" size 267054 crc 83E9A051 sha1 03893cff45fb974616e0a29d2b8918532da121b6 )
+)
+
+game (
+	name "Stuntman Seymour (Europe)"
+	rom ( name "StuntmanSeymour_v1.0.lha" size 211277 crc 25CA6455 sha1 3c46d3a52a90bd8bba16587219716344e0bc683c )
 )
 
 game (
@@ -14176,28 +16100,33 @@ game (
 )
 
 game (
+	name "Suicide Mission (Europe)"
+	rom ( name "SuicideMission_v1.0_1518.lha" size 126668 crc D872E952 sha1 51106105f1ced5aa8faee4df1db462b1733c0d65 )
+)
+
+game (
 	name "Summer Camp (Europe)"
 	rom ( name "SummerCamp_v1.1_2276.lha" size 376527 crc D4792122 sha1 daa337bfe348a5a923df99547d39f406ceb72998 )
 )
 
 game (
-	name "Summer Challenge (Europe)"
-	rom ( name "SummerChallenge_v1.1.lha" size 384886 crc 4681870E sha1 fa1800721c74b78fc1ade2100a99afecb42e2086 )
+	name "Summer Challenge (USA)"
+	rom ( name "SummerChallenge_v1.1_NTSC.lha" size 385070 crc D3044304 sha1 1573033d85f1130f4ff3e5d7ef7a2c79259bf690 )
 )
 
 game (
 	name "Summer Games & Summer Games II (Europe)"
-	rom ( name "SummerGames&SummerGames2_v1.0.lha" size 589960 crc 5ABE9591 sha1 d14734402db906acdc5cc4ccc83202d377e5b253 )
+	rom ( name "SummerGames&SummerGames2_v1.1_2895&2896.lha" size 594837 crc 464FB909 sha1 5f8d27434eb67948ef265281c54b48ee0b04e0c2 )
 )
 
 game (
 	name "Summer Games II (Europe)"
-	rom ( name "SummerGames2_v1.0.lha" size 357406 crc FBE74652 sha1 05291d23c5d6d6a6b67adbeede0d4a9f276d066a )
+	rom ( name "SummerGames2_v1.1_2896.lha" size 361979 crc 2A89279A sha1 05ee32a10e8d4e049b3ffa0a545395219a33db4a )
 )
 
 game (
 	name "Summer Games (Europe)"
-	rom ( name "SummerGames_v1.0.lha" size 238689 crc E6F62DF4 sha1 5bbac8c31f788278c14972f5704e689162376264 )
+	rom ( name "SummerGames_v1.1_2895.lha" size 243545 crc 098EDBA2 sha1 75407763b0d8ed53625b6831a8085104f55cdde2 )
 )
 
 game (
@@ -14216,17 +16145,17 @@ game (
 )
 
 game (
-	name "Super C (Fast) (Europe)"
+	name "Super C (Europe) (Fast)"
 	rom ( name "SuperC_v1.0a_Fast.lha" size 642892 crc 9C74B58B sha1 a1cbe8d363126d60331cad8b16ca96316f630e34 )
 )
 
 game (
 	name "Super Cars II (Europe)"
-	rom ( name "SuperCars2_v1.0_0224.lha" size 1791761 crc 2466B870 sha1 9ed3d4b78dfe2679036ac12d87ceb06580517402 )
+	rom ( name "SuperCars2_v1.3_0224.lha" size 1793472 crc B1D6AEEA sha1 89a165c0929d8dd34f29fb7616ff8b88a2569c5a )
 )
 
 game (
-	name "Super Cars (1 Disk) (Europe)"
+	name "Super Cars (Europe) (Budget)"
 	rom ( name "SuperCars_v1.3_1Disk_1528.lha" size 872900 crc 9EFB5775 sha1 bff5ce80e7dc6cdb105ad9e419464356895a47df )
 )
 
@@ -14237,32 +16166,37 @@ game (
 
 game (
 	name "Super Cauldron (Europe)"
-	rom ( name "SuperCauldron_v1.1.lha" size 879212 crc 80A4AEFE sha1 c40b15e9db207ba18b76a54318625ae746574d51 )
+	rom ( name "SuperCauldron_v1.2_3066.lha" size 886352 crc FD48C991 sha1 d67caf819f00190b9bfb36e79457cced2bf5536a )
 )
 
 game (
 	name "Superfrog (Europe) (CD32)"
-	rom ( name "Superfrog_v1.3_CD32.lha" size 3345225 crc C3F67B2B sha1 7def1a265daae846f5c63ae0f125324e94ac0aec )
+	rom ( name "Superfrog_v1.6_CD32.lha" size 3346083 crc 02063A64 sha1 09f6767d1a9fcd71bf249e08897fc31407b76a44 )
 )
 
 game (
 	name "Superfrog (Europe)"
-	rom ( name "Superfrog_v1.4_0035.lha" size 2791125 crc 36D4748C sha1 a39681f5303f45d1f937eee215d2a88755a0419c )
+	rom ( name "Superfrog_v1.6_0035.lha" size 2791965 crc 8B5C0794 sha1 69f65bf8f628bbde79b92b7ab4e3858bc5e55b92 )
 )
 
 game (
-	name "Superfrog (Amiga Action) (Europe) (Demo)"
+	name "Superfrog (Europe) (Demo) (Amiga Action)"
 	rom ( name "SuperfrogDemo_v1.1_AmigaAction.lha" size 435644 crc C07E31B9 sha1 b5dd6c3d2bc8cdb4b95432452cec837363bcd41f )
 )
 
 game (
-	name "Superfrog (CU Amiga) (Europe) (Demo)"
+	name "Superfrog (Europe) (Demo) (CU Amiga)"
 	rom ( name "SuperfrogDemo_v1.1_CUAmiga.lha" size 403797 crc 49D585C7 sha1 5be775ab955357a23a0952a191dd259c29bf57fe )
 )
 
 game (
-	name "Superfrog (The One) (Europe) (Demo)"
+	name "Superfrog (Europe) (Demo) (The One)"
 	rom ( name "SuperfrogDemo_v1.1_TheOne.lha" size 393202 crc 5C7BE51E sha1 c33bd5ca9229782c35c3fb31ce79e8baaca59feb )
+)
+
+game (
+	name "Super Gem'Z (Europe)"
+	rom ( name "SuperGemZ_v1.1.lha" size 936405 crc E1473986 sha1 eb8fc55aa972ba3c085a3ade8ed5f134da02c7d0 )
 )
 
 game (
@@ -14277,7 +16211,12 @@ game (
 
 game (
 	name "Super Hang-On (Europe)"
-	rom ( name "SuperHangOn_v1.6_0816.lha" size 398828 crc 73E5B18B sha1 e1c4b866d3549e1fe993ac03388ec85e053bc87d )
+	rom ( name "SuperHangOn_v1.7a_0816.lha" size 397189 crc C06F1EF1 sha1 f8cb8c718f1f542b8482ac4c406776fdb2272045 )
+)
+
+game (
+	name "Super Hang-On (USA)"
+	rom ( name "SuperHangOn_v1.7a_NTSC.lha" size 398605 crc 0BD4BD07 sha1 c5739642ed2bab40cb8c6f9dc77b60c56a83d77b )
 )
 
 game (
@@ -14292,7 +16231,7 @@ game (
 
 game (
 	name "Superman - The Man of Steel (Europe)"
-	rom ( name "Superman_v1.0.lha" size 497600 crc 2F584033 sha1 59fe0027b86e9077b6763167abec9dd230ae8a11 )
+	rom ( name "Superman_v1.1_3035.lha" size 473268 crc 636AE4E0 sha1 c1a98ad139eb59db850021008103ec3b98cfe4ec )
 )
 
 game (
@@ -14307,7 +16246,7 @@ game (
 
 game (
 	name "Super Monaco GP (Europe)"
-	rom ( name "SuperMonacoGP_v1.1.lha" size 472014 crc 61C66FDC sha1 2fccf818fc20e938f650b32ac9a6dc5e926450a7 )
+	rom ( name "SuperMonacoGP_v1.2.1_1422.lha" size 475405 crc 117F4B0C sha1 fdf94dc4ef133b182a780201fc050e87145bb665 )
 )
 
 game (
@@ -14332,7 +16271,7 @@ game (
 
 game (
 	name "Super Putty (Europe) (CD32)"
-	rom ( name "SuperPutty_v1.2a_CD32.lha" size 1640584 crc EFA6C872 sha1 57e388a50ffc74f63bb2b4065730999a94f198d3 )
+	rom ( name "SuperPutty_v1.2b_CD32.lha" size 1646789 crc D4EA197D sha1 915773f1b1baf4f4bff58cbf638e634af237797b )
 )
 
 game (
@@ -14342,7 +16281,17 @@ game (
 
 game (
 	name "Super Seymour Saves the Planet (Europe)"
-	rom ( name "SuperSeymourSavesThePlanet_v1.2.lha" size 244273 crc 4364D9AB sha1 b2baa13d41d29f7f0fa41c2597c165115bb00201 )
+	rom ( name "SuperSeymourSavesThePlanet_v1.3_2524.lha" size 238388 crc ADBC640A sha1 e8b17f7d16cd18ca1f7ca3ebbf7f205f4d578e46 )
+)
+
+game (
+	name "Super Silly Skidmarks (Europe) (CD)"
+	rom ( name "SuperSillySkidmarks_v2.2_CD.lha" size 10237176 crc B89965AF sha1 947fd104cb17ef5c4ea30e09c54e30f41dad3586 )
+)
+
+game (
+	name "Super Silly Skidmarks (Europe) (CD) (Low Mem)"
+	rom ( name "SuperSillySkidmarks_v2.2_LowMem_CD.lha" size 10237542 crc 33712F77 sha1 91702f4aeee779f6e62824f0403ceaef3666b965 )
 )
 
 game (
@@ -14361,13 +16310,53 @@ game (
 )
 
 game (
-	name "Super Skidmarks (Europe) (CD32)"
-	rom ( name "SuperSkidmarks_v1.1_CD32.lha" size 5327966 crc 53920F93 sha1 a9c63fe2111bfd64a295bd15d687d49ab389b424 )
+	name "Super Skidmarks+ (Europe) (CD)"
+	rom ( name "SuperSkidmarks+_v2.2_CD.lha" size 11470280 crc FACB7734 sha1 deb10867b4ff168a1bba90542420f39ce568b3ab )
 )
 
 game (
-	name "Super Skidmarks (Low Mem) (Europe) (CD32)"
-	rom ( name "SuperSkidmarks_v1.1_LowMem_CD32.lha" size 5328369 crc FB224633 sha1 a58fbce51d14cf3bedc7383147ab2f21834fdffb )
+	name "Super Skidmarks+ (Europe) (CD) (Low Mem)"
+	rom ( name "SuperSkidmarks+_v2.2_LowMem_CD.lha" size 11470664 crc 2350E745 sha1 e6826bb18343924c20ea9b7acb9c289f660726d0 )
+)
+
+game (
+	name "Super Skidmarks (Europe)"
+	rom ( name "SuperSkidmarks_v2.2_1797.lha" size 4537499 crc EC0379ED sha1 4f8f975f2fb51b929f17595b29e0b0e34aa7bddb )
+)
+
+game (
+	name "Super Skidmarks (Europe) (CD)"
+	rom ( name "SuperSkidmarks_v2.2_CD.lha" size 4863310 crc 8FF001F4 sha1 ff23026f01e2b3dc9273ed7e4344e34cfb43480d )
+)
+
+game (
+	name "Super Skidmarks (Europe) (CD32)"
+	rom ( name "SuperSkidmarks_v2.2_CD32.lha" size 5326993 crc 94E1A969 sha1 ae7bebdde51e85699c347d46d18b96aabe288ee2 )
+)
+
+game (
+	name "Super Skidmarks (Europe) (Low Mem)"
+	rom ( name "SuperSkidmarks_v2.2_LowMem_1797.lha" size 4537846 crc BFB9FB6E sha1 eac674a7228fc866d27e1ab2a0494fa32ef3eab6 )
+)
+
+game (
+	name "Super Skidmarks (Europe) (CD) (Low Mem)"
+	rom ( name "SuperSkidmarks_v2.2_LowMem_CD.lha" size 4863464 crc DB98717A sha1 c37a62f231de538be5e2552aff74020b8b15a129 )
+)
+
+game (
+	name "Super Skidmarks (Europe) (CD32) (Low Mem)"
+	rom ( name "SuperSkidmarks_v2.2_LowMem_CD32.lha" size 5327388 crc E97FA2F4 sha1 2f15c7cd47e0d988c9929649785820b0a682fe32 )
+)
+
+game (
+	name "Super Skidmarks Farm Yard Edition (Europe) (CD)"
+	rom ( name "SuperSkidmarksFarmYardEdition_v2.2_CD.lha" size 7027191 crc 158E9971 sha1 672ef8a080b18ee7db0c05a205a0b976019c181c )
+)
+
+game (
+	name "Super Skidmarks Farm Yard Edition (Europe) (CD) (Low Mem)"
+	rom ( name "SuperSkidmarksFarmYardEdition_v2.2_LowMem_CD.lha" size 7027421 crc 615AB5CA sha1 e416174e2ab5e1345bfb8679becd80234bab9884 )
 )
 
 game (
@@ -14376,18 +16365,18 @@ game (
 )
 
 game (
-	name "Super Skweek (512 KB) (Europe)"
+	name "Super Skweek (Europe) (512 kB)"
 	rom ( name "SuperSkweek_v1.1_512KB_1935&2403.lha" size 1123930 crc 3DAABC35 sha1 e98f8786bddd92702e294b3cba0383570a3e3b8c )
 )
 
 game (
 	name "Super Space Invaders (Europe)"
-	rom ( name "SuperSpaceInvaders_v1.2.lha" size 1532575 crc 41A8C194 sha1 e22714352df216a23b989d51992ddfa50cdf98ae )
+	rom ( name "SuperSpaceInvaders_v2.0_0585.lha" size 1532970 crc 12F0F61D sha1 9ee5dafcdd19da16f7aed1cdbce0fa04151ae3c4 )
 )
 
 game (
 	name "Super Space Invaders (USA)"
-	rom ( name "SuperSpaceInvaders_v1.2_NTSC.lha" size 1417722 crc 1158131B sha1 116a38d34d4f0cb629f5f300eaeeb06957b0e40c )
+	rom ( name "SuperSpaceInvaders_v2.0_NTSC.lha" size 1418036 crc 45CF2BF2 sha1 6a551915c23d988a0531326e379daa2e132fb84b )
 )
 
 game (
@@ -14402,17 +16391,17 @@ game (
 
 game (
 	name "Super Street Fighter II - The New Challengers (Europe)"
-	rom ( name "SuperStreetFighter2_v1.1_0147.lha" size 3335123 crc 2A9EE343 sha1 8aaa9f96f26f728e94e19754d7444f31e5184109 )
+	rom ( name "SuperStreetFighter2_v1.2_0147.lha" size 3335732 crc 2080D470 sha1 6336816597f91d8e583230c3d4b1f5e77a7a13ec )
 )
 
 game (
 	name "Super Street Fighter II - The New Challengers (Europe) (AGA)"
-	rom ( name "SuperStreetFighter2_v1.1_AGA.lha" size 4593998 crc 4D77DC4D sha1 6c4c999647850b03bf60c6054ea3f43f4908d5e3 )
+	rom ( name "SuperStreetFighter2_v1.2_AGA.lha" size 4594611 crc 1885112F sha1 66af434692773cb76c95cf0cd4bd91c17d7707a3 )
 )
 
 game (
 	name "Super Street Fighter II - The New Challengers (Europe) (AGA)"
-	rom ( name "SuperStreetFighter2DX_v1.1_AGA.lha" size 4643561 crc 67A0D257 sha1 9e7e84f57b9ac0843b362f535fd9cd321d53972b )
+	rom ( name "SuperStreetFighter2DX_v1.2_AGA.lha" size 4644177 crc F719C80F sha1 d834fa1b7ad592058f077225929c7caa0f22891a )
 )
 
 game (
@@ -14427,12 +16416,12 @@ game (
 
 game (
 	name "Super Tennis Champs & Data Disks (Europe)"
-	rom ( name "SuperTennisChamps&DataDisks_v1.1.lha" size 1431952 crc E4FC7357 sha1 c801e9b455941736db4a84e32373bb9d1e7b7b7c )
+	rom ( name "SuperTennisChamps&DataDisks_v1.2_1153.lha" size 1434269 crc 8E4945EE sha1 f23ed95255c82389a9f7254db3c6fdd8799a92dc )
 )
 
 game (
 	name "Super Tennis Champs (Europe)"
-	rom ( name "SuperTennisChamps_v1.1.lha" size 666649 crc 279F2D68 sha1 e4e3f8a9048bdee97e4e4f54760a275a173c51c9 )
+	rom ( name "SuperTennisChamps_v1.2_1153.lha" size 670180 crc 7A167E88 sha1 caf502806db1673a5b2dbd1d3e6a1c5e70874709 )
 )
 
 game (
@@ -14452,12 +16441,17 @@ game (
 
 game (
 	name "Surf Ninjas (Europe) (AGA)"
-	rom ( name "SurfNinjas_v1.0_AGA_1291.lha" size 1766164 crc D80B38F1 sha1 ae87eeec0e73a3344f12016c0a343333641cebef )
+	rom ( name "SurfNinjas_v1.1_AGA_1291.lha" size 1767630 crc 19C3ABD6 sha1 f647f274b4179dc34331fb3dd75b64cbae8ccd2e )
+)
+
+game (
+	name "Surf Ninjas (Europe) (CD32)"
+	rom ( name "SurfNinjas_v1.1_CD32.lha" size 9501757 crc C82518EA sha1 0e3f9d478045481f34f27a198ab7be723f6db7b3 )
 )
 
 game (
 	name "Suspicious Cargo - Special Edition (Europe)"
-	rom ( name "SuspiciousCargo_v1.0_0148.lha" size 1431570 crc C5C38AA3 sha1 e3f822b44d982cd53292ab8710f459dd8a382744 )
+	rom ( name "SuspiciousCargo_v2.0_0148.lha" size 1437662 crc 0EE61BAC sha1 3db4a30ca5f2678b753661f3e58da40743a3e368 )
 )
 
 game (
@@ -14472,7 +16466,7 @@ game (
 
 game (
 	name "Switchblade II (Europe)"
-	rom ( name "Switchblade2_v1.3_1725.lha" size 854415 crc 1397B9AA sha1 b6badcd84331da7fa52baecbea85328bf5489188 )
+	rom ( name "Switchblade2_v1.7_1725.lha" size 855571 crc E1C1F6F1 sha1 56a2cd31ff60e072cb1f1ab0bba810ced6ebf4bf )
 )
 
 game (
@@ -14491,13 +16485,18 @@ game (
 )
 
 game (
-	name "Sword and The Rose, The (Europe)"
-	rom ( name "Sword&TheRose_v1.2.lha" size 223988 crc 50B3A95D sha1 0e51afaf55b5f1022df5dc0e26b3b73ed87a6b76 )
+	name "Sword (Europe)"
+	rom ( name "Sword_v1.1.lha" size 2500948 crc F5A981EF sha1 3b9a92fd93f42950ac08e8f667b1251f43d1c227 )
 )
 
 game (
-	name "Sword (Europe)"
-	rom ( name "Sword_v1.0.lha" size 2500041 crc 59449EE6 sha1 cef42ee33e5308fbfd52b15808caba2559039e39 )
+	name "Sword (Europe) (512 kB)"
+	rom ( name "Sword_v1.1_512k.lha" size 2501267 crc 427B9148 sha1 5b6c3692a4e69a784f0d842884cf37327ee4a834 )
+)
+
+game (
+	name "Sword and The Rose, The (Europe)"
+	rom ( name "SwordAndTheRose_v1.3_2434.lha" size 241548 crc C8D8C9DF sha1 dd067ccf6aa9616f5872176888f2e8f3f7e9fa4d )
 )
 
 game (
@@ -14507,12 +16506,12 @@ game (
 
 game (
 	name "Sword of Honour (Europe)"
-	rom ( name "SwordOfHonour_v1.0_0149.lha" size 1384581 crc 4151A7E3 sha1 f8061a62ca6a6744321819b9e873a489c6c6e386 )
+	rom ( name "SwordOfHonour_v1.1_0149.lha" size 1385515 crc F26CC560 sha1 00fd536c469d976783401dd6689d8fa42070f7c9 )
 )
 
 game (
 	name "Sword of Sodan (Europe)"
-	rom ( name "SwordOfSodan_v1.0_1103.lha" size 2481900 crc 93F4555B sha1 aef1ecf4ee000e229443243792f89da24ca01d24 )
+	rom ( name "SwordOfSodan_v2.0a_1103.lha" size 2489510 crc 7968A51F sha1 d01ee65d69c64a1dae22501e2818b8507dcff19d )
 )
 
 game (
@@ -14527,26 +16526,26 @@ game (
 
 game (
 	name "Syndicate (Europe)"
-	rom ( name "Syndicate_v2.2_0739.lha" size 2333118 crc 5DF601E1 sha1 4dd7afe218545862d9ac5ae08b3ef49e44792add )
+	rom ( name "Syndicate_v2.7_0739.lha" size 2360716 crc 6AC6E29D sha1 d4e38f81733b5a4caada200f6e9fe086136c01bf )
 )
 
 game (
 	name "Syndicate (Europe) (CD32)"
-	rom ( name "Syndicate_v2.2_CD32.lha" size 2328738 crc B74C4DF5 sha1 9c76bc5717141b92fe74d75e637c793bee52fb00 )
+	rom ( name "Syndicate_v2.7_CD32.lha" size 2353699 crc 76CD6D8F sha1 39a062a80d06772048e0950627d9c93c3387cf11 )
 )
 
 game (
 	name "Syndicate (Germany)"
-	rom ( name "Syndicate_v2.2_De_0405.lha" size 2231068 crc 1E82AC08 sha1 9b869872ac19e8c4ccd1c9ff17b7f998b85566ef )
+	rom ( name "Syndicate_v2.7_De_0405.lha" size 2258958 crc 9AD25E50 sha1 487cb3536f12d6d5604f8a8cd5c8690f3b287929 )
 )
 
 game (
 	name "Syndicate - American Revolt Mission Disk (Europe)"
-	rom ( name "SyndicateAmericanRevolt_v2.2.lha" size 2343977 crc 5BDA669A sha1 273eb9dd58da2122ab99d35876f160587838c41f )
+	rom ( name "SyndicateAmericanRevolt_v2.7.lha" size 2345214 crc FF01A175 sha1 b7cdca1b203101b475d5b88b280d701f8e87654d )
 )
 
 game (
-	name "SportTime Table Hockey (Arcadia) (Europe)"
+	name "SportTime Table Hockey (Europe) (Arcadia)"
 	rom ( name "TableHockey_v0.1_Arcadia.lha" size 118128 crc 3A02101E sha1 98be0f0ed7d5bcf43408fa6eb904d7093c61d4bf )
 )
 
@@ -14566,6 +16565,11 @@ game (
 )
 
 game (
+	name "Talking Storybook, The - The Three Bears (Europe)"
+	rom ( name "TalkingStorybookTheThreeBears_v1.0.lha" size 665424 crc 954690C0 sha1 5a0f9616d4ebe5c7baf754e2ff4a7a181023bd0e )
+)
+
+game (
 	name "Tanglewood (Europe)"
 	rom ( name "Tanglewood_v1.0_1623.lha" size 326405 crc 92E790CB sha1 9946f7ee9413191e73f297af3202f19ba7698bc9 )
 )
@@ -14576,12 +16580,22 @@ game (
 )
 
 game (
+	name "Tank Buster (Europe)"
+	rom ( name "TankBuster_v1.0.lha" size 220157 crc 6E294FFD sha1 72290e00b55b4d9aa74d921b6b93522c2727523a )
+)
+
+game (
+	name "Tapper (Europe)"
+	rom ( name "Tapper_v1.0.lha" size 536745 crc 8E2FFD1D sha1 df2395defa583810e5a62ed64b9e059d6f95d739 )
+)
+
+game (
 	name "Targhan (Europe)"
 	rom ( name "Targhan_v1.4_1859.lha" size 519309 crc 5D14976B sha1 1f9d5e9fea138ce88ab1ba08f69b8ba51ae12106 )
 )
 
 game (
-	name "Targhan (Fast) (Europe)"
+	name "Targhan (Europe) (Fast)"
 	rom ( name "Targhan_v1.4_Fast_1859.lha" size 519600 crc C902C704 sha1 51dc6afdd747b3d9e45c88bcea0f13154b30231f )
 )
 
@@ -14591,8 +16605,13 @@ game (
 )
 
 game (
-	name "Targhan (Fast) (France)"
+	name "Targhan (France) (Fast)"
 	rom ( name "Targhan_v1.4_Fr_Fast_2405.lha" size 536298 crc 4A18D783 sha1 6951c334fcbcedb9692e84817d7c73bb92543a18 )
+)
+
+game (
+	name "Targhan (USA)"
+	rom ( name "Targhan_v1.4_NTSC.lha" size 520938 crc 7A2807E8 sha1 a5eb44fcc68314b2128aa7f4ecb962ec9effb962 )
 )
 
 game (
@@ -14607,7 +16626,7 @@ game (
 
 game (
 	name "Team Suzuki (Europe)"
-	rom ( name "TeamSuzuki_v1.1_1767.lha" size 404814 crc 3585D39D sha1 be872a514a37afad8a0451d377a1e421123b1d31 )
+	rom ( name "TeamSuzuki_v1.2_1767.lha" size 385618 crc 37CFDCF9 sha1 ff702649cd6983ea40ef2e59d0be26a9062f5da2 )
 )
 
 game (
@@ -14622,12 +16641,17 @@ game (
 
 game (
 	name "Tech (Europe)"
-	rom ( name "Tech_v1.0.lha" size 140096 crc 2ACB339D sha1 54a457dd1f658b8ae191c3e0c4eddbcc6e9f5fac )
+	rom ( name "Tech_v1.1.lha" size 143623 crc 61E0CF82 sha1 22348b9558c331f717d501f629993ba22f296040 )
 )
 
 game (
 	name "Technocop (Europe)"
-	rom ( name "Technocop_v1.2.lha" size 445192 crc FAF60C37 sha1 3d4e42ff38942b46eadc84a4f4e177ac5ee5c454 )
+	rom ( name "Technocop_v1.2.lha" size 446317 crc 2C30A918 sha1 4f58aab7052c11e9f880a92934ae75a1119bfa65 )
+)
+
+game (
+	name "Technocop (USA)"
+	rom ( name "Technocop_v1.2_NTSC.lha" size 449398 crc FD5D4553 sha1 222282ab3887cfb7d18bb1bcff1aefd1015edccc )
 )
 
 game (
@@ -14671,13 +16695,23 @@ game (
 )
 
 game (
+	name "Temple Of The Enlightened Souls, The (Europe)"
+	rom ( name "TempleOfTheEnlightenedSouls_v1.1.lha" size 563858 crc AE45E454 sha1 8be136723c67a9aea96067047f8415bd610c3aca )
+)
+
+game (
+	name "Templos Sagrados, Los (Spain)"
+	rom ( name "TemplosSagrados_v1.0_Es.lha" size 433320 crc 61888152 sha1 7f7edfb4306e9056cc494c7ccc942c3b99ab26dc )
+)
+
+game (
 	name "Tennis Champs (Europe)"
-	rom ( name "TennisChamps_v1.0.lha" size 459303 crc 281DFB34 sha1 b964b91506d7e37a0388a050bb0da9583cc8d93e )
+	rom ( name "TennisChamps_v1.0.lha" size 575186 crc 1EA7AB51 sha1 ac75ce97fb354edfa5f829f0a14adfef911378e9 )
 )
 
 game (
 	name "Tennis Cup II (Europe)"
-	rom ( name "TennisCup2_v1.0_0738.lha" size 1053672 crc 12B030C9 sha1 e25a85391100dc3b8253b506ad9120b817a18dc5 )
+	rom ( name "TennisCup2_v1.2_0738.lha" size 1054009 crc A0C78D45 sha1 cf617e986e674772b2d65507bc85e3900f9280cc )
 )
 
 game (
@@ -14686,7 +16720,7 @@ game (
 )
 
 game (
-	name "Tennis Cup (512 KB) (Europe)"
+	name "Tennis Cup (Europe) (512 kB)"
 	rom ( name "TennisCup_v1.3a_512Kb_0737.lha" size 683526 crc A8153A23 sha1 a60a6a2bbfa372a5e1704ac0192595b9e469ee8c )
 )
 
@@ -14696,12 +16730,12 @@ game (
 )
 
 game (
-	name "Tennis Cup (512 KB) (France)"
+	name "Tennis Cup (France) (512 kB)"
 	rom ( name "TennisCup_v1.3a_Fr_512Kb_1638.lha" size 680094 crc BED2BA3A sha1 50ec39db4195d7188f4bb308997d7554164ad90f )
 )
 
 game (
-	name "Ten Pin Bowling (Arcadia) (Europe)"
+	name "Ten Pin Bowling (Europe) (Arcadia)"
 	rom ( name "TenPinBowling_v0.1_Arcadia.lha" size 186153 crc 066120AC sha1 596efb7b987f71359aad7c53029d9dee9a568b75 )
 )
 
@@ -14737,17 +16771,17 @@ game (
 
 game (
 	name "Test Drive II & Data Disks (Europe)"
-	rom ( name "TestDrive2&DataDisks_v1.1_0588&0589&0590&0591&0818.lha" size 1417540 crc 28DCE854 sha1 3455ce718d6a552e9faed7ca2f0fdb009a47c904 )
+	rom ( name "TestDrive2&DataDisks_v1.5_0588&0589&0590&0591&0818.lha" size 1414796 crc 768610B9 sha1 4c839695038fda1e4de96f33f52139ae25cdb32d )
 )
 
 game (
 	name "Test Drive II - The Duel (Europe)"
-	rom ( name "TestDrive2_v1.1_0588.lha" size 432427 crc A631A04C sha1 44631e2a82e97dd7e2bf7188795b6ab684676052 )
+	rom ( name "TestDrive2_v1.5_0588.lha" size 434795 crc 15889E36 sha1 91e65cfe84616bf94c57a2ba0348ba036696a50e )
 )
 
 game (
 	name "Test Drive (Europe)"
-	rom ( name "TestDrive_v1.1_0089.lha" size 516112 crc CC05A13E sha1 b73e0e491fa3bfb53191e515919fb8652fc3393b )
+	rom ( name "TestDrive_v1.3_0089.lha" size 513613 crc DA2EB7E6 sha1 ff9f4db45b739907de76c415d6e136a9ac0fbbce )
 )
 
 game (
@@ -14756,18 +16790,18 @@ game (
 )
 
 game (
-	name "Tetris (Infogrames) (Europe)"
-	rom ( name "Tetris_v1.1_Infogrames.lha" size 439980 crc A9DEA283 sha1 14748a1106de860ac4ecf3bbaf3b41e383eae7de )
-)
-
-game (
-	name "Tetris (Mirrorsoft) (Europe)"
+	name "Tetris (Europe) (Mirrorsoft)"
 	rom ( name "Tetris_v1.1_Mirrorsoft.lha" size 105976 crc B793AEBB sha1 aa80248d55c4deeeeb522f0915b3f76c377767f2 )
 )
 
 game (
+	name "Tetris (Europe) (Infogrames)"
+	rom ( name "Tetris_v1.2_Infogrames.lha" size 443043 crc EC9AFA7F sha1 7c8ee800a750718efd0f7b82df86813b3e56ba5e )
+)
+
+game (
 	name "Tetris Pro (Europe)"
-	rom ( name "TetrisPro_v1.0.1.lha" size 370567 crc BF11714E sha1 42a112579125cd11b919efccb6eeeb9b905c5284 )
+	rom ( name "TetrisPro_v1.0.2.lha" size 370554 crc AFDB8B3E sha1 c865299bacf3f634f2800b1c0bf8bff1ad4d1c0c )
 )
 
 game (
@@ -14776,12 +16810,87 @@ game (
 )
 
 game (
+	name "Tex 01 - Mefisto (Italy)"
+	rom ( name "Tex01_v1.0_It.lha" size 635340 crc 19016343 sha1 b46cfd8e467784eee7f6a4c874a69faf502498c7 )
+)
+
+game (
+	name "Tex 02 - Il Drago Rosso (Italy)"
+	rom ( name "Tex02_v1.0_It.lha" size 703295 crc EE0A9069 sha1 0fb6febe9af5521aa212c2262ffab3237643b38a )
+)
+
+game (
+	name "Tex 03 - Spettri (Italy)"
+	rom ( name "Tex03_v1.0_It.lha" size 577875 crc E559785F sha1 fb632b1db05e32b9c5397530116f72840f911d94 )
+)
+
+game (
+	name "Tex 04 - San Francisco (Italy)"
+	rom ( name "Tex04_v1.0_It.lha" size 658569 crc E96B650C sha1 b21dde3d9a1dfcea596eb958bd6dad4f6c941697 )
+)
+
+game (
+	name "Tex 05 - Diabolico Intrigo (Italy)"
+	rom ( name "Tex05_v1.0_It.lha" size 656240 crc 5e930830 sha1 e5771d1232f4d2ef41b5982ee0d098818faa6e2b )
+)
+
+game (
+	name "Tex 06 - Lotta Sul Mare (Italy)"
+	rom ( name "Tex06_v1.0_It.lha" size 651478 crc E2BAA605 sha1 ecdc592a68f02e99a64e04c6d9f7ffcc2f3e908c )
+)
+
+game (
+	name "Tex 07 - El Morisco (Italy)"
+	rom ( name "Tex07_v1.0_It.lha" size 320433 crc 5DAE85D4 sha1 a826b1e48ef642a5bb31d7026f77d13a44208287 )
+)
+
+game (
+	name "Tex 08 - Dramma al Circo (Italy)"
+	rom ( name "Tex08_v1.0_It.lha" size 325980 crc 29D3FCE3 sha1 6406e29f45da25c48a0eb8993dfe22e4fd54f32b )
+)
+
+game (
+	name "Tex 09 - Il Fiore Della Morte (Italy)"
+	rom ( name "Tex09_v1.0_It.lha" size 258560 crc 670968EB sha1 c173f7aa6c677f4095184ddb9b555bf898faf5c8 )
+)
+
+game (
+	name "Tex 10 - Kento Non Perdona (Italy)"
+	rom ( name "Tex10_v1.0_It.lha" size 289588 crc CB220E94 sha1 41a5ece2070facb03544839e3e40695428317187 )
+)
+
+game (
+	name "Tex 11 - Duello All'Alba (Italy)"
+	rom ( name "Tex11_v1.0_It.lha" size 283632 crc 8C73177E sha1 8d6380376be1a70d92150fdd3b4b4ea611ac518f )
+)
+
+game (
+	name "Tex 12 - La Mano Rossa (Italy)"
+	rom ( name "Tex12_v1.0_It.lha" size 306105 crc C41C4978 sha1 3620965869eedc2680a80c9099efbfd2cd176978 )
+)
+
+game (
+	name "Tex - Piombo Caldo Part I (Italy)"
+	rom ( name "TexPiomboCaldoPart1_v1.0_It.lha" size 2712406 crc F58A4823 sha1 a63706538c8a8274795fd5c6dc9fb5a72bbdb394 )
+)
+
+game (
+	name "Tex - Piombo Caldo Part II (Italy)"
+	rom ( name "TexPiomboCaldoPart2_v1.0_It.lha" size 2678822 crc 93414F95 sha1 fd690deb38ef0fa04bc984c153eba1183f10ba56 )
+)
+
+game (
+	name "TFX - Tactical Fighter Experiment (Europe) (AGA)"
+	rom ( name "TFX_v2.1_AGA.lha" size 7609259 crc 046B7EA2 sha1 bb062b18783d86e3b87b634865c59cb919279dec )
+)
+
+game (
 	name "Theatre of Death (Europe)"
 	rom ( name "TheatreOfDeath_v1.1_0254.lha" size 1116488 crc EEF1114D sha1 769a29f616557659764d53d143392b7d0ab76d72 )
 )
 
 game (
-	name "Their Finest Hour & Their Finest Missions Volume 1 (Europe)"
+	name "Their Finest Hour & Missions Volume 1 (Europe)"
 	rom ( name "TheirFinestHour&Missions_v1.1_0037&1369.lha" size 835157 crc 944A2D0C sha1 745900292f6c46e15191a301a895ca896ff3397f )
 )
 
@@ -14791,13 +16900,18 @@ game (
 )
 
 game (
-	name "Theme Park (Europe)"
-	rom ( name "ThemePark_v1.0_0090.lha" size 661962 crc 44198261 sha1 bca48ddfb49b7fb86e09d780589c8a0e270ba4a7 )
+	name "Theme Park (Europe) (En,Fr,De,It) (AGA)"
+	rom ( name "ThemePark_v3.0_AGA_0153.lha" size 2873537 crc 3D37AF42 sha1 36ac6d278fb9aaf724a836d194650938724d3745 )
 )
 
 game (
-	name "Theme Park (Europe) (En,Fr,De,It) (AGA)"
-	rom ( name "ThemePark_v2.0_AGA_0153.lha" size 2868316 crc FE5187A9 sha1 b7f731736679cec99cacb3a38060339b1f24fc0b )
+	name "Theme Park (Europe) (En,Fr,De,It) (CD32)"
+	rom ( name "ThemePark_v3.0_CD32.lha" size 1992389 crc 89A7E9B6 sha1 8f06aaeddfd8a68dabcba542dd3bf3cec6f06ad8 )
+)
+
+game (
+	name "Theme Park (Europe)"
+	rom ( name "ThemePark_v3.1_0090.lha" size 667201 crc D42F066E sha1 ae5b88144787de6762126e64d7d680ec2146ac1e )
 )
 
 game (
@@ -14816,6 +16930,11 @@ game (
 )
 
 game (
+	name "Think Twice (Europe)"
+	rom ( name "ThinkTwice_v1.0_1695.lha" size 216378 crc 6E7AAA34 sha1 a6ff6951aec4bb5dfdb9249bbde494d3285e8d70 )
+)
+
+game (
 	name "Third Courier, The (Europe)"
 	rom ( name "ThirdCourier_v1.0_0593.lha" size 538681 crc 54189844 sha1 d2e0a4f8c2152275217b7a724e710bc76c4eec1c )
 )
@@ -14831,18 +16950,23 @@ game (
 )
 
 game (
-	name "Thomas the Tank Engine & Friends - Pinball (Europe) (AGA)"
+	name "Thomas The Tank Engine's Pinball (Europe) (AGA)"
 	rom ( name "ThomasTheTankEnginePinball_v1.2_AGA_2629.lha" size 999267 crc F857CF4A sha1 4a1bd23ac374a7b56716393ea0577be728e919bb )
 )
 
 game (
-	name "Thomas the Tank Engine & Friends - Pinball (Europe) (CD32)"
+	name "Thomas The Tank Engine's Pinball (Europe) (CD32)"
 	rom ( name "ThomasTheTankEnginePinball_v1.2_CD32.lha" size 999123 crc DA674060 sha1 5f90b967e560ffd3b9d045baf934cd4a4d9599bb )
 )
 
 game (
+	name "Three Stooges, The (Europe)"
+	rom ( name "ThreeStooges_v2.0_0741.lha" size 1098214 crc 04958F34 sha1 ce4e969bccbdb58dabfc3b9f1fc158f03ab1b3f8 )
+)
+
+game (
 	name "Three Stooges, The (USA)"
-	rom ( name "ThreeStooges_v1.0_NTSC_0740.lha" size 1200313 crc CEB8FC04 sha1 0b722de05d94a526fcb173788e5a7626c4bd1a39 )
+	rom ( name "ThreeStooges_v2.0_NTSC_0740.lha" size 1086602 crc EAE87F53 sha1 01146b028393c27e22689e770506e60e6b786079 )
 )
 
 game (
@@ -14852,12 +16976,12 @@ game (
 
 game (
 	name "Thunder Blade (Europe)"
-	rom ( name "ThunderBlade_v1.4_0393.lha" size 526236 crc 0A9AE391 sha1 3284e1e8d8ab87f58314f8df8ef893c98a41aefb )
+	rom ( name "ThunderBlade_v1.4.1_0393.lha" size 517930 crc A21E8E37 sha1 31af867cc5c8b06e74f93f4eb61d75bcd6579077 )
 )
 
 game (
 	name "Thunder Blade (USA)"
-	rom ( name "ThunderBlade_v1.4_NTSC_0948.lha" size 515398 crc 2EB66B2F sha1 f5a890470a149a63d075a5ac270e328831f33c04 )
+	rom ( name "ThunderBlade_v1.4.1_NTSC_0948.lha" size 507090 crc B7EBB440 sha1 9fb9086d11b960fe42cb0f37a1a03b705804a7db )
 )
 
 game (
@@ -14867,7 +16991,7 @@ game (
 
 game (
 	name "Thunder Burner (Europe)"
-	rom ( name "ThunderBurner_v1.0_2412.lha" size 589246 crc D2192C89 sha1 aa685e229ceacc1dad30b8b0aa2ee5f833973a92 )
+	rom ( name "ThunderBurner_v1.1_2412.lha" size 589520 crc 7F78C784 sha1 9ee18e9427767423adebe156a5c2a15454d2eeb4 )
 )
 
 game (
@@ -14877,22 +17001,32 @@ game (
 
 game (
 	name "Thunderhawk AH-73M (Europe)"
-	rom ( name "ThunderHawkAH73M_v2.2.1_0039.lha" size 1340157 crc F0170CB9 sha1 9f3af85e6b0bea7ab4ff8db832927815d2c098af )
+	rom ( name "ThunderHawk_v2.3_0039.lha" size 1338035 crc E465573A sha1 2650d82fff5e921e120d9b8381fc648857487445 )
 )
 
 game (
 	name "Thunderhawk AH-73M (Germany)"
-	rom ( name "ThunderHawkAH73M_v2.2.1_De.lha" size 1304082 crc 1B84A2FD sha1 c8ce26daf0709b4d6a3582610f8fe3d9352fced8 )
+	rom ( name "ThunderHawk_v2.3_De.lha" size 1301966 crc B183BC4B sha1 d96185b332706beaf5e38472d2ae416fe5695ce1 )
 )
 
 game (
 	name "Thunderhawk AH-73M (France)"
-	rom ( name "ThunderHawkAH73M_v2.2.1_Fr.lha" size 1319354 crc 5BF1A2C8 sha1 c03dace9aa756751bf4c508c631ebffa531d1321 )
+	rom ( name "ThunderHawk_v2.3_Fr.lha" size 1317240 crc 96381616 sha1 295b459be547d544740a59b6d79d9810d66adb73 )
+)
+
+game (
+	name "Thunderhawk AH-73M (USA)"
+	rom ( name "ThunderHawk_v2.3_NTSC_2019.lha" size 1338426 crc 95977B7D sha1 5d7c73472d134a1ef4f6c2f40694267e1afb8661 )
 )
 
 game (
 	name "Thunder Jaws (Europe)"
-	rom ( name "ThunderJaws_v1.2_0293.lha" size 1467474 crc 4AEF9138 sha1 6d544423f01cdd077dcb8a56daadd5a49e8458e2 )
+	rom ( name "ThunderJaws_v1.4_Files_0293.lha" size 1246988 crc 85B056CF sha1 77c3f3cbfcf6d0beb05e5be641135d79134872c2 )
+)
+
+game (
+	name "Thunder Jaws (Europe) (Image)"
+	rom ( name "ThunderJaws_v1.4_Image_0293.lha" size 1474439 crc 45B8D527 sha1 0339187107604c2ff316d1aedcf591a38bbe84e0 )
 )
 
 game (
@@ -14902,7 +17036,7 @@ game (
 
 game (
 	name "Tie-Break (Europe)"
-	rom ( name "TieBreak_v1.0.lha" size 409273 crc B9AD048C sha1 551810a434af0606e507f2e7176e19bd89165e4f )
+	rom ( name "TieBreak_v1.1_2637.lha" size 409672 crc F56158E9 sha1 0ae7c8c88b3762043f58558b3c196dcfda9ed743 )
 )
 
 game (
@@ -14912,17 +17046,17 @@ game (
 
 game (
 	name "Time (Europe)"
-	rom ( name "Time_v1.1.lha" size 794350 crc 4E24ED34 sha1 63cac3bb5bb4b38c0e254ef9fd93b5179dd3dd6f )
+	rom ( name "Time_v1.2.lha" size 794032 crc 01F36F69 sha1 ec520b142666ea0dd6398189ae04899b2df7c49e )
 )
 
 game (
 	name "Time (Germany)"
-	rom ( name "Time_v1.1_De_1697.lha" size 794103 crc D57575A8 sha1 066f0d15359e2ddcbc0be40fbe51d2f4991eb54f )
+	rom ( name "Time_v1.2_De_1697.lha" size 793787 crc 8FF79C17 sha1 1130f6712e990c04b8af174afbedb16624fe3912 )
 )
 
 game (
 	name "Time (France)"
-	rom ( name "Time_v1.1_Fr_2644.lha" size 793418 crc 25705BD8 sha1 f5e77d39d5112675f0a8eb8b8a443e445808e358 )
+	rom ( name "Time_v1.2_Fr_2644.lha" size 793094 crc B5D95C49 sha1 635e86f123b1ad028d85ac2b3fb8898351a9de1b )
 )
 
 game (
@@ -14932,7 +17066,7 @@ game (
 
 game (
 	name "Time Bandit (Europe)"
-	rom ( name "TimeBandit_v1.0.lha" size 139260 crc CC2D1351 sha1 6b927c475fc9d18ebf7a6c47812e5e0c9b54ad92 )
+	rom ( name "TimeBandit_v1.1.lha" size 139572 crc E89A6182 sha1 bc3268c4977a5a5b5e638d3fb0feca36fd29f7ec )
 )
 
 game (
@@ -14942,12 +17076,17 @@ game (
 
 game (
 	name "Time Machine (Europe)"
-	rom ( name "TimeMachine_v1.1_0974.lha" size 498550 crc 881F7969 sha1 dde4422c32713c6549bb29e5665ba8dfd8422ddb )
+	rom ( name "TimeMachine_v1.2_0974.lha" size 502773 crc B246DC04 sha1 7e1e396307f5afdf95a01a4735d7b44a93a70ade )
 )
 
 game (
 	name "Time Race (Europe)"
 	rom ( name "TimeRace_v1.0_2420.lha" size 776742 crc C8BD5F22 sha1 be95c4700d760409c9091e85cc3c169b76dcae95 )
+)
+
+game (
+	name "Time Runner (Europe)"
+	rom ( name "TimeRunner_v1.1_2984.lha" size 372005 crc 0586E0D8 sha1 46b66b79c479de290e5ae3dd095a886ee356758b )
 )
 
 game (
@@ -15101,7 +17240,7 @@ game (
 )
 
 game (
-	name "Time Runners 01 - Gateways In Time (Europe)"
+	name "Time Runners Series (Europe)"
 	rom ( name "TimeRunnersSeries_v1.0.lha" size 15646728 crc E92F5ECE sha1 1d1c10fbbc13d37f2f6abdcc689ca22be9c68ffc )
 )
 
@@ -15117,22 +17256,37 @@ game (
 
 game (
 	name "Time Soldier (Europe)"
-	rom ( name "TimeSoldier_v1.3.lha" size 979670 crc 6CF1CAC8 sha1 cfae62c4256c0aca8f489b02b8029799be8af496 )
+	rom ( name "TimeSoldier_v1.3.1.lha" size 979659 crc 9AFF2EAF sha1 b18129a3796cac52d1e7c09090882c84a4ed1b5d )
 )
 
 game (
 	name "Tintin on the Moon (Europe)"
-	rom ( name "TintinOnTheMoon_v1.3a_Files_1778.lha" size 490344 crc 81943CF8 sha1 b42cca962c88d1c484c2dcede7538a56e60c953f )
+	rom ( name "TintinOnTheMoon_v1.4_Files_1778.lha" size 490462 crc 275A1DCB sha1 ce50688afc48504d2ea1500779b29ad668a12442 )
 )
 
 game (
-	name "Tintin on the Moon (Image) (Europe)"
-	rom ( name "TintinOnTheMoon_v1.3a_Image_1778.lha" size 492543 crc 0BA82A6B sha1 962b3681c51066cc3a9e881bfb9bda38dbc7fba8 )
+	name "Tintin on the Moon (Europe) (Image)"
+	rom ( name "TintinOnTheMoon_v1.4_Image_1778.lha" size 492661 crc 904342E6 sha1 ab68dc30cc51588ad71190f4d1bdac87af2f80cd )
 )
 
 game (
 	name "Tin Toy Adventure (Europe) (AGA)"
-	rom ( name "TinToyAdventure_v1.0_AGA.lha" size 937767 crc 41E205A9 sha1 cf2bd707ba60afacd193da89282e342dacade594 )
+	rom ( name "TinToyAdventure_v1.3-B_AGA.lha" size 939676 crc 8104964A sha1 1705e7b18932eb3e3c3fdd215a50233935355cdb )
+)
+
+game (
+	name "Tiny Bobble (Europe)"
+	rom ( name "TinyBobble_v1.3.lha" size 191469 crc E913F799 sha1 7f7dcff35c3dc544d655cedae62d4a29e08e9f6f )
+)
+
+game (
+	name "Tiny Galaga (Europe) (PD/Freeware)"
+	rom ( name "TinyGalaga_v1.2.lha" size 42893 crc 79270AC7 sha1 dd0909327ab9b0f4ccebdb5417c2e987d7c73628 )
+)
+
+game (
+	name "Tiny Invaders (Europe)"
+	rom ( name "TinyInvaders_v1.1.lha" size 22128 crc EEFA6A05 sha1 fa47fe3b87402f1970615f5323948302f2c022c6 )
 )
 
 game (
@@ -15156,23 +17310,28 @@ game (
 )
 
 game (
+	name "Tinyus (Europe) (PD/Freeware)"
+	rom ( name "Tinyus_v1.0.lha" size 204362 crc 6A2DB058 sha1 19d1a41b13a1788ab2820157373c0371eef4bc68 )
+)
+
+game (
 	name "Tip Off (Europe)"
-	rom ( name "TipOff_v1.0_1551.lha" size 880683 crc 99339E30 sha1 3430eae521f1b37611ffac78598686c92ab84505 )
+	rom ( name "TipOff_v2.0_1551.lha" size 891059 crc D63BB11C sha1 fbb25ce2eeca6110e0c89cf2979b28a09f45a3b9 )
 )
 
 game (
 	name "Tip Off (Europe) (Fr,De,Es,It)"
-	rom ( name "TipOff_v1.0_DeEsFrIt_1269.lha" size 880852 crc EE8D62AD sha1 6f5521ee867fc5f24e7da2be2354e288b5b2be29 )
+	rom ( name "TipOff_v2.0_DeEsFrIt_1269.lha" size 891241 crc 4FC492E7 sha1 101bee44e4f07743d46a327de385bdfd02308851 )
 )
 
 game (
 	name "Tip Off (USA)"
-	rom ( name "TipOff_v1.0_NTSC.lha" size 886452 crc 870822D6 sha1 815c4395b2aa79b815bda8246c98de8f5f9761f6 )
+	rom ( name "TipOff_v2.0_NTSC.lha" size 887984 crc AE5C48DD sha1 24a49106df12421665996cce5017bccb1f91626f )
 )
 
 game (
 	name "Titan (Europe)"
-	rom ( name "Titan_v1.4_1913.lha" size 541149 crc F1B5A3CE sha1 4ecef3d6e501befa9d1c829e68e341203bba98e2 )
+	rom ( name "Titan_v2.0_1913.lha" size 542893 crc BC61D080 sha1 5ba502de35f946e32f6e509e39fbd45c8515422e )
 )
 
 game (
@@ -15182,12 +17341,32 @@ game (
 
 game (
 	name "Titus the Fox (Europe)"
-	rom ( name "TitusTheFox_v2.0_0226.lha" size 687942 crc A1878694 sha1 b23a29e44a51571bd429afb416de995035b3b25f )
+	rom ( name "TitusTheFox_v2.3_0226.lha" size 730772 crc 8899F593 sha1 9e755f1690c3fb78c3319757bf6d369af5510901 )
 )
 
 game (
 	name "Toki (Europe)"
-	rom ( name "Toki_v2.3_0040.lha" size 965677 crc B43BAFBB sha1 f6fee1ad815628317ff912eceee6028b1b3d0dc5 )
+	rom ( name "Toki_v2.3a_0040.lha" size 965716 crc D2767472 sha1 b7c91431e15929e089d4fdf8b265233017dca790 )
+)
+
+game (
+	name "Tolteka (Europe)"
+	rom ( name "Tolteka_v1.1.lha" size 213966 crc 4367FE4F sha1 fb845c49df51eb2c98a96f9490f2e9814d70c07c )
+)
+
+game (
+	name "Tom & Jerry 2 (Europe)"
+	rom ( name "Tom&Jerry2_v1.2_2229.lha" size 423356 crc 5DD473D8 sha1 14fbf9654d7dfda15f622269507df625ff2db615 )
+)
+
+game (
+	name "Tom & Jerry (Europe)"
+	rom ( name "Tom&Jerry_v1.2_1306.lha" size 422826 crc A8862BBE sha1 6b99ba857d57cbb7add6cab6b351a9fd97fb23b4 )
+)
+
+game (
+	name "Tom & Jerry - Hunting High and Low (EUrope)"
+	rom ( name "Tom&JerryHuntingHighAndLow_v1.2_1305.lha" size 428124 crc FF62244D sha1 1517d5c8f1419dbbe447f4a5e1c8d1a35a23eeaa )
 )
 
 game (
@@ -15251,13 +17430,18 @@ game (
 )
 
 game (
+	name "Top Wrestling (Europe)"
+	rom ( name "TopWrestling_v1.1.lha" size 1643535 crc EA667CDE sha1 8d1c6edc0aa1de5f604cef04c8135448795e4f12 )
+)
+
+game (
 	name "Tornado (Europe)"
-	rom ( name "Tornado_v1.1_0807.lha" size 2729340 crc 6F9EBA7A sha1 b462b016dbf0020e9abf602039ce34c12e1808cb )
+	rom ( name "Tornado_v2.0_0807.lha" size 2733093 crc D3C0E9C9 sha1 61511384a495e66526540706cf6ba22379b078be )
 )
 
 game (
 	name "Tornado (Europe) (AGA)"
-	rom ( name "Tornado_v1.1_AGA.lha" size 3772697 crc 30BFE1C3 sha1 eb33c838bb9950a82a9b6c7fd1863ffb9d0bdbef )
+	rom ( name "Tornado_v2.0_AGA.lha" size 3781457 crc 964C70CE sha1 9c0f98970c1ca65af5cde58020dca2d830e83801 )
 )
 
 game (
@@ -15267,7 +17451,7 @@ game (
 
 game (
 	name "Torvak the Warrior (Europe)"
-	rom ( name "TorvakTheWarrior_v1.3_1796.lha" size 1152186 crc C1B7F6CC sha1 2fa0c11f1a68993e8649a3d830dfa609e4aa3d69 )
+	rom ( name "TorvakTheWarrior_v1.4_1796.lha" size 1157630 crc DF1FF09D sha1 13170efdd501baa7b4f6da49a98eaab49273656a )
 )
 
 game (
@@ -15277,12 +17461,12 @@ game (
 
 game (
 	name "Total Eclipse (Europe)"
-	rom ( name "TotalEclipse_v1.0_2255.lha" size 338028 crc 57BD92D3 sha1 b4fbe61967e538dde671da105851d08c6b2e1d58 )
+	rom ( name "TotalEclipse_v1.1_2255.lha" size 339549 crc CE8D3683 sha1 6af8d71be8e82fd6433a4cae32db507595ce858a )
 )
 
 game (
 	name "Total Eclipse (USA)"
-	rom ( name "TotalEclipse_v1.0_NTSC_1973.lha" size 337253 crc AEB69C06 sha1 bea0f78433e239226824cc6922070f4b8463ebac )
+	rom ( name "TotalEclipse_v1.1_NTSC_1973.lha" size 339802 crc 5c57eee8 sha1 3d676cc0b18c1ab6a6d3c8d5f47fb98565a69478 )
 )
 
 game (
@@ -15291,13 +17475,13 @@ game (
 )
 
 game (
-	name "Total Recall (Europe)"
-	rom ( name "TotalRecall_v1.1_Files_1770.lha" size 816014 crc 8681C5E9 sha1 d95eadd4dc6d9f777c83a32771b2cb8e0500b131 )
+	name "Total Recall (Europe) (Budget)"
+	rom ( name "TotalRecall_v1.2_Files_1770.lha" size 816705 crc C3F98D0B sha1 8bdcc8dfac25f79bd5324ebfc3732de7274e483e )
 )
 
 game (
-	name "Total Recall (Image) (Europe)"
-	rom ( name "TotalRecall_v1.1_Image_1769.lha" size 1281354 crc 71C099CF sha1 3634c1da99e5ba004a6d3c7e7b4d56251bcd654b )
+	name "Total Recall (Europe)"
+	rom ( name "TotalRecall_v1.0_Image_1769.lha" size 1281615 crc 74B758B4 sha1 1d43efc9af5099ba95c385bae8d68e76947dac3b )
 )
 
 game (
@@ -15312,12 +17496,12 @@ game (
 
 game (
 	name "Tower of Souls (Europe) (AGA)"
-	rom ( name "TowerOfSouls_v1.0_AGA_2212.lha" size 2494047 crc 40174716 sha1 37f9783db91111ab111259ec2f685f5f4af80f6e )
+	rom ( name "TowerOfSouls_v1.0_AGA_2212.lha" size 2493873 crc 305E1F56 sha1 95f913351b1cab217122c7c1f4da0e1219c84469 )
 )
 
 game (
 	name "Tower Toppler (USA)"
-	rom ( name "TowerToppler_v1.0_NTSC_1392.lha" size 213027 crc 687CF6B6 sha1 3e644f818d70aeded110966ef0bd46b014b6cead )
+	rom ( name "TowerToppler_v1.5_NTSC_1392.lha" size 216430 crc 932ECC7F sha1 2d50d9bef0e378daec65ff1c05319d6a7826b2af )
 )
 
 game (
@@ -15336,7 +17520,7 @@ game (
 )
 
 game (
-	name "Toyottes, The (Image) (Europe)"
+	name "Toyottes, The (Europe) (Image)"
 	rom ( name "Toyottes_v1.1a_Image_2623.lha" size 296272 crc 261F7CBB sha1 c03181b3785236789b939e7ed59a584de6063646 )
 )
 
@@ -15351,13 +17535,13 @@ game (
 )
 
 game (
-	name "Traders (Europe)"
-	rom ( name "Traders_v1.20.lha" size 485647 crc 026D4A1C sha1 b590596e6800bfe4b6c720626cd76d1d9fcb4f93 )
+	name "Traders (Germany)"
+	rom ( name "Traders_v1.21_De_1584.lha" size 434063 crc 96B1EE8F sha1 af7b666bbcb8a09e1925508c4247454dbef4b8a2 )
 )
 
 game (
-	name "Traders (Germany)"
-	rom ( name "Traders_v1.20_De_1584.lha" size 492014 crc 7CEAA334 sha1 3991d4e5423639697e206de88f47909c10963ffd )
+	name "Traders (USA)"
+	rom ( name "Traders_v1.21_NTSC.lha" size 427302 crc 2BE08AC9 sha1 86b349290b0b4c43136b0fcd4d6cbb2bcb7aa968 )
 )
 
 game (
@@ -15376,13 +17560,28 @@ game (
 )
 
 game (
+	name "Transarctica (Spain)"
+	rom ( name "Transarctica_v1.4_Es.lha" size 1274033 crc 0ED416C2 sha1 cbf0ca386b4823406de3c4b3ac81bd810fe1198f )
+)
+
+game (
 	name "Transplant (Europe)"
 	rom ( name "Transplant_v1.01.lha" size 198960 crc 68B61700 sha1 09aa5369e568605221044453c7d185519d6b80d5 )
 )
 
 game (
+	name "Transputor (Europe)"
+	rom ( name "Transputor_v1.0_0395.lha" size 172204 crc CC23D7CB sha1 39d85a5fbeca5258d6403f1295bb2c9ff5e28533 )
+)
+
+game (
 	name "Transworld (Germany)"
 	rom ( name "Transworld_v1.0_De_2837.lha" size 540274 crc 5D9DCC07 sha1 6ce5ede812181b344fa2b69838f38246614dc436 )
+)
+
+game (
+	name "Trap Runner (Europe)"
+	rom ( name "TrapRunner_v1.0.lha" size 815146 crc 4471BC8A sha1 6fdefc981374592afcdcbd57b60a21e45595d92c )
 )
 
 game (
@@ -15397,12 +17596,12 @@ game (
 
 game (
 	name "Treasure Island Dizzy (Europe)"
-	rom ( name "TreasureIslandDizzy_v1.2_0594.lha" size 162267 crc C305BFBE sha1 7a7286fcbdc6f5f7dc3f3b9c22a6b793dbea4bc5 )
+	rom ( name "TreasureIslandDizzy_v1.3_0594.lha" size 162830 crc D8490938 sha1 8af58455101231e1408e75543742c6aa249688f6 )
 )
 
 game (
 	name "Treasure Island Dizzy (Europe) (CD32)"
-	rom ( name "TreasureIslandDizzy_v1.2_CD32.lha" size 162665 crc 8E5368E1 sha1 e0f06a7fb19141fae389287f884a9948e9f0e526 )
+	rom ( name "TreasureIslandDizzy_v1.3_CD32.lha" size 163228 crc D32F4F19 sha1 1f990279450c52293ed5e0f39e8b3e23d62b083e )
 )
 
 game (
@@ -15412,12 +17611,12 @@ game (
 
 game (
 	name "Treasure Trap (Europe)"
-	rom ( name "TreasureTrap_v1.01_1731.lha" size 723449 crc 453A0756 sha1 638751a67bac3dd8ac7d510f2db27b0557d4b9d7 )
+	rom ( name "TreasureTrap_v1.02_1731.lha" size 723751 crc C7DC24BB sha1 b2112cc4cae0c0753d750074eb31589aec130e2e )
 )
 
 game (
 	name "Trex Warrior - 22nd Century Gladiator (Europe)"
-	rom ( name "TrexWarrior_v1.0.lha" size 613960 crc D483F53E sha1 db32e2da664746ba6fb3f264072fcaddc7282c68 )
+	rom ( name "TrexWarrior_v1.1_3056.lha" size 617744 crc 99D9E989 sha1 34332d100e24c69fcedae77cd331b96bdce59868 )
 )
 
 game (
@@ -15437,37 +17636,42 @@ game (
 
 game (
 	name "Trivial Pursuit - The Computer Game - Genus Edition (Europe)"
-	rom ( name "TrivialPursuit_v1.2.lha" size 235940 crc 608F8D36 sha1 52c089fdfc70bc020e45b86df7ef757f1a287e91 )
+	rom ( name "TrivialPursuit_v2.0.lha" size 236091 crc D21B513E sha1 0bd6a75ff5c516d5d9d8a2e2ddeb60ae3b6ad097 )
 )
 
 game (
 	name "Trivial Pursuit - The Computer Game - Genus Edition (Germany)"
-	rom ( name "TrivialPursuit_v1.2_De_0595.lha" size 213343 crc 3FC6C270 sha1 c20f6388d6ee72f90f530ec57c0c81515138ed89 )
+	rom ( name "TrivialPursuit_v2.0_De_0595.lha" size 213498 crc 31FC5403 sha1 aa659ebfbed95d379d130d4bbaa22aab3fadbae4 )
 )
 
 game (
-	name "Trivial Pursuit - The Computer Game - Genus Edition (France) (Europe)"
-	rom ( name "TrivialPursuit_v1.2_Fr_2147.lha" size 207698 crc BCA3A084 sha1 70f27b1f964a070e4f13560a170c96c5d173da8b )
+	name "Trivial Pursuit - The Computer Game - Genus Edition (France)"
+	rom ( name "TrivialPursuit_v2.0_Fr_2147.lha" size 207845 crc 5D6E73F7 sha1 2d7e02232218ab80c794b938048c74160a3018ce )
 )
 
 game (
 	name "Trivial Pursuit - A New Beginning (Europe)"
-	rom ( name "TrivialPursuitANewBeginning_v1.0_1785.lha" size 398900 crc 35758871 sha1 8d33554c1a92ff96a6f080c794be5ea380c0efad )
+	rom ( name "TrivialPursuitANewBeginning_v2.0_1785.lha" size 337648 crc 3E32A81A sha1 9b635c9ce591c3702e762babc4f8c147fcf7e481 )
 )
 
 game (
-	name "Trivial Pursuit - A New Beginning (Germany)"
-	rom ( name "TrivialPursuitANewBeginning_v1.0_De_0091.lha" size 364571 crc 8EB662D0 sha1 d3a15e99edaa25e32cf876ad5cf3a8eed5e22ac2 )
+	name " Pursuit - A New Beginning (Germany)"
+	rom ( name "TrivialPursuitANewBeginning_v2.0_De_0091.lha" size 297624 crc E18C6A8D sha1 55279a007f8839d6bf6c37e0f0b3ca80b950fa7a )
 )
 
 game (
 	name "Trivial Pursuit - A New Beginning (France)"
-	rom ( name "TrivialPursuitANewBeginning_v1.0_Fr.lha" size 390223 crc 60E82280 sha1 0399c485c2d3707af549da4c737e5369cd9ad882 )
+	rom ( name "TrivialPursuitANewBeginning_v2.0_Fr.lha" size 328718 crc F0D059D7 sha1 588b2c7bc2b6b41ce67ca570c77fed99fab83699 )
 )
 
 game (
 	name "Troddlers (Europe)"
-	rom ( name "Troddlers_v1.1_0696.lha" size 790180 crc A94A22D7 sha1 30a6ca0c73db03bd4bc74b64ae6ccc696988d024 )
+	rom ( name "Troddlers_v1.2_Files_0696.lha" size 772235 crc 51C49853 sha1 d57bd4d111fee072b0c6fd8a5406c4220221cb7b )
+)
+
+game (
+	name "Troddlers (Europe) (Image)"
+	rom ( name "Troddlers_v1.2_Image_0696.lha" size 790543 crc 97DF50CE sha1 7cade95caf79988043fc7f38812b217e8d836f01 )
 )
 
 game (
@@ -15476,18 +17680,23 @@ game (
 )
 
 game (
+	name "Trois Petits Cochons S'Amusent, Les (France)"
+	rom ( name "TroisPetitsCochonsSAmusement_v1.0_Fr.lha" size 165250 crc 3AB7AB68 sha1 1ec08db092e9c5dfbd8dd6bd576729875c1eb17b )
+)
+
+game (
 	name "Trolls (Europe)"
-	rom ( name "Trolls_v1.2.lha" size 1447516 crc 8989DDB0 sha1 40092bd9316da0ec2ef3baabd0ab16a17a48a17f )
+	rom ( name "Trolls_v2.1.lha" size 1258312 crc 73579E96 sha1 7286df47a261e524cedf489fe7912ebf77ddb5d1 )
 )
 
 game (
 	name "Trolls (Europe) (AGA)"
-	rom ( name "Trolls_v1.2_AGA_0996.lha" size 1707171 crc 6656E8E9 sha1 24bc4a6a329a55036a570f095380010129157de9 )
+	rom ( name "Trolls_v2.1_AGA_0155.lha" size 1585095 crc 7D9CA8D7 sha1 2cf1a691284637653608baed274508335b1d97f9 )
 )
 
 game (
 	name "Trolls (Europe) (CD32)"
-	rom ( name "Trolls_v1.3_CD32.lha" size 1508308 crc 26447CBB sha1 0c6d6c172ee6570c2228477e10a0955f3dcd6d45 )
+	rom ( name "Trolls_v2.1_CD32.lha" size 1515989 crc 15A7B6BA sha1 bdcd6ba806b750646789438319b38e87cf76bff8 )
 )
 
 game (
@@ -15497,17 +17706,17 @@ game (
 
 game (
 	name "Tubular Worlds (Europe)"
-	rom ( name "TubularWorlds_v1.0_1MB.lha" size 1291677 crc F570337C sha1 93dc97718e6f0722b3692b5e1d5d665cebe268ea )
+	rom ( name "TubularWorlds_v1.2.lha" size 1318761 crc F7D105ED sha1 6baa2c032d91e25b423d27544d7a5b6f98efc949 )
 )
 
 game (
-	name "Tubular Worlds (512 KB) (Europe)"
-	rom ( name "TubularWorlds_v1.0_512KB.lha" size 1291912 crc 103AC77B sha1 0cd42c4b9011eae5a06f457e382512413ee13ab2 )
+	name "Tubular Worlds (Europe) (512 kB)"
+	rom ( name "TubularWorlds_v1.2_512k.lha" size 1319200 crc 6EBC811D sha1 b7e66b3780d01e6d3470da46ec8f5abbef23405b )
 )
 
 game (
 	name "Tubular Worlds (Europe) (AGA)"
-	rom ( name "TubularWorlds_v1.0_AGA.lha" size 1675401 crc 95F63614 sha1 d0bd1a98f5c0deff08c7cb3e8220b3afdb715088 )
+	rom ( name "TubularWorlds_v1.2_AGA.lha" size 1700579 crc C2427A43 sha1 851bff6f9a2b032dbacfc86f7b57f5bccb1f1bbd )
 )
 
 game (
@@ -15517,17 +17726,27 @@ game (
 
 game (
 	name "Turbo Cup (Europe)"
-	rom ( name "TurboCup_v1.2.lha" size 412029 crc 5CBC2010 sha1 ebc9460b7a27f32dab1a36f5ac0a25bb0f6f5d2e )
+	rom ( name "TurboCup_v1.3.lha" size 408885 crc 86392148 sha1 85b6037ae14831a50a8d972fdfb5efbe980dd670 )
 )
 
 game (
-	name "Turbo Cup Challenge (France)"
-	rom ( name "TurboCup_v1.2_Fr_2409.lha" size 412268 crc 11AD12D1 sha1 ac5cfd2e63858913f92c733d4c544456668a0268 )
+	name "Turbo Cup (France)"
+	rom ( name "TurboCup_v1.3_Fr_2409.lha" size 409148 crc 0A64FC99 sha1 dc01a9659475d61478c793a3ef59ca90c44da854 )
 )
 
 game (
 	name "Turbo OutRun (Europe)"
-	rom ( name "TurboOutRun_v1.2_1064.lha" size 520804 crc 6AD6AE18 sha1 fd2a369adae06e773750cf7ed66d6da11e4a6916 )
+	rom ( name "TurboOutRun_v2.0_1064.lha" size 525005 crc EA440BD4 sha1 1568bb29f96a712d7604214dc9c5f994de6d1b96 )
+)
+
+game (
+	name "Turbo OutRun (USA)"
+	rom ( name "TurboOutRun_v2.0_NTSC.lha" size 555854 crc 55D8ECBE sha1 daf061ac6f3aee4289a5d41541bcdc3b3de9f001 )
+)
+
+game (
+	name "TurboRaketti II (Europe)"
+	rom ( name "TurboRaketti2_v1.0.lha" size 301900 crc 0D0BC9D2 sha1 b6928367d6e95864aaea9d8afabc82c89f6fc16c )
 )
 
 game (
@@ -15541,7 +17760,7 @@ game (
 )
 
 game (
-	name "Turbo Trax (512 KB) (Europe)"
+	name "Turbo Trax (Europe) (512 kB)"
 	rom ( name "TurboTrax_v1.1_Arcane_512KB_0156.lha" size 2215874 crc F65A4D9E sha1 b34c854934d93cca4f9a04d1459745db966410e7 )
 )
 
@@ -15551,13 +17770,13 @@ game (
 )
 
 game (
-	name "Turrican II - The Final Fight (Europe) (CDTV)"
-	rom ( name "Turrican2_v1.4_CDTV.lha" size 1107181 crc 09D8908F sha1 07e241763b58e5f87636e51006fe1885b76c308d )
+	name "Turrican II - The Final Fight (Europe)"
+	rom ( name "Turrican2_v2.3_0029.lha" size 1056591 crc 7FCB6588 sha1 70b5008ab299f80eff372e0727e483c755b648aa )
 )
 
 game (
-	name "Turrican II - The Final Fight (Europe)"
-	rom ( name "Turrican2_v2.3_0029.lha" size 1056591 crc 7FCB6588 sha1 70b5008ab299f80eff372e0727e483c755b648aa )
+	name "Turrican II - The Final Fight (Europe) (CDTV)"
+	rom ( name "Turrican2_v2.3_CDTV.lha" size 1108884 crc 6ABCE44D sha1 816a655fedd98ffe0ee6b293b4b647c96fa711e1 )
 )
 
 game (
@@ -15567,6 +17786,11 @@ game (
 
 game (
 	name "Turrican 3 (Europe)"
+	rom ( name "Turrican3_v1.6_Files_2633.lha" size 923855 crc 531358E0 sha1 7835bd6a52f0f95204aee36453fac0291918b983 )
+)
+
+game (
+	name "Turrican 3 (Europe) (Image)"
 	rom ( name "Turrican3_v1.6_Image_2633.lha" size 956938 crc C4AE4425 sha1 86aa30e2440630b7dc278048278826d02624a5f5 )
 )
 
@@ -15582,12 +17806,12 @@ game (
 
 game (
 	name "Turrican (Europe) (CDTV)"
-	rom ( name "Turrican_v2.0_CDTV.lha" size 778445 crc 13531AAB sha1 31c9c06879cecc7658b7dc78ebd34a7703a816c5 )
+	rom ( name "Turrican_v2.1_CDTV.lha" size 779967 crc DCBEAFFE sha1 87584635bbeab0e5e5a3bedc0d686693399afc99 )
 )
 
 game (
 	name "Turrican (USA)"
-	rom ( name "Turrican_v2.0_NTSC_1838.lha" size 904417 crc 3C31B268 sha1 4a7fbfeafd8b884f0aab30386e437fc7631061a4 )
+	rom ( name "Turrican_v2.1_NTSC_1838.lha" size 905939 crc DED5931E sha1 b201a394dc43bf67c1b6f3b9774935a7ea944b78 )
 )
 
 game (
@@ -15601,28 +17825,43 @@ game (
 )
 
 game (
-	name "TV Sports Baseball (Europe)"
+	name "TV Sports - Baseball (Europe)"
 	rom ( name "TVSportsBaseball_v1.0_0754.lha" size 562053 crc 464F6A44 sha1 617b5ce2293d99e6a6199790b5d22db1b36f5539 )
 )
 
 game (
-	name "TV Sports Basketball (Europe)"
-	rom ( name "TVSportsBasketball_v1.0_2122.lha" size 756902 crc 01586146 sha1 f3b8c2012c8ba1a12f62a87cf67478eeba4893f4 )
+	name "TV Sports - Basketball (Europe) (Alt)"
+	rom ( name "TVSportsBasketball2223_v1.3.lha" size 785444 crc 3CA9B102 sha1 bd55db7b88dd1c7736dd64dd5ba774b85df8bd01 )
 )
 
 game (
-	name "TV Sports Boxing (Europe)"
+	name "TV Sports - Basketball (Italy) (Alt)"
+	rom ( name "TVSportsBasketball2223_v1.3_It.lha" size 785684 crc E969BABB sha1 eddd82368a77d951961bec116452309a07e06b73 )
+)
+
+game (
+	name "TV Sports - Basketball (Europe)"
+	rom ( name "TVSportsBasketball_v1.3_2122.lha" size 785045 crc B0E4FDBA sha1 797d7b563457a387aa103196a302d044abd11c4b )
+)
+
+game (
+	name "TV Sports - Basketball (Italy)"
+	rom ( name "TVSportsBasketball_v1.3_It.lha" size 785263 crc 7A7C1018 sha1 59d3e634323378a2d8dce384f6dd1958eabe6980 )
+)
+
+game (
+	name "TV Sports - Boxing (Europe)"
 	rom ( name "TVSportsBoxing_v1.0_0755.lha" size 774762 crc 57921DFB sha1 1e787b21ce76e6f01ad99c494abbf67e99ee9fe7 )
 )
 
 game (
-	name "TV Sports Football (Europe)"
+	name "TV Sports - Football (Europe)"
 	rom ( name "TVSportsFootball_v1.03_0407.lha" size 1033269 crc E5360D86 sha1 285c4ec424c661e4d9b093087a895a8349c44f07 )
 )
 
 game (
 	name "Twintris (Europe)"
-	rom ( name "Twintris_v1.1.lha" size 389953 crc BCA2A4F2 sha1 31bcc3079ae96e6df377769c12f1bb6ed93b4582 )
+	rom ( name "Twintris_v1.2.lha" size 390507 crc 557CCEA4 sha1 aa2c7427d8db1b15908a0f7e16c1a273c1bba15f )
 )
 
 game (
@@ -15632,12 +17871,12 @@ game (
 
 game (
 	name "Twinworld (Europe)"
-	rom ( name "TwinWorld_v1.1_1294.lha" size 831992 crc 7C7A2782 sha1 e4a0929fb4cc908b5e43d5530ca298ee8b05cd96 )
+	rom ( name "TwinWorld_v1.2_1294.lha" size 832913 crc 2B5E6FD1 sha1 2b964f7fd4c7751c8589f1d62ab2a3a382673d27 )
 )
 
 game (
 	name "Twylyte (Europe)"
-	rom ( name "Twylyte_v1.0a_0746.lha" size 261698 crc B4719999 sha1 fdb6ba587ee590091fd4a2e25830e5a3d937dec5 )
+	rom ( name "Twylyte_v1.2_0746.lha" size 243087 crc 1D3FB176 sha1 33d9255c6a28b394932a99d1c394c50ade0b6263 )
 )
 
 game (
@@ -15646,8 +17885,13 @@ game (
 )
 
 game (
+	name "Typhoon Thompson in Search for the Sea Child (USA) (512 kB)"
+	rom ( name "TyphoonThompson_v1.1_512k_NTSC_1389.lha" size 260957 crc 0FB72419 sha1 6acbd0a74ca9722569a11ec43683fa8d2bac0f5f )
+)
+
+game (
 	name "Typhoon Thompson in Search for the Sea Child (USA)"
-	rom ( name "TyphoonThompson_v1.0_NTSC_1389.lha" size 260551 crc 5BAB1BDA sha1 7b9bbe4178d7a55c0d883cf5b2472fb702d31b06 )
+	rom ( name "TyphoonThompson_v1.1_NTSC_1389.lha" size 260929 crc B1A31B45 sha1 3fe132cbe65c11c334877d8945a17f72fc37eaa5 )
 )
 
 game (
@@ -15656,7 +17900,7 @@ game (
 )
 
 game (
-	name "T-zer0 (No Movie) (Europe) (AGA) (Demo)"
+	name "T-zer0 (Europe) (AGA) (Demo) (No Movie)"
 	rom ( name "TZer0Demo_v1.0_NoMovie_AGA.lha" size 9555997 crc DA9831C1 sha1 824d7e9724141085ba882259389928bee3f07797 )
 )
 
@@ -15692,7 +17936,7 @@ game (
 
 game (
 	name "Ultima V - Warriors of Destiny (Europe)"
-	rom ( name "Ultima5_v1.3_0785.lha" size 501898 crc 91BC4E13 sha1 907df73ee390c2be1616057527f96cef5f4a2712 )
+	rom ( name "Ultima5_v1.4_0785.lha" size 501770 crc 6E04188E sha1 82ff2563a94773cdf1717bc43ae736f98b85a439 )
 )
 
 game (
@@ -15707,7 +17951,7 @@ game (
 
 game (
 	name "Ultimate! Golf (Europe)"
-	rom ( name "UltimateGolf_v1.2_2129.lha" size 345691 crc 0F858447 sha1 08a3915be462c827bc3a94d82a7cac732bee807f )
+	rom ( name "UltimateGolf_v1.3a_2129.lha" size 360199 crc FE663B21 sha1 07765d1a5d8b284e7d5185f87597c64c850da937 )
 )
 
 game (
@@ -15721,7 +17965,7 @@ game (
 )
 
 game (
-	name "Ultimate XTreme Racing (CD) (Europe) (AGA)"
+	name "Ultimate XTreme Racing (Europe) (AGA) (CD)"
 	rom ( name "UltimateXTremeRacing_v1.1_AGA_CD.lha" size 8111909 crc 9C345B69 sha1 fb3eb0a2fa3196e5bde772263f11a3832fa56c13 )
 )
 
@@ -15736,8 +17980,13 @@ game (
 )
 
 game (
+	name "Unendliche Geschichte II, Die (Germany)"
+	rom ( name "UnendlicheGeschichte2_v1.4_De.lha" size 854472 crc F15E3AE9 sha1 3729277b37c9b3c2fee70dbf98aab268b88e269b )
+)
+
+game (
 	name "Uninvited (Europe)"
-	rom ( name "Uninvited_v1.0.lha" size 520405 crc 7A252224 sha1 9d80e40e3ecdcaa63070dd68bed1c8b99e54f8a5 )
+	rom ( name "Uninvited_v1.1.lha" size 520768 crc B3AAF64D sha1 d003dcfac1e4acdc747b33f7d9c2ff58dfc9991f )
 )
 
 game (
@@ -15752,7 +18001,7 @@ game (
 
 game (
 	name "Universal Warrior (Europe)"
-	rom ( name "UniversalWarrior_v1.01_0597.lha" size 430816 crc 2DF3AAAA sha1 0c7a06e8f1690d0dc1d6f4b93899e1a708d4d92f )
+	rom ( name "UniversalWarrior_v1.02_0597.lha" size 432342 crc 25B8BAA7 sha1 e195f068287d3812d22ba30c447d1b4fdda71651 )
 )
 
 game (
@@ -15762,12 +18011,17 @@ game (
 
 game (
 	name "Universe (Europe)"
-	rom ( name "Universe_v1.3_0894.lha" size 4847818 crc DB3CD2D1 sha1 4ad3cbf5f3bad7ebc67cd776fe8a62a64d727843 )
+	rom ( name "Universe_v1.5_0894.lha" size 4860613 crc 3CCAF6B9 sha1 0a19407aaaa82fd07703b05deb196c61fc7643bd )
 )
 
 game (
-	name "Universe 3 (Europe) (CD32)"
-	rom ( name "Universe_v1.3_CD32.lha" size 4356811 crc 1142E025 sha1 7fc2233525da0e354be7363f5aadc69f9b6fa2a6 )
+	name "Universe (Europe) (Alt)"
+	rom ( name "Universe_v1.5_AltVersion.lha" size 4646534 crc F3E964CA sha1 96b3f66d6d9fc84cd6101c28bb7b97c102af4d5a )
+)
+
+game (
+	name "Universe (Europe) (CD32)"
+	rom ( name "Universe_v1.5_CD32.lha" size 4369623 crc 27742AEE sha1 950f0614b75d7cebe8417de952c29a43e178d623 )
 )
 
 game (
@@ -15781,7 +18035,7 @@ game (
 )
 
 game (
-	name "Unsensible Soccer (Europe)"
+	name "Unsensible Soccer (Europe) (Coverdisk - Amiga Action #42)"
 	rom ( name "UnsensibleSoccer_v1.0.lha" size 166713 crc 1942E00F sha1 cb88623971f4635da47d3ef279d90994db604f96 )
 )
 
@@ -15801,18 +18055,18 @@ game (
 )
 
 game (
-	name "Up Scope (Arcadia) (Europe)"
+	name "Up Scope (Europe) (Arcadia)"
 	rom ( name "UpScope_v1.01_Arcadia.lha" size 211475 crc BA660626 sha1 069d17293301a092f83d5ea430a1f6c85c7bd6ad )
 )
 
 game (
-	name "Uridium 2 (1 MB) (Europe)"
-	rom ( name "Uridium2_v0801.1_1MB_1526.lha" size 1237126 crc F364EED4 sha1 5acce4c7e6428cf5778961288f9c10ecde344874 )
+	name "Uridium 2 (Europe) (1 MB)"
+	rom ( name "Uridium2_v3.1.0_1MB_0276.lha" size 1237738 crc 09EA37D8 sha1 d95eaf76ddab14c8ab3f3a6fdffe34dfed4843b5 )
 )
 
 game (
 	name "Uridium 2 (Europe)"
-	rom ( name "Uridium2_v0801.1_2MB_1526.lha" size 1237123 crc 94947B37 sha1 19d7cfcc8299f636269820fa8293381bbe81fdc3 )
+	rom ( name "Uridium2_v3.1.0_2MB_0276.lha" size 1237740 crc 146105CD sha1 d23cae0a9dfb544f316481a8f45dec06991fb5b4 )
 )
 
 game (
@@ -15821,7 +18075,7 @@ game (
 )
 
 game (
-	name "Utopia - The New Worlds (Europe)"
+	name "Utopia & The New Worlds (Europe)"
 	rom ( name "Utopia&NewWorlds_v1.3_0757&2576.lha" size 1436728 crc DA0EB2D3 sha1 e29089b2d27568b22c95b0dc752ffb0bb24c9fb1 )
 )
 
@@ -15831,18 +18085,23 @@ game (
 )
 
 game (
+	name "Vac-Suit Jack (Europe) (Demo)"
+	rom ( name "VacSuitJackDemo_v1.0.lha" size 301884 crc 0FEF45C5 sha1 c01200fcc034c9e21025914304d1e556ba9dec54 )
+)
+
+game (
 	name "Vader (Europe)"
-	rom ( name "Vader_v1.0.lha" size 233546 crc A5285805 sha1 9064bef6e3953a562c787729f27aa83aa5488b54 )
+	rom ( name "Vader_v1.1_2956.lha" size 233875 crc BE84A83D sha1 ff9a6df96449a19dcf1bdf02a0cf92f6e73591bf )
 )
 
 game (
 	name "Valhalla - Before the War (Europe)"
-	rom ( name "ValhallaBeforeTheWar_v1.2_0756.lha" size 3504513 crc 25390C53 sha1 22c3d5f5d70807211b209db73e5d4ec84c0bb099 )
+	rom ( name "ValhallaBeforeTheWar_v1.4_0756.lha" size 3507169 crc 38A9D885 sha1 22574cd7d839b562b8516588f94c29d5b494cb83 )
 )
 
 game (
 	name "Valhalla and the Lord of Infinity (Europe)"
-	rom ( name "ValhallaLordOfInfinity_v1.1.lha" size 3182786 crc BF870DF4 sha1 4c45e4e464010eed9cb112ee33b36974ea4a7076 )
+	rom ( name "ValhallaLordOfInfinity_v1.2.lha" size 3185429 crc D5BCE12F sha1 53054db5c6709ede0a60e0c9b9a3becbc61af5c7 )
 )
 
 game (
@@ -15867,32 +18126,32 @@ game (
 
 game (
 	name "Vengeance of Excalibur (Europe)"
-	rom ( name "VengeanceOfExcalibur_v1.01_2499.lha" size 1693668 crc A3B9358A sha1 1039c9c3265e307a294ea8f1c61cc12149b45bf5 )
+	rom ( name "VengeanceOfExcalibur_v1.02_2499.lha" size 1693903 crc 6568FDAE sha1 b955108950028ce9c92f9c4cca83da0dde05a916 )
 )
 
 game (
 	name "Vengeance of Excalibur (Germany)"
-	rom ( name "VengeanceOfExcalibur_v1.01_De_2499.lha" size 1690115 crc 55D7E88A sha1 f5be73825b121a2317ffbbbe551c7600b77e028a )
+	rom ( name "VengeanceOfExcalibur_v1.02_De_2499.lha" size 1690347 crc E8DBDAA2 sha1 a5de7a4243f82d857ea962cd85e6bd8dfc331eb7 )
 )
 
 game (
 	name "Vengeance of Excalibur (France)"
-	rom ( name "VengeanceOfExcalibur_v1.01_Fr_2499.lha" size 1688949 crc 97E64656 sha1 dc556a1be9331235b9440827763714ea60f74d7c )
+	rom ( name "VengeanceOfExcalibur_v1.02_Fr_2499.lha" size 1689184 crc 4716DF96 sha1 5243b23d7d98ff2813508a582d7d380b870e0659 )
 )
 
 game (
-	name "Hawkwind (Europe)"
-	rom ( name "VenomWing_v1.1.lha" size 1080347 crc E8F23091 sha1 7528998fab40dc4da1fad7ff78a091f7ce71c1e1 )
+	name "Venom Wing (Europe)"
+	rom ( name "VenomWing_v2.0a.lha" size 1080786 crc DAB9EAC0 sha1 d28607283411817d5a0491f10570c1084f438098 )
 )
 
 game (
 	name "Venus - The Flytrap (Europe)"
-	rom ( name "VenusTheFlytrap_v1.2.lha" size 1013011 crc F4D47873 sha1 b835fa56ee7b72e6d14457c0288ea4284deaad22 )
+	rom ( name "VenusTheFlytrap_v1.3_1984.lha" size 1013335 crc 9C6A2A5A sha1 e1ccd70d36c147b5b06b7792eb8e4615e1cc467c )
 )
 
 game (
-	name "Venus - The Flytrap (No Intro) (Europe)"
-	rom ( name "VenusTheFlytrap_v1.2_NoIntro_1985.lha" size 729530 crc E8621E8D sha1 31e2b454d67df14211c66afdbb60c914bea7cb2c )
+	name "Venus - The Flytrap (Europe) (No Intro)"
+	rom ( name "VenusTheFlytrap_v1.3_NoIntro_1985.lha" size 729850 crc 8437AC74 sha1 7aaadd68e62a03716d2d7e8ac7c7926510eca3fe )
 )
 
 game (
@@ -15902,7 +18161,12 @@ game (
 
 game (
 	name "Verteidiger Der Krone II (Germany) (CD32)"
-	rom ( name "VerteidigerDerKrone2_v1.1_CD32_De.lha" size 8367083 crc 222841BC sha1 3b08fce856813dc6b6add27ce47792e716742528 )
+	rom ( name "VerteidigerDerKrone2_v1.2_CD32_De.lha" size 8367377 crc D770D803 sha1 a96f7f96473ae14f3f0a296e6389f543419608c7 )
+)
+
+game (
+	name "Veteran (Europe)"
+	rom ( name "Veteran_v1.0_2970.lha" size 177972 crc 3EDBEE63 sha1 74974aac78bcb44a558bf9cf3ce0f59593979127 )
 )
 
 game (
@@ -15917,12 +18181,17 @@ game (
 
 game (
 	name "VideoKid (Europe)"
-	rom ( name "VideoKid_v1.0_2555.lha" size 1319755 crc F67077FA sha1 ddb26ea5b7856898228e9c1df5b543260ea158fd )
+	rom ( name "VideoKid_v2.1_2555.lha" size 1326618 crc 58314A7D sha1 e40dc17bd618261b844cc306bb2f32f214354576 )
 )
 
 game (
 	name "Vigilante (Europe)"
 	rom ( name "Vigilante_v1.1_1188.lha" size 342566 crc 57092C03 sha1 5cf9818742c356391b61a8690756ee823322bef2 )
+)
+
+game (
+	name "Vindex (Europe)"
+	rom ( name "Vindex_v1.0_2806.lha" size 394676 crc 945FBC5F sha1 675eec6f367a9aed469c227c12c1e997ec9905d9 )
 )
 
 game (
@@ -15932,17 +18201,17 @@ game (
 
 game (
 	name "Violator (Europe)"
-	rom ( name "Violator_v2.0.lha" size 292334 crc DF11FE16 sha1 18be1a7c204928677d105fdb5df62a8e2d9345b2 )
+	rom ( name "Violator_v2.1_2658.lha" size 301411 crc 434F4DDD sha1 5a5cb1eb47516124b0a3c857342045b215122c36 )
 )
 
 game (
 	name "Virocop (Europe)"
-	rom ( name "Virocop_v1.0-B_1836.lha" size 1737429 crc 37E2A4A8 sha1 60dfe1059a1a640b13d78be0ede5e9d23eed2d0d )
+	rom ( name "Virocop_v1.0_1836.lha" size 1739633 crc BE01F9BF sha1 fcf0a254cb7f4c5d325b733b038ffe5654899202 )
 )
 
 game (
 	name "Virocop (Europe) (AGA)"
-	rom ( name "Virocop_v1.4_AGA_1920.lha" size 2035237 crc 3BB4D94D sha1 651f5454920cb1c7cefc345f42d698328d6a615e )
+	rom ( name "Virocop_v1.6_AGA_1920.lha" size 2037006 crc 7EB06AED sha1 98cb70f807c8dcbb66bfa692cc3530de14a5945b )
 )
 
 game (
@@ -15951,7 +18220,7 @@ game (
 )
 
 game (
-	name "Virtual Karting II (CD) (Europe) (AGA)"
+	name "Virtual Karting II (Europe) (AGA) (CD)"
 	rom ( name "VirtualKarting2_v1.1_AGA_CD.lha" size 1760750 crc 90B70B7B sha1 09075e4489f901064f0c6468f1b15c19d0d770a6 )
 )
 
@@ -15982,7 +18251,7 @@ game (
 
 game (
 	name "Vixen (Europe)"
-	rom ( name "Vixen_v1.3_0993.lha" size 164024 crc 363FA0CA sha1 edea98b64c19b5b40ed7e9a66e3a6a14b9bf74d6 )
+	rom ( name "Vixen_v1.4_0993.lha" size 164341 crc D6BEDE9B sha1 0629834c2dd314813a6f3b250cfc4333c4d00483 )
 )
 
 game (
@@ -15997,7 +18266,17 @@ game (
 
 game (
 	name "Voodoo Nightmare (Europe)"
-	rom ( name "VoodooNightmare_v1.1_2556.lha" size 613273 crc 9C4D9F5B sha1 d793f504e3646201218810c07868916f64da6145 )
+	rom ( name "VoodooNightmare_v2.0_2556.lha" size 609555 crc F721E64E sha1 2428c215c5383e865f4a2530ef85c5c4a25f558c )
+)
+
+game (
+	name "Vortex (USA)"
+	rom ( name "Vortex_v1.0_NTSC_1412.lha" size 910040 crc 8CD4B63C sha1 f59c5b53d2eaedd08617e7c4437f841dcd0cf075 )
+)
+
+game (
+	name "Voyage au Centre de la Terre (France)"
+	rom ( name "VoyageAuCentreDeLaTerre_v1.0_Fr.lha" size 872793 crc ED94E90A sha1 9988dc61b32b05bce54d20eefa5d6f3a11564354 )
 )
 
 game (
@@ -16052,32 +18331,32 @@ game (
 
 game (
 	name "Wacuś the Detective (Poland)"
-	rom ( name "WacusTheDetective_v1.0a_Pl.lha" size 2270707 crc 08929428 sha1 576090961494420aeb3437d5837127f3640a72b6 )
+	rom ( name "WacusTheDetective_v1.2_Pl.lha" size 2270985 crc 83728A56 sha1 f71c330e953ebccfd59528c2a5c15649db6fd427 )
 )
 
 game (
 	name "Walker (Europe)"
-	rom ( name "Walker_v1.0_Crunched_0159.lha" size 2077213 crc 404D1C77 sha1 7e5754fb18b9b5b06647e3d8bc3f88b41da44524 )
+	rom ( name "Walker_v1.1_0159.lha" size 2028289 crc C642C12D sha1 26baadd060b4ff6f334bf3b1c02bb3a5d3a64c41 )
 )
 
 game (
-	name "Walker (No Speech) (Europe)"
-	rom ( name "Walker_v1.0_Crunched_NoSpeech_0159.lha" size 2077555 crc D0D1A7FE sha1 7f7ee74b377fabec2dc6215af1216162db8432d3 )
+	name "Walker (Europe) (Crunched)"
+	rom ( name "Walker_v1.1_Crunched_0159.lha" size 2078147 crc 5F25792A sha1 f163c8fc0d195a7424edc6a87d5d7def7a059db8 )
 )
 
 game (
-	name "Walker (Decrunched) (Europe)"
-	rom ( name "Walker_v1.0_Decrunched_0159.lha" size 2027763 crc FA2C4EF2 sha1 8dbb56a60c557885395d6b4d211c4c5398f4c395 )
+	name "Walker (Europe) (Crunched) (No Speech)"
+	rom ( name "Walker_v1.1_Crunched_NoSpeech_0159.lha" size 2078485 crc 6227B915 sha1 e4e199bc015954eb84e1b1a055638419bfd4852e )
 )
 
 game (
-	name "Walker (Decrunched) (No Speech) (Europe)"
-	rom ( name "Walker_v1.0_Decrunched_NoSpeech_0159.lha" size 2028097 crc CDB14ED2 sha1 0f554f11b0d7ac013364b3f344b1fc3b426786d5 )
+	name "Walker (Europe) (No Speech)"
+	rom ( name "Walker_v1.1_NoSpeech_0159.lha" size 2028621 crc CB4E92F8 sha1 925546e53be7f90cdee3508f6d93065480a62849 )
 )
 
 game (
 	name "Wall, The (Europe)"
-	rom ( name "Wall_v1.0.lha" size 499217 crc AC09D2BF sha1 d6e297ee5a415d830168e3b53affd246d42bb1be )
+	rom ( name "Wall_v1.0.lha" size 578467 crc 21E7D26C sha1 a646d4ad6d82c185c8f0e95b3c13b24452f90148 )
 )
 
 game (
@@ -16136,23 +18415,23 @@ game (
 )
 
 game (
-	name "War Zone (Paradox) (Europe)"
+	name "War Zone (Europe) (Paradox)"
 	rom ( name "WarZone_v1.1_Paradox_1212.lha" size 85297 crc 0A10B428 sha1 26d8aca8f25bdb27c901f891579b814eedc45aa1 )
 )
 
 game (
-	name "War Zone (Core) (Europe)"
+	name "War Zone (Europe) (Core)"
 	rom ( name "WarZone_v2.0_CoreDesign_0598.lha" size 518647 crc 87447B17 sha1 de837c2e8ac0be26e9a48e1a18db11d4540d082c )
 )
 
 game (
 	name "Watchtower (Europe) (AGA)"
-	rom ( name "Watchtower_v1.1_AGA_1071.lha" size 1483502 crc CD49C990 sha1 a24a48a8a162b2c7c242bb159d723bbf34ab2215 )
+	rom ( name "Watchtower_v1.2_AGA_1071.lha" size 1483636 crc 40ED1F33 sha1 e1eb4ece29ed20d66b13709538d8b268b6249ef6 )
 )
 
 game (
 	name "Waterloo (Europe)"
-	rom ( name "Waterloo_v1.1_1938.lha" size 411658 crc DD13D4CC sha1 b61457f5c8e1b74963606410a3a84d3ea7e4f970 )
+	rom ( name "Waterloo_v1.1_0408.lha" size 295280 crc D3E7C100 sha1 7d84c39ce86b9b9c6a96411f37c7bf1144a1bea9 )
 )
 
 game (
@@ -16197,32 +18476,32 @@ game (
 
 game (
 	name "Ween - The Prophecy (Europe)"
-	rom ( name "WeenTheProphecy_v1.2.lha" size 1743152 crc BA16FEC9 sha1 0db2023177671512a56e4ba28db03e9374ed5cfe )
+	rom ( name "WeenTheProphecy_v1.3.lha" size 1742283 crc 6C89CF43 sha1 26ae4a22ed4bebf0ea26ff09a02b402b4912fb37 )
 )
 
 game (
 	name "Ween - The Prophecy (Germany)"
-	rom ( name "WeenTheProphecy_v1.2_De.lha" size 1747222 crc 9068CAE0 sha1 56c45d79248b65797ffc5cf8e48de5dbb015efb6 )
+	rom ( name "WeenTheProphecy_v1.3_De.lha" size 1746355 crc EEABE317 sha1 3b09794edbfbdc364b3ec015d913a6d077c6b91e )
 )
 
 game (
 	name "Ween - The Prophecy (Spain)"
-	rom ( name "WeenTheProphecy_v1.2_Es.lha" size 1748503 crc BEF11B7A sha1 9a38c539ff759d45f0a6c59c24db1ce630e1ff2c )
+	rom ( name "WeenTheProphecy_v1.3_Es.lha" size 1747636 crc 17173BFE sha1 17afe46c6b12d8dacbce5f993d7b346e6feccf38 )
 )
 
 game (
 	name "Ween - The Prophecy (France)"
-	rom ( name "WeenTheProphecy_v1.2_Fr_2326.lha" size 1766834 crc 72F01260 sha1 040cc1833ab945fe579c58c64a2ff63c1d05a013 )
+	rom ( name "WeenTheProphecy_v1.3_Fr_2326.lha" size 1765966 crc DA0FA6EA sha1 bc85b59eb569c15450e6e89eecb4ebce27edfeb6 )
 )
 
 game (
 	name "Ween - The Prophecy (Italy)"
-	rom ( name "WeenTheProphecy_v1.2_It.lha" size 1750942 crc 98A1046E sha1 670279a8c96b3b31ba554671840abd5f8af23c56 )
+	rom ( name "WeenTheProphecy_v1.3_It.lha" size 1750073 crc 24CF5C2B sha1 d5c6e7b440fd4d888d8bf91229cde52bb5de2860 )
 )
 
 game (
 	name "Weird Dreams (Europe)"
-	rom ( name "WeirdDreams_v1.0_2100.lha" size 506131 crc F7512A72 sha1 34bdf90704a0ebe66e2fa8752aaeaaf695e588cc )
+	rom ( name "WeirdDreams_v2.1_2100.lha" size 516968 crc 2132C60F sha1 247b336731a531824d6746ef140288cf2dfefa7b )
 )
 
 game (
@@ -16232,12 +18511,12 @@ game (
 
 game (
 	name "Wembley International Soccer (Europe)"
-	rom ( name "WembleyInternationalSoccer_v1.0.lha" size 501129 crc 54D9310A sha1 7700416704f1b4fbcdb75a05b44084d5cf690de9 )
+	rom ( name "WembleyInternationalSoccer_v1.01.lha" size 501414 crc 53082C02 sha1 79c7f244aa17c9cc476a2a40d880388186a9dbdb )
 )
 
 game (
 	name "Wembley International Soccer (Europe) (AGA)"
-	rom ( name "WembleyInternationalSoccer_v1.0_AGA_1704.lha" size 726069 crc AD7904C7 sha1 8b68bf889e56a71c718a9480d118cb620b2d93fa )
+	rom ( name "WembleyInternationalSoccer_v1.01_AGA_1704.lha" size 726299 crc 1A21251F sha1 7c9a9ca488ad93459a11a7646095c50c76d17692 )
 )
 
 game (
@@ -16247,12 +18526,17 @@ game (
 
 game (
 	name "Western Games (Europe)"
-	rom ( name "WesternGames_v1.0_0790.lha" size 963745 crc D155B233 sha1 34276a905a4f0c99f129e90a0f5a5e2e65c280a3 )
+	rom ( name "WesternGames_v1.0_0790.lha" size 920653 crc 68B65781 sha1 3f91eedebd159f5896c6889ef2794d0fccfbe65a )
 )
 
 game (
 	name "West Phaser (Europe)"
-	rom ( name "WestPhaser_v1.1.lha" size 1114260 crc 4D305714 sha1 7aed798c52f8517d690e896034a5f091d213ff6d )
+	rom ( name "WestPhaser_v1.2.lha" size 1114040 crc AA74F9A2 sha1 2cc48b3207bcd86140f2835a9feda8941e564e66 )
+)
+
+game (
+	name "West Phaser (France)"
+	rom ( name "WestPhaser_v1.2_Fr.lha" size 1093144 crc A2CD9C21 sha1 8a6cd7250c806da0a7030f4695e32e9b5bcc12c5 )
 )
 
 game (
@@ -16297,12 +18581,17 @@ game (
 
 game (
 	name "Whizz (Europe) (AGA)"
-	rom ( name "Whizz_v1.2_AGA_0803.lha" size 1663988 crc D9045EBE sha1 80cfda83a016540463efe61d831f6eed27fd4e2a )
+	rom ( name "Whizz_v1.2_AGA_1315.lha" size 1662654 crc 840DE4BA sha1 ae662188f830a67a443684908c9e257c910ccf32 )
 )
 
 game (
 	name "Who Framed Roger Rabbit (Europe)"
-	rom ( name "WhoFramedRogerRabbit_v1.0.lha" size 939596 crc 6EECC3D0 sha1 8b48b3510c78bdff7a7ba06157d51f6aee8feab1 )
+	rom ( name "WhoFramedRogerRabbit_v2.0_0160.lha" size 826555 crc 295AA75E sha1 48f69f2bb972422aba959414e3cd695fd1d718a4 )
+)
+
+game (
+	name "Who Framed Roger Rabbit (Europe) (Pre-release)"
+	rom ( name "WhoFramedRogerRabbit_v2.0_PreRelease.lha" size 873381 crc 35B242E9 sha1 af02bfd13a7e3ddb28cfcee3d62141f56cbd3ae7 )
 )
 
 game (
@@ -16312,7 +18601,7 @@ game (
 
 game (
 	name "Wicked (Europe)"
-	rom ( name "Wicked_v1.1_0295.lha" size 392401 crc 8F865035 sha1 20d9cd4e1a6cbaf35288eb69d430161cadc1fc41 )
+	rom ( name "Wicked_v1.2_0295.lha" size 392517 crc 442C080B sha1 54ecaa88f923bd2de7f920a8cb96e5acb168206f )
 )
 
 game (
@@ -16321,8 +18610,13 @@ game (
 )
 
 game (
+	name "Wild Life (Europe)"
+	rom ( name "WildLife_v1.0.lha" size 302164 crc B924664E sha1 ddb1cf5657eeb092a647d4facfcd58443f531236 )
+)
+
+game (
 	name "Wild Streets (Europe)"
-	rom ( name "WildStreets_v1.0_1678.lha" size 712757 crc D2661362 sha1 08f7410adf7640d9dd0c335fcd83272010cba336 )
+	rom ( name "WildStreets_v1.2_1678.lha" size 711241 crc 5337A6F6 sha1 c7d9d01cf81fd0722a7a2973bb57fac19770c3ff )
 )
 
 game (
@@ -16341,12 +18635,22 @@ game (
 )
 
 game (
+	name "Willy the Kid (Germany)"
+	rom ( name "WillyTheKid_v1.0.1_De.lha" size 187490 crc AB1ED538 sha1 6019006d1dd7ccddc01564ba7a6d4103bded0ce5 )
+)
+
+game (
+	name "Wind in the Willows (Europe)"
+	rom ( name "WindInTheWillows_v1.0_2998.lha" size 306777 crc 2C2E414B sha1 53b21250281a6cb094302e2e59d533b14688fce0 )
+)
+
+game (
 	name "Window Wizard (Europe)"
 	rom ( name "WindowWizard_v1.0_Files_2649.lha" size 656608 crc 00247D36 sha1 5337741994fdac4c765a0851059690a5aff54735 )
 )
 
 game (
-	name "Window Wizard (Image) (Europe)"
+	name "Window Wizard (Europe) (Image)"
 	rom ( name "WindowWizard_v1.0_Image_2649.lha" size 657174 crc 720307D1 sha1 9f27fc29c858e8c1fb1d67d97e6ea3b34683dd64 )
 )
 
@@ -16356,7 +18660,7 @@ game (
 )
 
 game (
-	name "Wind Surf Willy (Fast) (Europe)"
+	name "Wind Surf Willy (Europe) (Fast)"
 	rom ( name "WindSurfWilly_v1.3_Fast_2879.lha" size 281239 crc E485E38D sha1 e4e2e9b2bbe13ba423ae8e6ba3c1dd67436f6562 )
 )
 
@@ -16366,13 +18670,13 @@ game (
 )
 
 game (
-	name "Wind Surf Willy (Fast) (France)"
+	name "Wind Surf Willy (France) (Fast)"
 	rom ( name "WindSurfWilly_v1.3_Fr_Fast_2878.lha" size 279133 crc D8C42646 sha1 344333439275ae5c9c726c5872c5ac2b1e4db228 )
 )
 
 game (
 	name "Windwalker (USA)"
-	rom ( name "Windwalker_v1.0_NTSC_1391.lha" size 555262 crc 7A8C5CF5 sha1 5ad006062680759d9361005fa40b88d560e726a4 )
+	rom ( name "Windwalker_v1.02_NTSC_1391.lha" size 555834 crc A9159D97 sha1 7e84aeb6c3d17db6397f7ca35d2fd051bbf2ac39 )
 )
 
 game (
@@ -16397,17 +18701,17 @@ game (
 
 game (
 	name "Wings of Death (Europe)"
-	rom ( name "WingsOfDeath_v1.02_3022.lha" size 902405 crc 5D094EC9 sha1 180d80930995f30c3d4a661035fb84e39c684a03 )
+	rom ( name "WingsOfDeath_v1.03_3022.lha" size 902606 crc 88322682 sha1 166011e2ee01c0a6940833ff122bf616ea4be190 )
 )
 
 game (
 	name "Wings of Fury (Europe)"
-	rom ( name "WingsOfFury_v1.2_0599.lha" size 366348 crc 94F469A7 sha1 db96d9e73eb0a9c42496ac2349a0b0488d2dbe05 )
+	rom ( name "WingsOfFury_v1.2a_0599.lha" size 366410 crc 74A2D476 sha1 9779bb873cd07f7ba917cf120880b4f8509463ec )
 )
 
 game (
-	name "Wings of Fury (Chip) (Europe)"
-	rom ( name "WingsOfFury_v1.2_Chip_0599.lha" size 366642 crc 73A21C8D sha1 92d7a306f3fbf4efabb6d2bf63e040de71a62d5c )
+	name "Wings of Fury (Europe) (Fast)"
+	rom ( name "WingsOfFury_v1.2a_Fast_0599.lha" size 364707 crc 36F02008 sha1 491cc8da122ba5e1226ad7674a2ad95756e73977 )
 )
 
 game (
@@ -16452,22 +18756,32 @@ game (
 
 game (
 	name "Winzer (Europe)"
-	rom ( name "Winzer_v1.01.lha" size 522082 crc CCC89740 sha1 372c9be4229bf521a738827c20926039662f2ee1 )
+	rom ( name "Winzer_v1.02.lha" size 522191 crc 25DDB638 sha1 f30e256b1378d145dd042232be376422dbbc7b4c )
 )
 
 game (
 	name "Winzer (Germany)"
-	rom ( name "Winzer_v1.01_De_1760.lha" size 522523 crc 15174E3A sha1 39e64f9a3787ded4b324ccc2dc485ac35b57c126 )
+	rom ( name "Winzer_v1.02_De_1760.lha" size 522686 crc 61C5DFDE sha1 73cab6f8b9bc265fb4da87d35617b275727efaa2 )
 )
 
 game (
 	name "Winzer (Germany) (CDTV)"
-	rom ( name "Winzer_v1.01_De_CDTV.lha" size 2812585 crc B339FBA7 sha1 e404830931222813216216001b1260cba8df0dc1 )
+	rom ( name "Winzer_v1.02_De_CDTV.lha" size 2812853 crc 1D3A3DD1 sha1 e060c7758fc1270bad527597e9305113354a3f6b )
+)
+
+game (
+	name "Wipe Out (Europe)"
+	rom ( name "WipeOut_v1.01_0161.lha" size 277649 crc 272D4B1C sha1 6d9d64cda3425635741822550dced5261da8e4c4 )
 )
 
 game (
 	name "Wisielec (Poland)"
 	rom ( name "Wisielec_v1.02_Pl.lha" size 515454 crc 0B3ECA94 sha1 011547766b5d1ae5497cf7cef2034c6cdd06544d )
+)
+
+game (
+	name "Wizards Castle (Europe)"
+	rom ( name "WizardsCastle_v1.0.lha" size 741935 crc 9D482DFA sha1 044c11b51d94839b4d1dc840f7059a630f2246af )
 )
 
 game (
@@ -16487,17 +18801,22 @@ game (
 
 game (
 	name "Wizkid (Europe)"
-	rom ( name "Wizkid_v1.2_1449.lha" size 1154915 crc E32890CD sha1 b179127387395785db763267d41d0ca13db47326 )
+	rom ( name "Wizkid_v1.4_1449.lha" size 1155136 crc 8B3D014F sha1 bb910dfdecf3dace2d991ed91e21519523b3c1f8 )
+)
+
+game (
+	name "Wizmo (Europe)"
+	rom ( name "Wizmo_v1.0.lha" size 341122 crc 4E9CBFAF sha1 231a6212c4d5eead6cc1ecc732001274b7665971 )
 )
 
 game (
 	name "Wiz 'n' Liz (Europe)"
-	rom ( name "WizNLiz_v2.1_0749.lha" size 929302 crc E261A677 sha1 ec8fcce03c9dce17841aa32c232f17919476728a )
+	rom ( name "WizNLiz_v2.21_0749.lha" size 946151 crc 8A97A49B sha1 be089975803ce360cc879613789d61b9409099d0 )
 )
 
 game (
 	name "Wolfchild (Europe)"
-	rom ( name "Wolfchild_v1.1_0411.lha" size 1301032 crc 8116CFA7 sha1 5862d905fd646abddba39902efc67dcf2c01243c )
+	rom ( name "Wolfchild_v1.2_0411.lha" size 1301913 crc 3C7E51C5 sha1 f2f659ba969e77af90fd40e3f5d01a024f60e0f3 )
 )
 
 game (
@@ -16506,13 +18825,18 @@ game (
 )
 
 game (
-	name "Super Wonderboy - Wonderboy in Monsterland (Europe)"
+	name "Wonderboy (Europe)"
+	rom ( name "Wonderboy_v2.0.lha" size 636199 crc 61E8B8A2 sha1 cde49647fd865ff71ef6717873414b8ea94a48bc )
+)
+
+game (
+	name "Wonderboy in Monsterland (Europe)"
 	rom ( name "WonderboyInMonsterland_v1.1.lha" size 429555 crc 520C1516 sha1 e01e136b30659bdd9dbfd790170638aca5cfd18c )
 )
 
 game (
 	name "Wonder Dog (Europe)"
-	rom ( name "WonderDog_v1.2_1201.lha" size 1317132 crc F74ED9BE sha1 268f9c50a37a9fe1a42e8699c1e1b1298c00b390 )
+	rom ( name "WonderDog_v1.3_1201.lha" size 1317189 crc 573141CD sha1 c6b96bb3f05fcbc3fca00a4114429bcea35f26bb )
 )
 
 game (
@@ -16536,7 +18860,7 @@ game (
 )
 
 game (
-	name "World Cricket (USA)"
+	name "World Circuit (USA)"
 	rom ( name "WorldCircuit_v1.0_NTSC.lha" size 1494780 crc 0B1AC5D6 sha1 28a37dca311ce60ef1ca143703e44a5c896370d1 )
 )
 
@@ -16566,7 +18890,7 @@ game (
 )
 
 game (
-	name "World Class Soccer (U.S. Gold) (Europe)"
+	name "World Class Soccer (Europe) (U.S. Gold)"
 	rom ( name "WorldClassSoccer_v1.2.lha" size 305552 crc 3193BE7B sha1 605d9c4c6f5030325b81fa7276c210f15fff20de )
 )
 
@@ -16577,11 +18901,16 @@ game (
 
 game (
 	name "World Cup 90 (Europe)"
-	rom ( name "WorldCup90_v1.0.lha" size 444521 crc C759266D sha1 34f17840f9e656706851ad6b33c38bc44c9b08a2 )
+	rom ( name "WorldCup90_v2.0.lha" size 412271 crc C6D9F214 sha1 f4c6be3e554e139f6bf1158ff64e841415febcaa )
 )
 
 game (
-	name "World Darts (Arcadia) (Europe)"
+	name "World Cup USA 94 (Europe)"
+	rom ( name "WorldCupUSA94_v1.0_0163.lha" size 670357 crc 4BE76B7D sha1 38b6c1cc54ec1bd32675beecd10cae507835b73c )
+)
+
+game (
+	name "World Darts (Europe) (Arcadia)"
 	rom ( name "WorldDarts_v0.1_Arcadia.lha" size 398310 crc 56A3C76A sha1 87c2fb3ac1c1f21a36c8e0feb050566e1084b3ce )
 )
 
@@ -16616,12 +18945,12 @@ game (
 )
 
 game (
-	name "World Trophy Soccer (Arcadia) (Europe)"
+	name "World Trophy Soccer (Europe) (Arcadia)"
 	rom ( name "WorldTrophySoccer_v0.1_Arcadia.lha" size 441999 crc 9EEE4815 sha1 76381f3c95f4ef955d3fe76a37bdae1274acfe23 )
 )
 
 game (
-	name "Worms (1 MB) (Europe)"
+	name "Worms (Europe) (1 MB)"
 	rom ( name "Worms_v1.0_1MB_0230.lha" size 468541 crc 16FB315A sha1 511ab6a17f4abd978ddf456aaadb1491c01380ba )
 )
 
@@ -16631,7 +18960,12 @@ game (
 )
 
 game (
-	name "Worms (1 MB) (Europe) (CD32)"
+	name "Worms (Europe) (CD32) (AVI)"
+	rom ( name "Worms_v1.0_AVI_CD32.lha" size 62972318 crc E0388B47 sha1 95f34bcfb46fc5d5d6a13160c37037d6798287bd )
+)
+
+game (
+	name "Worms (Europe) (CD32) (1 MB)"
 	rom ( name "Worms_v1.0_CD32_1MB.lha" size 765289 crc 2EA7C0E3 sha1 e27373e2c8d152f299d5d57820c14d26b8b39616 )
 )
 
@@ -16646,12 +18980,12 @@ game (
 )
 
 game (
-	name "Worms - The Director's Cut (12 MB) (Europe) (AGA)"
+	name "Worms - The Director's Cut (Europe) (AGA) (12 MB)"
 	rom ( name "WormsDirectorsCut_v1.3_AGA_12MB_0605.lha" size 1832415 crc 1AB91E90 sha1 45ae759bdb34a19565e36b03998f87961e8a7a85 )
 )
 
 game (
-	name "Worms - The Director's Cut (8 MB) (Europe) (AGA)"
+	name "Worms - The Director's Cut (Europe) (AGA) (8 MB)"
 	rom ( name "WormsDirectorsCut_v1.3_AGA_8MB_0605.lha" size 1834293 crc D3D0E54D sha1 9c35c53aefd38bb7bf6eb2cb08fa21405755a5e8 )
 )
 
@@ -16663,6 +18997,11 @@ game (
 game (
 	name "W Potrzasku (Poland)"
 	rom ( name "WPotrzasku_v1.0_Pl.lha" size 2562036 crc 74E81AD0 sha1 1c64f404887e1d02adef4f6e5d219fc58a728ac7 )
+)
+
+game (
+	name "Wrangler (Europe)"
+	rom ( name "Wrangler_v1.0_2980.lha" size 150970 crc 494509D1 sha1 7b24f07d785bf31890faae056c98b66dab815f9e )
 )
 
 game (
@@ -16681,8 +19020,13 @@ game (
 )
 
 game (
+	name "Wrong Way Driver (Europe)"
+	rom ( name "WrongWayDriver_v1.0.lha" size 74165 crc CDDFCEA4 sha1 aa9e358fd22d2b00c636488aa5a0d43cbf9ef80d )
+)
+
+game (
 	name "WWF European Rampage Tour (Europe)"
-	rom ( name "WWFEuropeanRampageTour_v1.0_1298.lha" size 1944737 crc 4918BB80 sha1 9202072809fc958c847a3e88b54f8dbfb289b840 )
+	rom ( name "WWFEuropeanRampageTour_v1.1_1298.lha" size 1947835 crc 3EAB987C sha1 aca6dea1c3cf45a50a75f906ecd2d9550dc3f5c9 )
 )
 
 game (
@@ -16697,11 +19041,21 @@ game (
 
 game (
 	name "Xenomorph (Europe)"
-	rom ( name "Xenomorph_v1.1_0296.lha" size 639223 crc DF2162C1 sha1 a3b3e8bebadfb85a69111ea5ab071903f1a20c57 )
+	rom ( name "Xenomorph_v2.0_0296.lha" size 694451 crc 92C91BCF sha1 17a359a7799ba4d008fa5fe734f2288d8206d933 )
 )
 
 game (
-	name "Xenon 2 - Megablast (1 Disk) (Europe)"
+	name "Xenomorph (Germany)"
+	rom ( name "Xenomorph_v2.0_De_2939.lha" size 695014 crc 5A677137 sha1 cc04bf2cf1fdcf196216710b5952b92fe17ab634 )
+)
+
+game (
+	name "Xenomorph (France)"
+	rom ( name "Xenomorph_v2.0_Fr.lha" size 694772 crc 8A56188B sha1 1525cdd7f30d8749e96ea133947aad9db305d53f )
+)
+
+game (
+	name "Xenon 2 - Megablast (Europe) (1 Disk)"
 	rom ( name "Xenon2_v1.12_1Disk_2234.lha" size 1026153 crc 10A2E670 sha1 4f919da43e6660ab854c9dd83d9a78cd8e399108 )
 )
 
@@ -16726,7 +19080,7 @@ game (
 )
 
 game (
-	name "Xenon (Arcadia) (Europe)"
+	name "Xenon (Europe) (Arcadia)"
 	rom ( name "Xenon_v0.2_Arcadia.lha" size 330793 crc 062D3865 sha1 1e2f58341fa81f87388b21bd436f0dd9900bc4e4 )
 )
 
@@ -16751,6 +19105,11 @@ game (
 )
 
 game (
+	name "Xorron 2001 (Europe)"
+	rom ( name "Xorron2001_v1.0.lha" size 418842 crc 0569EC32 sha1 1723ba4f64bcd3a3da65c2283a265db260fe71e4 )
+)
+
+game (
 	name "X-Out (Europe) (Budget - Kixx)"
 	rom ( name "XOut_v1.2_1Disk_1274.lha" size 796440 crc 173BCED8 sha1 2732e83c775724da41370845ce986e0ae2398194 )
 )
@@ -16762,12 +19121,12 @@ game (
 
 game (
 	name "XP8 (Europe)"
-	rom ( name "XP8_v1.2_0607.lha" size 1562299 crc 3D0DB721 sha1 571218097cb79008675737fe38249bb6aee537a4 )
+	rom ( name "XP8_v2.1_0607.lha" size 1563718 crc E47A8A65 sha1 b76c6358a8923b9a570270c9aa9c68834ccec81c )
 )
 
 game (
 	name "XP8 (Europe) (AGA)"
-	rom ( name "XP8_v1.2_AGA.lha" size 2513182 crc DE43F70D sha1 140be4e57dee5340ced7fef2a08d0b7a4d02892c )
+	rom ( name "XP8_v2.1_AGA.lha" size 2514582 crc A075D418 sha1 3a9738bb58afa49f7b7d124f39a4ec163bc0aeb8 )
 )
 
 game (
@@ -16817,36 +19176,36 @@ game (
 
 game (
 	name "Yolanda (Europe)"
-	rom ( name "Yolanda_v1.0a_Files.lha" size 202255 crc 7323A4FA sha1 76e5f6e76970f47b020d1068e8cf2ff98b81394a )
+	rom ( name "Yolanda_v1.1_Files_3028.lha" size 205862 crc 2D713676 sha1 c7263753f244bab68e5ddbfcacac68b9445f074f )
 )
 
 game (
-	name "Yolanda (Image) (Europe)"
-	rom ( name "Yolanda_v1.0a_Image.lha" size 205539 crc F2003F3E sha1 f0c9d6df3c0b76ca87b9c9858aff9cee645337f9 )
+	name "Yolanda (Europe) (Image)"
+	rom ( name "Yolanda_v1.1_Image_3028.lha" size 209199 crc B6E52050 sha1 4b1784249073b04f6ce99ed5817aff73c8071d39 )
 )
 
 game (
 	name "Zak McKracken and the Alien Mindbenders (Europe)"
-	rom ( name "ZakMcKracken_v1.2_0965.lha" size 975769 crc E24672E9 sha1 963fc34d5e46d0067174a18e75aeb616dca61576 )
+	rom ( name "ZakMcKracken_v1.4_0965.lha" size 977210 crc 181B91BF sha1 55ffc650f7ec5da6393017dc428683af3c053b24 )
 )
 
 game (
 	name "Zak McKracken and the Alien Mindbenders (Germany)"
-	rom ( name "ZakMcKracken_v1.2_De_0413.lha" size 977970 crc 7674FB97 sha1 d14e8a02d690882ebff7a24b539fe2b5e9d3ffb3 )
+	rom ( name "ZakMcKracken_v1.4_De_0413.lha" size 979411 crc 2800FD35 sha1 14d2cac1849d3ac6be175af304d12116c2d624ec )
 )
 
 game (
 	name "Zak McKracken and the Alien Mindbenders (France)"
-	rom ( name "ZakMcKracken_v1.2_Fr.lha" size 979012 crc E819084F sha1 9255b6cea29deff984296a40d60e2bfd35630612 )
+	rom ( name "ZakMcKracken_v1.4_Fr.lha" size 980453 crc AC7BE01D sha1 e6f2a5040f59dfd93832e1e0ecc0d737e1c34f54 )
 )
 
 game (
 	name "Zak McKracken and the Alien Mindbenders (Italy)"
-	rom ( name "ZakMcKracken_v1.2_It.lha" size 975439 crc 5589AD21 sha1 bdb93392b2b1703f3163b28db8b9da7892731574 )
+	rom ( name "ZakMcKracken_v1.4_It.lha" size 976880 crc B9671750 sha1 7a42c8a70ea2cb12f8a40d61f44075117bea60aa )
 )
 
 game (
-	name "Will Harvey's Zany Golf (USA)"
+	name "Zany Golf (USA)"
 	rom ( name "ZanyGolf_v1.1_NTSC_1482.lha" size 497707 crc 37A53BB0 sha1 d3cea813bc2c38f7566877a99f4e002e689cad60 )
 )
 
@@ -16857,12 +19216,12 @@ game (
 
 game (
 	name "Zaxxon (Europe)"
-	rom ( name "Zaxxon_v1.1_1MB.lha" size 175521 crc 0C170C1C sha1 68d11b77888bc05071a6b37e5fa021a5989224d8 )
+	rom ( name "Zaxxon_v2.0.lha" size 168008 crc 7A144599 sha1 3354d57c47fd0f84fed0dbd2e4ff2f147bd9bbe4 )
 )
 
 game (
-	name "Zaxxon (512 KB) (Europe)"
-	rom ( name "Zaxxon_v1.1_512KB.lha" size 156417 crc 328CF9FB sha1 7add1034f62083b72bbc4d306f3f9991a947e22a )
+	name "Zaxxon (Europe) (512 kB)"
+	rom ( name "Zaxxon_v2.0_512k.lha" size 148804 crc F6CC30DD sha1 4c7ac043946d8bcc7d255e6781e1e27dc528c358 )
 )
 
 game (
@@ -16962,11 +19321,10 @@ game (
 
 game (
 	name "Zyconix (Europe)"
-	rom ( name "Zyconix_v1.0.lha" size 718779 crc A10B94CA sha1 aaadc2b38c3739fda3af4d59d3351fdd975037f5 )
+	rom ( name "Zyconix_v1.2_1057.lha" size 716069 crc 2E6EF220 sha1 b2e4c07a6ecb1ff67d9a481446cc4ede1aceda62 )
 )
 
 game (
 	name "Zynaps (Europe)"
 	rom ( name "Zynaps_v1.0_0879.lha" size 286792 crc 45C49AC5 sha1 ae710da5fe187a7130f26fe0e0816d72d69a30ec )
 )
-


### PR DESCRIPTION
Full Retroplay WHDLoad Game Set 19/05/2025:
- all missing games added / updated,
- naming checked against various databases.
All set is now recognized correctly by Retroarch.
 
The plan is to clean-up Amiga thumbnails in a space-saving manner so I'm asking for a direct access to master branch to speed the things up. Cheers!