### PR TITLE
Improve Touhou Fan Translations Metadata

### DIFF
--- a/dat/NEC - PC-98.dat
+++ b/dat/NEC - PC-98.dat
@@ -8,35 +8,100 @@ game (
 	name "Touhou Reiiden - Highly Responsive to Prayers"
 	description "Touhou Reiiden - Highly Responsive to Prayers (English Translation)"
 	genre "Break Out"
+	franchise "Touhou"
+	releaseyear "1997"
+	releasemonth "8"
 	rom ( name "TH01 - Highly Responsive to Prayers.hdi" size 5330944 crc 9883C55A md5 6750fc0224e0a4ba1d7e31a00dfae4f7 sha1 123fb01863a64c032a3d88790bde5bd27ffdd5b6 )
+)
+
+game (
+	name "Touhou Reiiden - Highly Responsive to Prayers"
+	description "Touhou Reiiden - Highly Responsive to Prayers (English Translation) (Moriya Shrine)"
+	genre "Break Out"
+	franchise "Touhou"
+	releaseyear "1997"
+	releasemonth "8"
+	rom ( name "th01e.hdi" size 5330944 crc CF1B5834 md5 5ef02bef7968fa456a49a248ad28c337 sha1 bc7cc120f716313561448a248d537b4179cb64e9 )
 )
 
 game (
 	name "Touhou Fuumaroku - the Story of Eastern Wonderland"
 	description "Touhou Fuumaroku - the Story of Eastern Wonderland (English Translation)"
 	genre "Bullet Hell"
+	franchise "Touhou"
+	releaseyear "1997"
+	releasemonth "8"
 	rom ( name "TH02 - The Story of Eastern Wonderland.hdi" size 5330944 crc 421BEFEF md5 db08fc7e11adf951ea25aaae102315af sha1 497534faab9534eb60ed26871ae8ba700c0fa6f3 )
+)
+
+game (
+	name "Touhou Fuumaroku - the Story of Eastern Wonderland"
+	description "Touhou Fuumaroku - the Story of Eastern Wonderland (English Translation) (Moriya Shrine)"
+	genre "Bullet Hell"
+	franchise "Touhou"
+	releaseyear "1997"
+	releasemonth "8"
+	rom ( name "th02e.hdi" size 5330944 crc 35A08C2C md5 fac309391c14f69336cf5148a5a01497 sha1 556cfbd05836c85b72f682dcb39e995a5a03ad85 )
 )
 
 game (
 	name "Touhou Yumejikuu - the Phantasmagoria of Dim.Dream"
 	description "Touhou Yumejikuu ~ the Phantasmagoria of Dim.Dream (English Translation)"
 	genre "Bullet Hell"
+	franchise "Touhou"
+	releaseyear "1997"
+	releasemonth "12"
 	rom ( name "TH03 - Phantasmagoria of Dim. Dream.hdi" size 11145216 crc DBA47518 md5 b521406a5b2d8f3e87ddda4ead766f51 sha1 b72bdeffab1aca5f21a4516c52cdc52770306c99 )
+)
+
+game (
+	name "Touhou Yumejikuu - the Phantasmagoria of Dim.Dream"
+	description "Touhou Yumejikuu ~ the Phantasmagoria of Dim.Dream (English Translation) (Moriya Shrine)"
+	genre "Bullet Hell"
+	franchise "Touhou"
+	releaseyear "1997"
+	releasemonth "12"
+	rom ( name "th03e.hdi" size 11145216 crc 58B9842A md5 14d5f8e3a014bd6b9db09ff0a34b5f49 sha1 725970336e4fd527832e42e9b5da65706b9122d3 )
 )
 
 game (
 	name "Touhou Gensoukyou - Lotus Land Story"
 	description "Touhou Gensoukyou - Lotus Land Story (English Translation)"
 	genre "Bullet Hell"
+	franchise "Touhou"
+	releaseyear "1998"
+	releasemonth "8"
 	rom ( name "TH04 - Lotus Land Story.hdi" size 11145216 crc EEC33DF8 md5 8630d8de6ead093cde2098940c737ffd sha1 e33a7aefb37efcad9b99559477b35ca9114f6515 )
+)
+
+game (
+	name "Touhou Gensoukyou - Lotus Land Story"
+	description "Touhou Gensoukyou - Lotus Land Story (English Translation) (Moriya Shrine)"
+	genre "Bullet Hell"
+	franchise "Touhou"
+	releaseyear "1998"
+	releasemonth "8"
+	rom ( name "th04e.hdi" size 11145216 crc 9759B342 md5 82a4cd9c90835d66181bd15276460fa3 sha1 271b4fddce5c209080444dc52f689c20b76a7864 )
 )
 
 game (
 	name "Touhou Kaikidan - Mystic Square"
 	description "Touhou Kaikidan - Mystic Square (English Translation)"
 	genre "Bullet Hell"
+	franchise "Touhou"
+	releaseyear "1998"
+	releasemonth "12"
 	rom ( name "TH05 - Mystic Square.hdi" size 11145216 crc DFBFDBD6 md5 c5afb2cd5b580f3e84378c284ff8e18d sha1 57f15006463dee88d8adb6a57c4127c65caa2324 )
+)
+
+game (
+	name "Touhou Kaikidan - Mystic Square"
+	description "Touhou Kaikidan - Mystic Square (English Translation) (Moriya Shrine)"
+	genre "Bullet Hell"
+	franchise "Touhou"
+	releaseyear "1998"
+	releasemonth "12"
+	rom ( name "th05e.hdi" size 11145216 crc 128ADEA6 md5 b387bb710f0580018ff638377e188ae8 sha1 030398090e654722cd835edd4cbf8d2305ca8079 )
 )
 
 game (


### PR DESCRIPTION
I saw that the version that is provided from [Moriya Shrine](https://moriyashrine.org/resources/categories/retro-era.6/) is different from the versions already in the "dat/NEC - PC-98.dat" file. I added these versions using this nushell script:
```nushell
#!/usr/bin/env nu
def main [] {
  fd -e hdi | lines | each {|e| sum $e}
}

def sum [filename: string] {
  $"rom \( name \"($filename | path basename)\" size (du $filename | $in.apparent | into int | last) crc (cksum -a crc32b $filename | split words | first | into int | format number | $in.upperhex | str substring 2.. ) md5 (md5sum $filename | split words | first) sha1 (sha1sum $filename | split words | first) \)"
}
```
I manually tested this using the explore view in RetroArch, and it worked fine. I just had to copy over the rdb file to the correct location.

I also added more metadata such as releaseyear, franchise, releasemonth to both the already existing translations and the ones I added.

I am unsure whether or not the titles are correctly set for three reasons:

1. The titles at Moriya Shrine are different as compared to the ones already in the file.
2. The titles already provided are inconsistent, but only in the description "Touhou Yumejikuu ~ the Phantasmagoria of Dim.Dream (English Translation)" instead of "Touhou Yumejikuu - the Phantasmagoria of Dim.Dream (English Translation)", why is it suddenly ~ and not - as in all other cases?
3. The titles are not the same on as on Wikipedia, "the" is added where Wikipedia lacks them.

There might be more metadata such as publisher and origin.

Lastly I want to mention that I am unsure whether or not I should add the resulting rdb file, espcially since when I saw that I got a different result for all the other rdb files as well (perhaps a version mismatch or similar).