### PR TITLE
fix: Fix Sonic & Knuckles (World) genre classification

### DIFF
--- a/metadat/genre/Sega - Mega Drive - Genesis.dat
+++ b/metadat/genre/Sega - Mega Drive - Genesis.dat
@@ -11171,7 +11171,7 @@ game (
 
 game (
 	comment "Sonic & Knuckles (World)"
-	genre "Shoot'em Up"
+	genre "Platform"
 	rom ( crc 0658F691 )
 )
 


### PR DESCRIPTION
Sonic & Knuckles (World) (CRC 0658F691) is classified as `Shoot'em Up` but it's a platform game.

All other Sonic & Knuckles lock-on combinations (S&K+S2, S&K+S3) are correctly classified as `Platform`. Only the standalone S&K entry has the wrong genre.

