### PR TITLE
fix(genre): Sonic & Knuckles remaining variants — Shoot'em Up → Platform

### DIFF
--- a/metadat/genre/Sega - Mega Drive - Genesis.dat
+++ b/metadat/genre/Sega - Mega Drive - Genesis.dat
@@ -11165,7 +11165,7 @@ game (
 
 game (
 	comment "Sonic & Knuckles (World) (Beta) (1994-05-25)"
-	genre "Shoot'em Up"
+	genre "Platform"
 	rom ( crc 8E8DADD0 )
 )
 
@@ -11177,43 +11177,43 @@ game (
 
 game (
 	comment "Sonic & Knuckles (World) (Beta) (1994-06-06)"
-	genre "Shoot'em Up"
+	genre "Platform"
 	rom ( crc 03A52F63 )
 )
 
 game (
 	comment "Sonic & Knuckles (World) (Beta) (1994-06-08)"
-	genre "Shoot'em Up"
+	genre "Platform"
 	rom ( crc 7A6C1317 )
 )
 
 game (
 	comment "Sonic & Knuckles (World) (Beta) (1994-06-10)"
-	genre "Shoot'em Up"
+	genre "Platform"
 	rom ( crc 7092F368 )
 )
 
 game (
 	comment "Sonic & Knuckles (World) (Beta) (1994-06-12)"
-	genre "Shoot'em Up"
+	genre "Platform"
 	rom ( crc B0A253E8 )
 )
 
 game (
 	comment "Sonic & Knuckles (World) (Beta) (1994-06-18)"
-	genre "Shoot'em Up"
+	genre "Platform"
 	rom ( crc 2615F5DC )
 )
 
 game (
 	comment "Sonic & Knuckles (World) (Beta) (1994-06-19)"
-	genre "Shoot'em Up"
+	genre "Platform"
 	rom ( crc 1EA5B9D1 )
 )
 
 game (
 	comment "Sonic & Knuckles (World) (Sonic Classic Collection)"
-	genre "Shoot'em Up"
+	genre "Platform"
 	rom ( crc C7249CDF )
 )
 
@@ -11225,7 +11225,7 @@ game (
 
 game (
 	comment "Sonic & Knuckles + Sonic The Hedgehog (Japan, Korea) (En)"
-	genre "Shoot'em Up"
+	genre "Platform"
 	rom ( crc B6C67EAC )
 )
 


### PR DESCRIPTION
Follow-up to #1642 which fixed the main `Sonic & Knuckles (World)` entry.

This fixes the remaining 9 variants that were still misclassified as Shoot'em Up:
- 7 beta builds (1994-05-25 through 1994-06-19)
- Sonic Classic Collection re-release
- Sonic & Knuckles + Sonic The Hedgehog (Japan, Korea)

All are the same platformer game and should share the Platform genre.