### PR TITLE
Add Metadata to Touhou Fan Translations

### DIFF
--- a/dat/NEC - PC-98.dat
+++ b/dat/NEC - PC-98.dat
@@ -11,6 +11,10 @@ game (
 	franchise "Touhou"
 	releaseyear "1997"
 	releasemonth "8"
+	origin "Japan"
+	publisher "Amusement Makers"
+	developer "ZUN Soft"
+	users 1
 	rom ( name "TH01 - Highly Responsive to Prayers.hdi" size 5330944 crc 9883C55A md5 6750fc0224e0a4ba1d7e31a00dfae4f7 sha1 123fb01863a64c032a3d88790bde5bd27ffdd5b6 )
 )
 
@@ -21,6 +25,10 @@ game (
 	franchise "Touhou"
 	releaseyear "1997"
 	releasemonth "8"
+	origin "Japan"
+	publisher "Amusement Makers"
+	developer "ZUN Soft"
+	users 1
 	rom ( name "th01e.hdi" size 5330944 crc CF1B5834 md5 5ef02bef7968fa456a49a248ad28c337 sha1 bc7cc120f716313561448a248d537b4179cb64e9 )
 )
 
@@ -31,6 +39,10 @@ game (
 	franchise "Touhou"
 	releaseyear "1997"
 	releasemonth "8"
+	origin "Japan"
+	publisher "Amusement Makers"
+	developer "ZUN Soft"
+	users 1
 	rom ( name "TH02 - The Story of Eastern Wonderland.hdi" size 5330944 crc 421BEFEF md5 db08fc7e11adf951ea25aaae102315af sha1 497534faab9534eb60ed26871ae8ba700c0fa6f3 )
 )
 
@@ -41,6 +53,10 @@ game (
 	franchise "Touhou"
 	releaseyear "1997"
 	releasemonth "8"
+	origin "Japan"
+	publisher "Amusement Makers"
+	developer "ZUN Soft"
+	users 1
 	rom ( name "th02e.hdi" size 5330944 crc 35A08C2C md5 fac309391c14f69336cf5148a5a01497 sha1 556cfbd05836c85b72f682dcb39e995a5a03ad85 )
 )
 
@@ -51,6 +67,10 @@ game (
 	franchise "Touhou"
 	releaseyear "1997"
 	releasemonth "12"
+	origin "Japan"
+	publisher "Amusement Makers"
+	developer "ZUN Soft"
+	users 2
 	rom ( name "TH03 - Phantasmagoria of Dim. Dream.hdi" size 11145216 crc DBA47518 md5 b521406a5b2d8f3e87ddda4ead766f51 sha1 b72bdeffab1aca5f21a4516c52cdc52770306c99 )
 )
 
@@ -61,6 +81,10 @@ game (
 	franchise "Touhou"
 	releaseyear "1997"
 	releasemonth "12"
+	origin "Japan"
+	publisher "Amusement Makers"
+	developer "ZUN Soft"
+	users 2
 	rom ( name "th03e.hdi" size 11145216 crc 58B9842A md5 14d5f8e3a014bd6b9db09ff0a34b5f49 sha1 725970336e4fd527832e42e9b5da65706b9122d3 )
 )
 
@@ -71,6 +95,10 @@ game (
 	franchise "Touhou"
 	releaseyear "1998"
 	releasemonth "8"
+	origin "Japan"
+	publisher "Amusement Makers"
+	developer "ZUN Soft"
+	users 1
 	rom ( name "TH04 - Lotus Land Story.hdi" size 11145216 crc EEC33DF8 md5 8630d8de6ead093cde2098940c737ffd sha1 e33a7aefb37efcad9b99559477b35ca9114f6515 )
 )
 
@@ -81,6 +109,10 @@ game (
 	franchise "Touhou"
 	releaseyear "1998"
 	releasemonth "8"
+	origin "Japan"
+	publisher "Amusement Makers"
+	developer "ZUN Soft"
+	users 1
 	rom ( name "th04e.hdi" size 11145216 crc 9759B342 md5 82a4cd9c90835d66181bd15276460fa3 sha1 271b4fddce5c209080444dc52f689c20b76a7864 )
 )
 
@@ -91,6 +123,10 @@ game (
 	franchise "Touhou"
 	releaseyear "1998"
 	releasemonth "12"
+	origin "Japan"
+	publisher "Amusement Makers"
+	developer "ZUN Soft"
+	users 1
 	rom ( name "TH05 - Mystic Square.hdi" size 11145216 crc DFBFDBD6 md5 c5afb2cd5b580f3e84378c284ff8e18d sha1 57f15006463dee88d8adb6a57c4127c65caa2324 )
 )
 
@@ -101,6 +137,10 @@ game (
 	franchise "Touhou"
 	releaseyear "1998"
 	releasemonth "12"
+	origin "Japan"
+	publisher "Amusement Makers"
+	developer "ZUN Soft"
+	users 1
 	rom ( name "th05e.hdi" size 11145216 crc 128ADEA6 md5 b387bb710f0580018ff638377e188ae8 sha1 030398090e654722cd835edd4cbf8d2305ca8079 )
 )
 


### PR DESCRIPTION
I added origin, publisher, developer and maxusers metadata for touhou fan translations. Which meant adding this:
```diff
+       origin "Japan"
+       publisher "Amusement Makers"
+       developer "ZUN Soft"
+       users 1
```
With the only exception being the third game which has a vs mode meaning that maxusers is 2.
I used the touhou wiki and Wikipedia to find the information.
I manually tested using explore in RetroArch for all fields added.