### PR TITLE
Add Homebrew DAT for GCE - Vectrex

### DIFF
--- a/metadat/homebrew/GCE - Vectrex.dat
+++ b/metadat/homebrew/GCE - Vectrex.dat
@@ -8,7 +8,7 @@ clrmamepro (
 game (
 	name "Beluga Dreams (World) (v1.0) (Aftermarket) (Unl)"
 	description "Beluga Dreams (World) (v1.0) (Aftermarket) (Unl)"
-	rom ( name "Beluga Dreams Free 1.0.bin" size 10778 crc 1ea3b7b4 md5 e3f901324b064e0eec6aa5f655518afa sha1 34c232b2a9d43a2c9e39f181f7a38872120e0296)
+	rom ( name "Beluga Dreams Free 1.0.bin" size 10778 crc 1ea3b7b4 md5 e3f901324b064e0eec6aa5f655518afa sha1 34c232b2a9d43a2c9e39f181f7a38872120e0296 )
 )
 
 game (

--- a/metadat/homebrew/GCE - Vectrex.dat
+++ b/metadat/homebrew/GCE - Vectrex.dat
@@ -1,0 +1,42 @@
+clrmamepro (
+	name "GCE - Vectrex"
+	description "Homebrew for GCE - Vectrex"
+	version "2026.6.1"
+	homepage "https://github.com/libretro/libretro-database/tree/master/metadat"
+)
+
+game (
+	name "Beluga Dreams (World) (v1.0) (Aftermarket) (Unl)"
+	description "Beluga Dreams (World) (v1.0) (Aftermarket) (Unl)"
+	rom ( name "Beluga Dreams Free 1.0.bin" size 10778 crc 1ea3b7b4 md5 e3f901324b064e0eec6aa5f655518afa sha1 34c232b2a9d43a2c9e39f181f7a38872120e0296)
+)
+
+game (
+	name "Vec-Man (World) (v2.5 - ParaJVE Version) (Aftermarket) (Unl)"
+	description "Vec-Man (World) (v2.5 - ParaJVE Version) (Aftermarket) (Unl)"
+	rom ( name "vec_man_parajve.bin" size 27224 crc cf1a247d md5 bf8dc3f580487a61f8034c7defa79d9c sha1 d6a7c33d812a8da3563aca8838797a693ac8d2d2000000 )
+)
+
+game (
+	name "Vec-Man (World) (v2.5) (Aftermarket) (Unl)"
+	description "Vec-Man (World) (v2.5) (Aftermarket) (Unl)"
+	rom ( name "vec_man.bin" size 28171 crc ebb800ed md5 b4e85c762a44f2bdff59ddb9e4d35fb5 sha1 e271f67e5196353a141f2cf083de578dc695c220 )
+)
+
+game (
+	name "Vectrexagon (World) (v1.2) (Aftermarket) (Unl)"
+	description "Vectrexagon (World) (v1.2) (Aftermarket) (Unl)"
+	rom ( name "vectrexagon_v12.bin" size 24685 crc bcc8e15b md5 7fd05f6a7b71e44f8b6b2fc4519e39cb sha1 224584ad88ffde4c2e7d1518cca417b72b2a71c7 )
+)
+
+game (
+	name "Quartz's Quest (World) (v1.2) (Aftermarket) (Unl)"
+	description "Quartz's Quest (World) (v1.2) (Aftermarket) (Unl)"
+	rom ( name "Quart'z_Quest_Free_1.2.bin" size 23741 crc cd9d1623 md5 e018b905f4a6be9b162beca5611c6010 sha1 f0e02abef5048902b523bd6ae58561fd1c0bbdf6 )
+)
+
+game (
+	name "Every Day Is Halloween (World) (v1.0) (Aftermarket) (Unl)"
+	description "Every Day Is Halloween (World) (v1.0) (Aftermarket) (Unl)"
+	rom ( name "EDIH_v100.BIN" size 32768 crc 277a58fa md5 806c2ae784e05b12ec5f0c734c341765 sha1 2a5bcc2c7911a19c5a0e21124b0382cae31b2c88 )
+)


### PR DESCRIPTION
Added a homebrew DAT file for GCE - Vectrex.

Included games:
- Vec-Man
- Beluga Dreams
- Every Day is Halloween
- Quartz's Quest
- Vectrexagon

Some data modified from [Lost Level Archive](https://github.com/televandalist/lost-level-archive/blob/main/DATs/046%20-%20Lost%20Level%20Archive%20-%20GCE%20-%20Vectrex%20(v20260109).xml)