### PR TITLE
Add sizes to databases that do not have it yet.

### DIFF
--- a/dat/CHIP-8.dat
+++ b/dat/CHIP-8.dat
@@ -9,5 +9,5 @@ game (
     name "Wonky Pong"
     developer "TomRintjema"
     description "Pong, but wonky. Made for Octojam IV."
-    rom ( name "wonkypong.ch8" crc 82D2DBA8 )
+    rom ( name "wonkypong.ch8" size 538 crc 82D2DBA8 )
 )

--- a/dat/ChaiLove.dat
+++ b/dat/ChaiLove.dat
@@ -16,7 +16,7 @@ game (
 	releasemonth "11"
 	releaseday "2"
 	version "1.0.1"
-	rom ( name "FloppyBird.chailove" crc 1a534bbb )
+	rom ( name "FloppyBird.chailove" size 1236066 crc 1a534bbb )
 )
 
 game (
@@ -29,7 +29,7 @@ game (
 	releasemonth "2"
 	releaseday "21"
 	version "2.0.0"
-	rom ( name "GameOfLife.chailove" crc a4e28c8c )
+	rom ( name "GameOfLife.chailove" size 1797 crc a4e28c8c )
 )
 
 game (
@@ -42,7 +42,7 @@ game (
 	releasemonth "3"
 	releaseday "5"
 	version "2.0.0"
-	rom ( name "JSTest.chailove" crc 61dc7b7c )
+	rom ( name "JSTest.chailove" size 1256986 crc 61dc7b7c )
 )
 
 game (
@@ -55,7 +55,7 @@ game (
 	releasemonth "3"
 	releaseday "5"
 	version "2.0.0"
-	rom ( name "Nyan Cat.chailove" crc 41c29b13 )
+	rom ( name "Nyan Cat.chailove" size 1886084 crc 41c29b13 )
 )
 
 game (
@@ -68,7 +68,7 @@ game (
 	releasemonth "3"
 	releaseday "5"
 	version "2.0.0"
-	rom ( name "Snake.chai" crc 3b300b4b )
+	rom ( name "Snake.chai" size 4244 crc 3b300b4b )
 )
 
 game (
@@ -81,5 +81,5 @@ game (
 	releasemonth "12"
 	releaseday "30"
 	version "2.0.0"
-	rom ( name "Launcher.chailove" crc 68194648 )
+	rom ( name "Launcher.chailove" size 1317567 crc 68194648 )
 )

--- a/dat/Lutro.dat
+++ b/dat/Lutro.dat
@@ -13,27 +13,27 @@ game (
 	name "Deep Dungeon"
 	description "Deep Dungeon"
 	developer "Jean-André Santoni"
-	rom ( name "lutro-deepdungeon.lutro" )
+	rom ( name "lutro-deepdungeon.lutro" size 1032395 )
 )
 
 game (
 	name "Game of Life"
 	description "Game of Life"
-	rom ( name "game-of-life.lutro" )
+	rom ( name "game-of-life.lutro" size 2207 )
 )
 
 game (
 	name "In Your Face City Trains"
 	description "In Your Face City Trains"
 	developer "Tangram Games"
-	rom ( name "lutro-iyfct.lutro" )
+	rom ( name "lutro-iyfct.lutro" size 1729829 )
 )
 
 game (
 	name "Platformer"
 	description "Platformer"
 	developer "Jean-André Santoni"
-	rom ( name "lutro-platformer.lutro" )
+	rom ( name "lutro-platformer.lutro" size 1048975 )
 )
 
 game (
@@ -46,34 +46,34 @@ game (
 	releasemonth 3
 	releaseyear 2015
 	releaseday 10
-	rom ( name "lutro-pong.lutro" )
+	rom ( name "lutro-pong.lutro" size 63530 )
 )
 
 game (
 	name "Sienna"
 	description "Sienna"
 	developer "Tangram Games"
-	rom ( name "lutro-sienna.lutro" )
+	rom ( name "lutro-sienna.lutro" size 1646071 )
 )
 
 game (
 	name "Snake"
 	description "Snake"
 	developer "Jean-André Santoni"
-	rom ( name "lutro-snake.lutro" )
+	rom ( name "lutro-snake.lutro" size 1739 )
 )
 
 game (
 	name "Spaceship"
 	description "Spaceship"
 	developer "Jean-André Santoni"
-	rom ( name "lutro-spaceship.lutro" )
+	rom ( name "lutro-spaceship.lutro" size 642195 )
 )
 
 game (
 	name "Tetris"
 	description "Tetris"
-	rom ( name "lutro-tetris.lutro" )
+	rom ( name "lutro-tetris.lutro" size 1485936 )
 )
 
 game (

--- a/dat/Wolfenstein 3D.dat
+++ b/dat/Wolfenstein 3D.dat
@@ -58,7 +58,7 @@ game (
 	genre "Shooter"
 	origin "US"
 	esrb_rating "M"
-	rom ( name GAMEMAPS.WL1 crc CC53D341 )
+	rom ( name GAMEMAPS.WL1 size 27425 crc CC53D341 )
 )
 
 game (
@@ -72,7 +72,7 @@ game (
 	genre "Shooter"
 	origin "US"
 	esrb_rating "M"
-	rom ( name GAMEMAPS.WL6 crc ADA5C827 )
+	rom ( name GAMEMAPS.WL6 size 150652 crc ADA5C827 )
 )
 
 game (
@@ -86,7 +86,7 @@ game (
 	genre "Shooter"
 	origin "US"
 	esrb_rating "M"
-	rom ( name GAMEMAPS.SDM crc C9F3AFEE )
+	rom ( name GAMEMAPS.SDM size 5534 crc C9F3AFEE )
 )
 
 game (


### PR DESCRIPTION
An upcoming scan optimization PR works better if there is some indication of ROM size in all databases, so it was added. CHIP-8 could do with a bigger update, the DB is even less than the RetroArch freely available downloads.