### PR TITLE
Improve FBNeo dat generator script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 *.dat text eol=lf
 *.xml text eol=lf
 *.cht text eol=lf
+*.py text eol=lf

--- a/scripts/FBNeo_dat_gen.py
+++ b/scripts/FBNeo_dat_gen.py
@@ -3,36 +3,36 @@
 # FBNeo_dat_gen.py
 # Written in 2017 by SpiralBrad <SpiralBrad@spiralgoat.com>
 
-## usage: FBNeo_dat_gen.py [-h] -dat DAT -path PATH [-output_file OUTPUT_FILE]
-##                       [-header_name HEADER_NAME]
-##                       [-header_description HEADER_DESCRIPTION]
-##                       [-header_version HEADER_VERSION]
+## usage: FBNeo_dat_gen.py [-h] --dat DAT --path PATH [--output-file OUTPUT_FILE]
+##                       [--header-name HEADER_NAME]
+##                       [--header-description HEADER_DESCRIPTION]
+##                       [--header-version HEADER_VERSION]
 ## 
 ## Generates Final Burn Neo .dat file needed for RetroArch/libretro-
 ## db/c_converter
 ## 
 ## optional arguments:
 ##   -h, --help            show this help message and exit
-##   -output_file OUTPUT_FILE
+##   -o, --output_file OUTPUT_FILE
 ##                         Path to the target output file; example: FBNeo - 
 ##                         Arcade games.dat
-##   -header_name HEADER_NAME
+##   --header-name HEADER_NAME
 ##                         Override the clrmamepro(name) in the output .dat
-##   -header_description HEADER_DESCRIPTION
+##   --header-description HEADER_DESCRIPTION
 ##                         Override the clrmamepro(description) in the output 
 ##                         .dat
-##   -header_version HEADER_VERSION
+##   --header-version HEADER_VERSION
 ##                         Override the clrmamepro(version) in the output .dat
 ## 
 ## required arguments:
-##   -dat DAT              Misc -> Generate dat file -> Generate dat (Arcade 
+##   -d, --dat DAT              Misc -> Generate dat file -> Generate dat (Arcade 
 ##                         only)
-##   -path PATH            Path to a split, ClrMamePro verified and TorrentZipped 
+##   -p, --path PATH            Path to a split, ClrMamePro verified and TorrentZipped 
 ##                         ROM set matching the Arcade only dat
 ## 
-## example usage: python3 FBA_dat_gen.py -dat "FBNeo v0.2.97.42 (ClrMame Pro 
-##                  XML).dat" -path  "/path/to/split/verified/torrentzipped/roms/" 
-##                  -output_file "FBNeo - Arcade Games.dat"
+## example usage: python3 FBA_dat_gen.py --dat "FBNeo v0.2.97.42 (ClrMame Pro 
+##                  XML).dat" --path  "/path/to/split/verified/torrentzipped/roms/" 
+##                  --output-file "FBNeo - Arcade Games.dat"
 
 #-   To the extent possible under law, the author(s) have dedicated all 
 #-   copyright and related and neighboring rights to this software to the 
@@ -69,19 +69,19 @@ def setup_argparse():
     """Set up the argparse arguments and return the argparse instance"""
     parser = argparse.ArgumentParser(prog='FBgen.py', description='Generates Final Burn Neo .dat file needed for RetroArch/libretro-db/c_converter')
     required_arguments = parser.add_argument_group('required arguments')
-    required_arguments.add_argument('-dat', help='Misc -> Generate dat file -> Generate dat (Arcade only)', required=True)
-    required_arguments.add_argument('-path', help='Path to a split, ClrMamePro verified and TorrentZipped ROM set matching the Arcade only dat', required=True)
-    parser.add_argument('-output_file', help='Path to the target output file; example: FBNeo - Arcade games.dat')
-    parser.add_argument('-header_name', help='Override the clrmamepro(name) in the output .dat')
-    parser.add_argument('-header_description', help='Override the clrmamepro(description) in the output .dat')
-    parser.add_argument('-header_version', help='Override the clrmamepro(version) in the output .dat')
+    required_arguments.add_argument('-d', '--dat', help='Misc -> Generate dat file -> Generate dat (Arcade only)', required=True)
+    required_arguments.add_argument('-p', '--path', help='Path to a split, ClrMamePro verified and TorrentZipped ROM set matching the Arcade only dat', required=True)
+    parser.add_argument('-o', '--output-file', help='Path to the target output file; example: FBNeo - Arcade games.dat')
+    parser.add_argument('--header-name', help='Override the clrmamepro(name) in the output .dat')
+    parser.add_argument('--header-description', help='Override the clrmamepro(description) in the output .dat')
+    parser.add_argument('--header-version', help='Override the clrmamepro(version) in the output .dat')
 
     if len(sys.argv) == 1:
         parser.print_help()
         print('\n'.join(['',
-                         'example usage: python3 FBA_dat_gen.py -dat "FBNeo v0.2.97.42 (ClrMame Pro ', 
+                         'example usage: python3 FBA_dat_gen.py --dat "FBNeo v0.2.97.42 (ClrMame Pro ', 
                          '                 XML).dat" -path  "/path/to/split/verified/torrentzipped/roms/" ',
-                         '                 -output_file "FBNeo - Arcade Games.dat"']))
+                         '                 --output-file "FBNeo - Arcade Games.dat"']))
         parser.exit()
     return parser
 
