### PR TITLE
Add Gran Turismo 2 widescreen cheats that work with all psx cores.

### DIFF
--- a/cht/Sony - PlayStation/Gran Turismo 2 USA (v1.0).cht
+++ b/cht/Sony - PlayStation/Gran Turismo 2 USA (v1.0).cht
@@ -1,0 +1,5 @@
+cheats = 1
+
+cheat0_desc = "Widescreen 16-9"
+cheat0_code = "D0010000+FFE8+8007B2AC+0156+D0010000+FFD0+8007B2AC+03DE+D0010000+FFE0+8007B2AC+01AC+8007B2AE+3402"
+cheat0_enable = false

--- a/cht/Sony - PlayStation/Gran Turismo 2 USA (v1.1).cht
+++ b/cht/Sony - PlayStation/Gran Turismo 2 USA (v1.1).cht
@@ -1,0 +1,5 @@
+cheats = 1
+
+cheat0_desc = "Widescreen 16-9"
+cheat0_code = "D0010000+FFE8+8007B2FC+0156+D0010000+FFD0+8007B2FC+03DE+D0010000+FFE0+8007B2FC+01AC+8007B2FE+3402"
+cheat0_enable = false

--- a/cht/Sony - PlayStation/Gran Turismo 2 USA (v1.2).cht
+++ b/cht/Sony - PlayStation/Gran Turismo 2 USA (v1.2).cht
@@ -1,0 +1,5 @@
+cheats = 1
+
+cheat0_desc = "Widescreen 16-9"
+cheat0_code = "D0010000+FFE8+8007B39C+0156+D0010000+FFD0+8007B39C+03DE+D0010000+FFE0+8007B39C+01AC+8007B39E+3402"
+cheat0_enable = false


### PR DESCRIPTION
The current widescreen cheats only work with the swanstation core (not beetle_psx or pcsx_rearmed).

These cheats aren't as refined, but they works with all cores.

[Source](https://forums.pcsx2.net/Thread-PSOne-Widescreen-Patches)