### PR TITLE
Add Sonic CD (USA) to Sega CD database request

### DIFF
--- a/dat/Sega - Mega-CD - Sega CD.dat
+++ b/dat/Sega - Mega-CD - Sega CD.dat
@@ -1,0 +1,6 @@
+game (
+	name "Sonic CD (USA)"
+	region "USA"
+	serial "4407"
+	rom ( name "Sonic CD (USA) (Track 01).bin" size 139381872 crc A6184E05 md5 ED96420538F989E94480F810D5F90685 sha1 3C316AF52CC9EE8C30976A1CDB66339545DDA3BD serial "4407" )
+)


### PR DESCRIPTION
Verified dump. Hashes match Redump set.