@@ -141,7 +141,7 @@ def generate_game_list(dat_root, path, parser):
     game_list = []
     
     if not os.path.isdir(path):
-        print('Path is not dir or not found: ' + path + '\n')
+        print(f'Path is not dir or not found: {path}\n')
         parser.print_help()
         parser.exit()
     else:
@@ -193,7 +193,7 @@ def generate_game_list(dat_root, path, parser):
     return '\n'.join(game_list)
 
 def output(args, header, game_list):
-    """Combine <header> and <game_list> and print to stdout, or write to specified -output_file"""
+    """Combine <header> and <game_list> and print to stdout, or write to specified --output-file"""
     if not args.output_file:
         # print to stdout
         print('\n'.join([header, '', game_list]).rstrip())

--- a/scripts/FBNeo_dat_gen.py
+++ b/scripts/FBNeo_dat_gen.py
@@ -55,12 +55,14 @@ import zlib
 def main():
     parser = setup_argparse()
     args = parser.parse_args()
+    if parser == None:
+        print("parser is none")
     dat_root = get_datroot(args.dat, parser)
     header_name = get_header_name(args)
     header_version = get_header_version(args, dat_root, parser)
     header_description = get_header_description(args, header_version)
     header = generate_dat_header(header_name, header_description, header_version)
-    game_list = generate_game_list(dat_root, args.path)
+    game_list = generate_game_list(dat_root, args.path, parser)
     output(args, header, game_list)
 
 def setup_argparse():
@@ -74,7 +76,7 @@ def setup_argparse():
     parser.add_argument('-header_description', help='Override the clrmamepro(description) in the output .dat')
     parser.add_argument('-header_version', help='Override the clrmamepro(version) in the output .dat')
 
-    if len(sys.argv[1:])==0:
+    if len(sys.argv) == 1:
         parser.print_help()
         print('\n'.join(['',
                          'example usage: python3 FBA_dat_gen.py -dat "FBNeo v0.2.97.42 (ClrMame Pro ', 
@@ -134,13 +136,12 @@ def generate_dat_header(name, description, version):
               ')']
     return '\n'.join(header)
 
-def generate_game_list(dat_root, path):
+def generate_game_list(dat_root, path, parser):
     """Generate the sorted list of games with all metadata and return a textual dat list"""
     game_list = []
     
     if not os.path.isdir(path):
-        print('Path not found: ' + path)
-        print('')
+        print('Path is not dir or not found: ' + path + '\n')
         parser.print_help()
         parser.exit()
     else:
@@ -162,6 +163,9 @@ def generate_game_list(dat_root, path):
                         # set zip filename
                         entry.zip = game.get('name') + '.zip'
                         zip_path = os.path.join(path, entry.zip)
+                        if not os.path.exists(zip_path):
+                            print(f'Did not find "{zip_path}", skipping.')
+                            continue
                         # set zip size
                         entry.size = os.path.getsize(zip_path)
                         # set zip crc
@@ -180,7 +184,7 @@ def generate_game_list(dat_root, path):
         for entry in game_entries:
             text_entry = ['game (',
                           '\t' + 'name "%s"' % entry.name,
-                          '\t' + 'year "%s"' % entry.year,
+                          '\t' + 'releaseyear "%s"' % entry.year,
                           '\t' + 'publisher "%s"' % entry.publisher,
                           '\t' + 'rom ( name %s size %s crc %s md5 %s sha1 %s )' % (entry.zip, entry.size, entry.crc, entry.md5, entry.sha1),
                           ')',


### PR DESCRIPTION
FBNeo_dat_gen.py has a few issues.

1. The file was encoded as dos, which was different from the rest of the scripts.
2. The script did not follow convention for cli args.
3. A function tried to use the parser variable which was not passed to the function leading to error.
4. When it generates the dat, it uses year instead of releaseyear.

This PR essentially just fixes these problems.