### PR TITLE
dat: Update Neo Geo Pocket Color metadat to match No-Intro

### DIFF
--- a/metadat/developer/SNK - Neo Geo Pocket Color.dat
+++ b/metadat/developer/SNK - Neo Geo Pocket Color.dat
@@ -204,7 +204,7 @@ game (
 game (
 	comment "King of Fighters R-2 - Pocket Fighting Series (World) (En,Ja)"
 	developer "SNK"
-	rom ( crc D5F69C02 )
+	rom ( crc 9BC63F27 )
 )
 
 game (
@@ -270,13 +270,13 @@ game (
 game (
 	comment "Metal Slug - 1st Mission (World) (En,Ja)"
 	developer "Ukiyotei"
-	rom ( crc 4C224504 )
+	rom ( crc D29EC1BA )
 )
 
 game (
 	comment "Metal Slug - 2nd Mission (World) (En,Ja)"
 	developer "Ukiyotei"
-	rom ( crc F4507FA5 )
+	rom ( crc 18E692A5 )
 )
 
 game (
@@ -600,7 +600,7 @@ game (
 game (
 	comment "Samurai Shodown! 2 - Pocket Fighting Series (World) (En,Ja)"
 	developer "SNK"
-	rom ( crc CE88B26D )
+	rom ( crc 58A62FB2 )
 )
 
 game (
@@ -672,19 +672,19 @@ game (
 game (
 	comment "SNK vs. Capcom - The Match of the Millennium (World) (En,Ja)"
 	developer "Capcom"
-	rom ( crc A54C3026 )
+	rom ( crc 682A7A7B )
 )
 
 game (
 	comment "Sonic The Hedgehog - Pocket Adventure (World)"
 	developer "SNK"
-	rom ( crc 0AD6BCF7 )
+	rom ( crc 8BD22145 )
 )
 
 game (
 	comment "SNK vs. Capcom - The Match of the Millennium (Japan) (Demo)"
 	developer "Capcom"
-	rom ( crc A54C3026 )
+	rom ( crc 1E19E307 )
 )
 
 game (

--- a/metadat/developer/SNK - Neo Geo Pocket Color.dat
+++ b/metadat/developer/SNK - Neo Geo Pocket Color.dat
@@ -6,19 +6,19 @@ clrmamepro (
 game (
 	comment "Biomotor Unitron (Japan)"
 	developer "Yumekobo"
-	rom ( crc DC07E2EF )
+	rom ( crc FCBBE494 )
 )
 
 game (
 	comment "Big Bang Pro Wrestling (Japan) (En,Ja)"
 	developer "S-Neo"
-	rom ( crc B783C372 )
+	rom ( crc F1716FDF )
 )
 
 game (
 	comment "Bakumatsu Rouman Tokubetsu Hen - Gekka no Kenshi - Tsuki ni Saku Hana, Chiri Yuku Hana (Japan)"
 	developer "Saurus"
-	rom ( crc 5EB119BE )
+	rom ( crc BE913CFA )
 )
 
 game (
@@ -34,31 +34,25 @@ game (
 )
 
 game (
-	comment "Biomotor Unitron (Japan) (Demo)"
-	developer "Yumekobo"
-	rom ( crc 3D515243 )
-)
-
-game (
 	comment "Cool Cool Jam (Japan)"
 	developer "SNK"
-	rom ( crc 9B2A8331 )
+	rom ( crc 0FD6F378 )
 )
 
 game (
 	comment "Cool Boarders Pocket (Japan, Europe) (En,Ja)"
 	developer "UEP Systems"
-	rom ( crc 62476C26 )
+	rom ( crc 2ED72635 )
 )
 
 game (
 	comment "Bust-A-Move Pocket (USA)"
 	developer "Taito"
-	rom ( crc 2DC1A1A3 )
+	rom ( crc B073D601 )
 )
 
 game (
-	comment "Bust-A-Move Pocket (USA) (Demo)"
+	comment "Bust-A-Move Pocket (USA) (Beta)"
 	developer "Taito"
 	rom ( crc 78A1361D )
 )
@@ -78,7 +72,7 @@ game (
 game (
 	comment "Delta Warp (Japan) (En,Ja)"
 	developer "Iosys"
-	rom ( crc ADD4FDFF )
+	rom ( crc 1273B10E )
 )
 
 game (
@@ -94,21 +88,9 @@ game (
 )
 
 game (
-	comment "Densha de Go! 2 on Neo Geo Pocket (Japan)"
+	comment "Densha de Go! 2 on NeoGeo Pocket (Japan)"
 	developer "Taito"
-	rom ( crc 0DA57257 )
-)
-
-game (
-	comment "Delta Warp (Japan) (Demo)"
-	developer "Iosys"
-	rom ( crc A3C89788 )
-)
-
-game (
-	comment "Densha de Go! 2 on Neo Geo Pocket (Japan) (Beta)"
-	developer "Taito"
-	rom ( crc 2FC4623E )
+	rom ( crc A0334549 )
 )
 
 game (
@@ -178,7 +160,7 @@ game (
 )
 
 game (
-	comment "Fatal Fury F-Contact - Pocket Fighting Series (World) (En,Ja)"
+	comment "Fatal Fury - First Contact - Pocket Fighting Series (World) (En,Ja)"
 	developer "SNK"
 	rom ( crc E7E5D6E8 )
 )
@@ -198,7 +180,7 @@ game (
 game (
 	comment "Kikou Seiki Unitron - Sono Tsuide. Hikari Umareru Chi Yori. (Japan)"
 	developer "Yumekobo"
-	rom ( crc C7C1FCF5 )
+	rom ( crc F029F1C0 )
 )
 
 game (
@@ -234,7 +216,7 @@ game (
 game (
 	comment "Koi Koi Mahjong (Japan) (v08)"
 	developer "Visco"
-	rom ( crc 021F7D0C )
+	rom ( crc 75FE164C )
 )
 
 game (
@@ -246,7 +228,7 @@ game (
 game (
 	comment "Last Blade, The - Beyond the Destiny (USA, Europe)"
 	developer "Saurus"
-	rom ( crc 94FCFD1E )
+	rom ( crc 4238A840 )
 )
 
 game (
@@ -256,15 +238,9 @@ game (
 )
 
 game (
-	comment "Magical Drop Pocket (Japan) (Demo)"
-	developer "SAS Sakata"
-	rom ( crc D76F1A47 )
-)
-
-game (
 	comment "Memories Off - Pure (Japan)"
 	developer "Kindle Imagine Develop"
-	rom ( crc A7926E90 )
+	rom ( crc 7F919DDE )
 )
 
 game (
@@ -292,12 +268,6 @@ game (
 )
 
 game (
-	comment "Metal Slug - 2nd Mission (World) (En,Ja) (Demo)"
-	developer "Ukiyotei"
-	rom ( crc 8B1647D4 )
-)
-
-game (
 	comment "Neo Baccarat - Pocket Casino Series (Japan, Europe) (En) (v16)"
 	developer "Dyna Corp."
 	rom ( crc 22AAB454 )
@@ -318,23 +288,17 @@ game (
 game (
 	comment "Neo Derby Champ Daiyosou (Japan)"
 	developer "Dyna Corporation"
-	rom ( crc 98C6C4FD )
+	rom ( crc 4760564A )
 )
 
 game (
-	comment "Neo Cherry Master Color - Pocket Casino Series (World) (En,Ja) (Demo)"
-	developer "Dyna Corp."
-	rom ( crc 2F6EB991 )
-)
-
-game (
-	comment "Neo Dragon's Wild - Real Casino Series (World) (En,Ja) (v11)"
+	comment "Neo Dragon's Wild - Pocket Casino Series (World) (En,Ja) (v11)"
 	developer "Dyna Corp."
 	rom ( crc 225FD7F9 )
 )
 
 game (
-	comment "Neo Dragon's Wild - Real Casino Series (World) (En,Ja) (v13)"
+	comment "Neo Dragon's Wild - Pocket Casino Series (World) (En,Ja) (v13)"
 	developer "Dyna Corp."
 	rom ( crc 5D028C99 )
 )
@@ -348,25 +312,19 @@ game (
 game (
 	comment "Neo Poke Pro Yakyuu (Japan) (v32)"
 	developer "SNK"
-	rom ( crc DF6435D7 )
+	rom ( crc C624388F )
 )
 
 game (
 	comment "Neo Poke Pro Yakyuu (Japan) (v1F)"
 	developer "SNK"
-	rom ( crc DF6435D7 )
+	rom ( crc 3CA883A5 )
 )
 
 game (
-	comment "Neo Turf Masters (World) (En,Ja)"
+	comment "Neo Turf Masters - Pocket Sports Series (World) (En,Ja)"
 	developer "SNK"
-	rom ( crc D83C7981 )
-)
-
-game (
-	comment "Neo Turf Masters (World) (En,Ja) (Demo)"
-	developer "SNK"
-	rom ( crc 9DCA6ED6 )
+	rom ( crc E0E853DD )
 )
 
 game (
@@ -378,13 +336,13 @@ game (
 game (
 	comment "Nige-ron-pa (Japan)"
 	developer "Dennou Eizou"
-	rom ( crc 3CC3E269 )
+	rom ( crc A9063D9E )
 )
 
 game (
 	comment "Oekaki Puzzle (Japan)"
 	developer "Success"
-	rom ( crc CD657665 )
+	rom ( crc A9118E82 )
 )
 
 game (
@@ -394,7 +352,7 @@ game (
 )
 
 game (
-	comment "Pachi-slot Aruze Oukoku - Porcano 2 (Japan)"
+	comment "Pachi-Slot Aruze Oukoku - Porcano 2 (Japan)"
 	developer "Aruze Corp"
 	rom ( crc 96DDFBE3 )
 )
@@ -402,19 +360,19 @@ game (
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Azteca (Japan) (v04)"
 	developer "Aruze Corp"
-	rom ( crc BA74A414 )
+	rom ( crc 9FF16520 )
 )
 
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Azteca (Japan) (v03)"
 	developer "Aruze Corp"
-	rom ( crc BA74A414 )
+	rom ( crc 2314440A )
 )
 
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Azteca (Japan) (v06)"
 	developer "Aruze Corp"
-	rom ( crc BA74A414 )
+	rom ( crc C9B55E6B )
 )
 
 game (
@@ -438,13 +396,13 @@ game (
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - e-CUP (Japan) (v03)"
 	developer "Aruze Corp"
-	rom ( crc 6571A5EF )
+	rom ( crc B5311753 )
 )
 
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Hanabi (Japan) (v03)"
 	developer "Aruze Corp"
-	rom ( crc 54DD615E )
+	rom ( crc 4014FF42 )
 )
 
 game (
@@ -456,7 +414,7 @@ game (
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Hanabi (Japan) (v04)"
 	developer "Aruze Corp"
-	rom ( crc 54DD615E )
+	rom ( crc 2A4F45AB )
 )
 
 game (
@@ -474,19 +432,19 @@ game (
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Ward of Lights (Japan) (v04)"
 	developer "Aruze Corp"
-	rom ( crc 4A004B5E )
+	rom ( crc A54EC305 )
 )
 
 game (
 	comment "Pachinko Hisshou Guide - Pocket Parlor (Japan)"
 	developer "Vistec"
-	rom ( crc E43C4028 )
+	rom ( crc 543DC257 )
 )
 
 game (
 	comment "Pachinko Hisshou Guide - Pocket Parlor (Japan) (Beta)"
 	developer "Vistec"
-	rom ( crc E43C4028 )
+	rom ( crc CCF07C2F )
 )
 
 game (
@@ -510,55 +468,55 @@ game (
 game (
 	comment "Picture Puzzle (Europe)"
 	developer "Success"
-	rom ( crc 0DBF93AC )
+	rom ( crc 6F2D35E6 )
 )
 
 game (
 	comment "Pocket Reversi (Europe) (vA1)"
 	developer "Success"
-	rom ( crc 9250F099 )
+	rom ( crc 22C07C25 )
 )
 
 game (
 	comment "Pocket Reversi (Japan)"
 	developer "Success"
-	rom ( crc 477D3A49 )
+	rom ( crc D115FEDF )
 )
 
 game (
 	comment "Pocket Reversi (Europe) (v03)"
 	developer "Success"
-	rom ( crc 9250F099 )
+	rom ( crc 9589F2F2 )
 )
 
 game (
-	comment "Puyo Pop (World) (En,Ja) (v05)"
+	comment "Puyo Pop (Japan) (En,Ja) (v05)"
 	developer "Compile"
 	rom ( crc 3090B2FD )
 )
 
 game (
-	comment "Puyo Pop (World) (En,Ja) (v06)"
+	comment "Puyo Pop (USA) (En,Ja) (v06)"
 	developer "Compile"
-	rom ( crc 5C649D1E )
+	rom ( crc 5EA9559E )
 )
 
 game (
 	comment "Pocket Tennis Color - Pocket Sports Series (World) (En,Ja)"
 	developer "Yumekobo"
-	rom ( crc 52F17827 )
+	rom ( crc E0B9AA22 )
 )
 
 game (
-	comment "Puzzle Bobble Mini (Japan, Europe) (En)"
+	comment "Puzzle Bobble Mini (Europe)"
 	developer "Taito"
-	rom ( crc 23AABF1E )
+	rom ( crc D31312DC )
 )
 
 game (
-	comment "Puzzle Bobble Mini (Japan, Europe) (En,Ja) (Demo)"
+	comment "Puzzle Bobble Mini (Japan) (En)"
 	developer "Taito"
-	rom ( crc 23AABF1E )
+	rom ( crc D6544F6C )
 )
 
 game (
@@ -580,15 +538,9 @@ game (
 )
 
 game (
-	comment "Rockman - Battle & Fighters (Japan) (Demo)"
-	developer "Capcom"
-	rom ( crc 16A98AC4 )
-)
-
-game (
 	comment "Rockman - Battle & Fighters (Japan)"
 	developer "Capcom"
-	rom ( crc 9C861E49 )
+	rom ( crc 3C010642 )
 )
 
 game (
@@ -624,7 +576,7 @@ game (
 game (
 	comment "SNK Gals' Fighters (Japan)"
 	developer "Yumekobo"
-	rom ( crc 34B30474 )
+	rom ( crc D73B5B9F )
 )
 
 game (
@@ -664,33 +616,21 @@ game (
 )
 
 game (
-	comment "SNK vs. Capcom - Gekitotsu Card Fighters - SNK Supporter Version (Japan) (Beta)"
-	developer "SNK"
-	rom ( crc E70E3F1A )
-)
-
-game (
 	comment "SNK vs. Capcom - The Match of the Millennium (World) (En,Ja)"
 	developer "Capcom"
 	rom ( crc 682A7A7B )
 )
 
 game (
-	comment "Sonic The Hedgehog - Pocket Adventure (World)"
+	comment "Sonic The Hedgehog - Pocket Adventure (World) (En,Ja)"
 	developer "SNK"
 	rom ( crc 8BD22145 )
 )
 
 game (
-	comment "SNK vs. Capcom - The Match of the Millennium (Japan) (Demo)"
-	developer "Capcom"
-	rom ( crc 1E19E307 )
-)
-
-game (
-	comment "Sonic The Hedgehog - Pocket Adventure (World) (Beta) (1999-10-22)"
+	comment "Sonic The Hedgehog - Pocket Adventure (World) (Beta)"
 	developer "SNK"
-	rom ( crc D95D8E55 )
+	rom ( crc 45FC3BCA )
 )
 
 game (

--- a/metadat/esrb/SNK - Neo Geo Pocket Color.dat
+++ b/metadat/esrb/SNK - Neo Geo Pocket Color.dat
@@ -114,7 +114,7 @@ game (
 game (
 	comment "King of Fighters R-2 - Pocket Fighting Series (World) (En,Ja)"
 	esrb_rating "E"
-	rom ( crc D5F69C02 )
+	rom ( crc 9BC63F27 )
 )
 
 game (
@@ -156,13 +156,13 @@ game (
 game (
 	comment "Metal Slug - 1st Mission (World) (En,Ja)"
 	esrb_rating "E"
-	rom ( crc 4C224504 )
+	rom ( crc D29EC1BA )
 )
 
 game (
 	comment "Metal Slug - 2nd Mission (World) (En,Ja)"
 	esrb_rating "E"
-	rom ( crc F4507FA5 )
+	rom ( crc 18E692A5 )
 )
 
 game (
@@ -288,7 +288,7 @@ game (
 game (
 	comment "Samurai Shodown! 2 - Pocket Fighting Series (World) (En,Ja)"
 	esrb_rating "E"
-	rom ( crc CE88B26D )
+	rom ( crc 58A62FB2 )
 )
 
 game (
@@ -342,19 +342,19 @@ game (
 game (
 	comment "SNK vs. Capcom - The Match of the Millennium (World) (En,Ja)"
 	esrb_rating "E"
-	rom ( crc A54C3026 )
+	rom ( crc 682A7A7B )
 )
 
 game (
 	comment "Sonic The Hedgehog - Pocket Adventure (World)"
 	esrb_rating "E"
-	rom ( crc 0AD6BCF7 )
+	rom ( crc 8BD22145 )
 )
 
 game (
 	comment "SNK vs. Capcom - The Match of the Millennium (Japan) (Demo)"
 	esrb_rating "E"
-	rom ( crc A54C3026 )
+	rom ( crc 1E19E307 )
 )
 
 game (

--- a/metadat/esrb/SNK - Neo Geo Pocket Color.dat
+++ b/metadat/esrb/SNK - Neo Geo Pocket Color.dat
@@ -6,13 +6,13 @@ clrmamepro (
 game (
 	comment "Biomotor Unitron (Japan)"
 	esrb_rating "E"
-	rom ( crc DC07E2EF )
+	rom ( crc FCBBE494 )
 )
 
 game (
 	comment "Bakumatsu Rouman Tokubetsu Hen - Gekka no Kenshi - Tsuki ni Saku Hana, Chiri Yuku Hana (Japan)"
 	esrb_rating "E"
-	rom ( crc 5EB119BE )
+	rom ( crc BE913CFA )
 )
 
 game (
@@ -28,25 +28,19 @@ game (
 )
 
 game (
-	comment "Biomotor Unitron (Japan) (Demo)"
-	esrb_rating "E"
-	rom ( crc 3D515243 )
-)
-
-game (
 	comment "Cool Boarders Pocket (Japan, Europe) (En,Ja)"
 	esrb_rating "E"
-	rom ( crc 62476C26 )
+	rom ( crc 2ED72635 )
 )
 
 game (
 	comment "Bust-A-Move Pocket (USA)"
 	esrb_rating "E"
-	rom ( crc 2DC1A1A3 )
+	rom ( crc B073D601 )
 )
 
 game (
-	comment "Bust-A-Move Pocket (USA) (Demo)"
+	comment "Bust-A-Move Pocket (USA) (Beta)"
 	esrb_rating "E"
 	rom ( crc 78A1361D )
 )
@@ -106,7 +100,7 @@ game (
 )
 
 game (
-	comment "Fatal Fury F-Contact - Pocket Fighting Series (World) (En,Ja)"
+	comment "Fatal Fury - First Contact - Pocket Fighting Series (World) (En,Ja)"
 	esrb_rating "E"
 	rom ( crc E7E5D6E8 )
 )
@@ -138,19 +132,13 @@ game (
 game (
 	comment "Last Blade, The - Beyond the Destiny (USA, Europe)"
 	esrb_rating "E"
-	rom ( crc 94FCFD1E )
+	rom ( crc 4238A840 )
 )
 
 game (
 	comment "Magical Drop Pocket (Japan)"
 	esrb_rating "E"
 	rom ( crc 694CE2DC )
-)
-
-game (
-	comment "Magical Drop Pocket (Japan) (Demo)"
-	esrb_rating "E"
-	rom ( crc D76F1A47 )
 )
 
 game (
@@ -166,12 +154,6 @@ game (
 )
 
 game (
-	comment "Metal Slug - 2nd Mission (World) (En,Ja) (Demo)"
-	esrb_rating "E"
-	rom ( crc 8B1647D4 )
-)
-
-game (
 	comment "Neo Cherry Master Color - Pocket Casino Series (World) (En,Ja)"
 	esrb_rating "E"
 	rom ( crc 2F6EB991 )
@@ -180,23 +162,17 @@ game (
 game (
 	comment "Neo Derby Champ Daiyosou (Japan)"
 	esrb_rating "E"
-	rom ( crc 98C6C4FD )
+	rom ( crc 4760564A )
 )
 
 game (
-	comment "Neo Cherry Master Color - Pocket Casino Series (World) (En,Ja) (Demo)"
-	esrb_rating "E"
-	rom ( crc 2F6EB991 )
-)
-
-game (
-	comment "Neo Dragon's Wild - Real Casino Series (World) (En,Ja) (v11)"
+	comment "Neo Dragon's Wild - Pocket Casino Series (World) (En,Ja) (v11)"
 	esrb_rating "E"
 	rom ( crc 225FD7F9 )
 )
 
 game (
-	comment "Neo Dragon's Wild - Real Casino Series (World) (En,Ja) (v13)"
+	comment "Neo Dragon's Wild - Pocket Casino Series (World) (En,Ja) (v13)"
 	esrb_rating "E"
 	rom ( crc 5D028C99 )
 )
@@ -208,15 +184,9 @@ game (
 )
 
 game (
-	comment "Neo Turf Masters (World) (En,Ja)"
+	comment "Neo Turf Masters - Pocket Sports Series (World) (En,Ja)"
 	esrb_rating "E"
-	rom ( crc D83C7981 )
-)
-
-game (
-	comment "Neo Turf Masters (World) (En,Ja) (Demo)"
-	esrb_rating "E"
-	rom ( crc 9DCA6ED6 )
+	rom ( crc E0E853DD )
 )
 
 game (
@@ -232,33 +202,33 @@ game (
 )
 
 game (
-	comment "Puyo Pop (World) (En,Ja) (v05)"
+	comment "Puyo Pop (Japan) (En,Ja) (v05)"
 	esrb_rating "E"
 	rom ( crc 3090B2FD )
 )
 
 game (
-	comment "Puyo Pop (World) (En,Ja) (v06)"
+	comment "Puyo Pop (USA) (En,Ja) (v06)"
 	esrb_rating "E"
-	rom ( crc 5C649D1E )
+	rom ( crc 5EA9559E )
 )
 
 game (
 	comment "Pocket Tennis Color - Pocket Sports Series (World) (En,Ja)"
 	esrb_rating "E"
-	rom ( crc 52F17827 )
+	rom ( crc E0B9AA22 )
 )
 
 game (
-	comment "Puzzle Bobble Mini (Japan, Europe) (En)"
+	comment "Puzzle Bobble Mini (Europe)"
 	esrb_rating "E"
-	rom ( crc 23AABF1E )
+	rom ( crc D31312DC )
 )
 
 game (
-	comment "Puzzle Bobble Mini (Japan, Europe) (En,Ja) (Demo)"
+	comment "Puzzle Bobble Mini (Japan) (En)"
 	esrb_rating "E"
-	rom ( crc 23AABF1E )
+	rom ( crc D6544F6C )
 )
 
 game (
@@ -306,7 +276,7 @@ game (
 game (
 	comment "SNK Gals' Fighters (Japan)"
 	esrb_rating "E"
-	rom ( crc 34B30474 )
+	rom ( crc D73B5B9F )
 )
 
 game (
@@ -334,33 +304,21 @@ game (
 )
 
 game (
-	comment "SNK vs. Capcom - Gekitotsu Card Fighters - SNK Supporter Version (Japan) (Beta)"
-	esrb_rating "E"
-	rom ( crc E70E3F1A )
-)
-
-game (
 	comment "SNK vs. Capcom - The Match of the Millennium (World) (En,Ja)"
 	esrb_rating "E"
 	rom ( crc 682A7A7B )
 )
 
 game (
-	comment "Sonic The Hedgehog - Pocket Adventure (World)"
+	comment "Sonic The Hedgehog - Pocket Adventure (World) (En,Ja)"
 	esrb_rating "E"
 	rom ( crc 8BD22145 )
 )
 
 game (
-	comment "SNK vs. Capcom - The Match of the Millennium (Japan) (Demo)"
+	comment "Sonic The Hedgehog - Pocket Adventure (World) (Beta)"
 	esrb_rating "E"
-	rom ( crc 1E19E307 )
-)
-
-game (
-	comment "Sonic The Hedgehog - Pocket Adventure (World) (Beta) (1999-10-22)"
-	esrb_rating "E"
-	rom ( crc D95D8E55 )
+	rom ( crc 45FC3BCA )
 )
 
 game (

--- a/metadat/franchise/SNK - Neo Geo Pocket Color.dat
+++ b/metadat/franchise/SNK - Neo Geo Pocket Color.dat
@@ -12,7 +12,7 @@ game (
 game (
 	comment "King of Fighters R-2 - Pocket Fighting Series (World) (En,Ja)"
 	franchise "The King of Fighters"
-	rom ( crc D5F69C02 )
+	rom ( crc 9BC63F27 )
 )
 
 game (
@@ -36,13 +36,13 @@ game (
 game (
 	comment "Metal Slug - 1st Mission (World) (En,Ja)"
 	franchise "Metal Slug"
-	rom ( crc 4C224504 )
+	rom ( crc D29EC1BA )
 )
 
 game (
 	comment "Metal Slug - 2nd Mission (World) (En,Ja)"
 	franchise "Metal Slug"
-	rom ( crc F4507FA5 )
+	rom ( crc 18E692A5 )
 )
 
 game (
@@ -72,7 +72,7 @@ game (
 game (
 	comment "Samurai Shodown! 2 - Pocket Fighting Series (World) (En,Ja)"
 	franchise "Samurai Shodown"
-	rom ( crc CE88B26D )
+	rom ( crc 58A62FB2 )
 )
 
 game (
@@ -90,7 +90,7 @@ game (
 game (
 	comment "Sonic The Hedgehog - Pocket Adventure (World)"
 	franchise "Sonic"
-	rom ( crc 0AD6BCF7 )
+	rom ( crc 8BD22145 )
 )
 
 game (

--- a/metadat/franchise/SNK - Neo Geo Pocket Color.dat
+++ b/metadat/franchise/SNK - Neo Geo Pocket Color.dat
@@ -4,7 +4,7 @@ clrmamepro (
 )
 
 game (
-	comment "Fatal Fury F-Contact - Pocket Fighting Series (World) (En,Ja)"
+	comment "Fatal Fury - First Contact - Pocket Fighting Series (World) (En,Ja)"
 	franchise "Fatal Fury"
 	rom ( crc E7E5D6E8 )
 )
@@ -46,27 +46,21 @@ game (
 )
 
 game (
-	comment "Metal Slug - 2nd Mission (World) (En,Ja) (Demo)"
-	franchise "Metal Slug"
-	rom ( crc 8B1647D4 )
-)
-
-game (
 	comment "Pac-Man (World) (En,Ja)"
 	franchise "Pac-Man"
 	rom ( crc 21E8CC15 )
 )
 
 game (
-	comment "Puyo Pop (World) (En,Ja) (v05)"
+	comment "Puyo Pop (Japan) (En,Ja) (v05)"
 	franchise "Puyo Puyo"
 	rom ( crc 3090B2FD )
 )
 
 game (
-	comment "Puyo Pop (World) (En,Ja) (v06)"
+	comment "Puyo Pop (USA) (En,Ja) (v06)"
 	franchise "Puyo Puyo"
-	rom ( crc 5C649D1E )
+	rom ( crc 5EA9559E )
 )
 
 game (
@@ -88,14 +82,14 @@ game (
 )
 
 game (
-	comment "Sonic The Hedgehog - Pocket Adventure (World)"
+	comment "Sonic The Hedgehog - Pocket Adventure (World) (En,Ja)"
 	franchise "Sonic"
 	rom ( crc 8BD22145 )
 )
 
 game (
-	comment "Sonic The Hedgehog - Pocket Adventure (World) (Beta) (1999-10-22)"
+	comment "Sonic The Hedgehog - Pocket Adventure (World) (Beta)"
 	franchise "Sonic"
-	rom ( crc D95D8E55 )
+	rom ( crc 45FC3BCA )
 )
 

--- a/metadat/genre/SNK - Neo Geo Pocket Color.dat
+++ b/metadat/genre/SNK - Neo Geo Pocket Color.dat
@@ -6,19 +6,19 @@ clrmamepro (
 game (
 	comment "Biomotor Unitron (Japan)"
 	genre "Role-playing (RPG)"
-	rom ( crc DC07E2EF )
+	rom ( crc FCBBE494 )
 )
 
 game (
 	comment "Big Bang Pro Wrestling (Japan) (En,Ja)"
 	genre "Sports"
-	rom ( crc B783C372 )
+	rom ( crc F1716FDF )
 )
 
 game (
 	comment "Bakumatsu Rouman Tokubetsu Hen - Gekka no Kenshi - Tsuki ni Saku Hana, Chiri Yuku Hana (Japan)"
 	genre "Action"
-	rom ( crc 5EB119BE )
+	rom ( crc BE913CFA )
 )
 
 game (
@@ -34,31 +34,25 @@ game (
 )
 
 game (
-	comment "Biomotor Unitron (Japan) (Demo)"
-	genre "Role-playing (RPG)"
-	rom ( crc 3D515243 )
-)
-
-game (
 	comment "Cool Cool Jam (Japan)"
 	genre "Music / Dancing"
-	rom ( crc 9B2A8331 )
+	rom ( crc 0FD6F378 )
 )
 
 game (
 	comment "Cool Boarders Pocket (Japan, Europe) (En,Ja)"
 	genre "Sports"
-	rom ( crc 62476C26 )
+	rom ( crc 2ED72635 )
 )
 
 game (
 	comment "Bust-A-Move Pocket (USA)"
 	genre "Strategy"
-	rom ( crc 2DC1A1A3 )
+	rom ( crc B073D601 )
 )
 
 game (
-	comment "Bust-A-Move Pocket (USA) (Demo)"
+	comment "Bust-A-Move Pocket (USA) (Beta)"
 	genre "Strategy"
 	rom ( crc 78A1361D )
 )
@@ -78,7 +72,7 @@ game (
 game (
 	comment "Delta Warp (Japan) (En,Ja)"
 	genre "Puzzle"
-	rom ( crc ADD4FDFF )
+	rom ( crc 1273B10E )
 )
 
 game (
@@ -94,21 +88,9 @@ game (
 )
 
 game (
-	comment "Densha de Go! 2 on Neo Geo Pocket (Japan)"
+	comment "Densha de Go! 2 on NeoGeo Pocket (Japan)"
 	genre "Simulation"
-	rom ( crc 0DA57257 )
-)
-
-game (
-	comment "Delta Warp (Japan) (Demo)"
-	genre "Puzzle"
-	rom ( crc A3C89788 )
-)
-
-game (
-	comment "Densha de Go! 2 on Neo Geo Pocket (Japan) (Beta)"
-	genre "Simulation"
-	rom ( crc 2FC4623E )
+	rom ( crc A0334549 )
 )
 
 game (
@@ -168,7 +150,7 @@ game (
 game (
 	comment "Evolution - Eternal Dungeons (Europe) (v03)"
 	genre "Role-playing (RPG)"
-	rom ( crc 3BF6BCC8 )
+	rom ( crc A60582F8 )
 )
 
 game (
@@ -190,7 +172,7 @@ game (
 )
 
 game (
-	comment "Fatal Fury F-Contact - Pocket Fighting Series (World) (En,Ja)"
+	comment "Fatal Fury - First Contact - Pocket Fighting Series (World) (En,Ja)"
 	genre "Fighting"
 	rom ( crc E7E5D6E8 )
 )
@@ -210,7 +192,7 @@ game (
 game (
 	comment "Kikou Seiki Unitron - Sono Tsuide. Hikari Umareru Chi Yori. (Japan)"
 	genre "Role-playing (RPG)"
-	rom ( crc C7C1FCF5 )
+	rom ( crc F029F1C0 )
 )
 
 game (
@@ -246,7 +228,7 @@ game (
 game (
 	comment "Koi Koi Mahjong (Japan) (v08)"
 	genre "Board"
-	rom ( crc 021F7D0C )
+	rom ( crc 75FE164C )
 )
 
 game (
@@ -258,7 +240,7 @@ game (
 game (
 	comment "Last Blade, The - Beyond the Destiny (USA, Europe)"
 	genre "Action"
-	rom ( crc 94FCFD1E )
+	rom ( crc 4238A840 )
 )
 
 game (
@@ -268,15 +250,9 @@ game (
 )
 
 game (
-	comment "Magical Drop Pocket (Japan) (Demo)"
-	genre "Puzzle"
-	rom ( crc D76F1A47 )
-)
-
-game (
 	comment "Memories Off - Pure (Japan)"
 	genre "Adventure"
-	rom ( crc A7926E90 )
+	rom ( crc 7F919DDE )
 )
 
 game (
@@ -304,12 +280,6 @@ game (
 )
 
 game (
-	comment "Metal Slug - 2nd Mission (World) (En,Ja) (Demo)"
-	genre "Shooter"
-	rom ( crc 8B1647D4 )
-)
-
-game (
 	comment "Neo Baccarat - Pocket Casino Series (Japan, Europe) (En) (v16)"
 	genre "Gambling"
 	rom ( crc 22AAB454 )
@@ -330,23 +300,17 @@ game (
 game (
 	comment "Neo Derby Champ Daiyosou (Japan)"
 	genre "Sports with Animals"
-	rom ( crc 98C6C4FD )
+	rom ( crc 4760564A )
 )
 
 game (
-	comment "Neo Cherry Master Color - Pocket Casino Series (World) (En,Ja) (Demo)"
-	genre "Gambling"
-	rom ( crc 2F6EB991 )
-)
-
-game (
-	comment "Neo Dragon's Wild - Real Casino Series (World) (En,Ja) (v11)"
+	comment "Neo Dragon's Wild - Pocket Casino Series (World) (En,Ja) (v11)"
 	genre "Gambling"
 	rom ( crc 225FD7F9 )
 )
 
 game (
-	comment "Neo Dragon's Wild - Real Casino Series (World) (En,Ja) (v13)"
+	comment "Neo Dragon's Wild - Pocket Casino Series (World) (En,Ja) (v13)"
 	genre "Gambling"
 	rom ( crc 5D028C99 )
 )
@@ -360,25 +324,19 @@ game (
 game (
 	comment "Neo Poke Pro Yakyuu (Japan) (v32)"
 	genre "Sports"
-	rom ( crc DF6435D7 )
+	rom ( crc C624388F )
 )
 
 game (
 	comment "Neo Poke Pro Yakyuu (Japan) (v1F)"
 	genre "Sports"
-	rom ( crc DF6435D7 )
+	rom ( crc 3CA883A5 )
 )
 
 game (
-	comment "Neo Turf Masters (World) (En,Ja)"
+	comment "Neo Turf Masters - Pocket Sports Series (World) (En,Ja)"
 	genre "Sports"
-	rom ( crc D83C7981 )
-)
-
-game (
-	comment "Neo Turf Masters (World) (En,Ja) (Demo)"
-	genre "Sports"
-	rom ( crc 9DCA6ED6 )
+	rom ( crc E0E853DD )
 )
 
 game (
@@ -390,13 +348,13 @@ game (
 game (
 	comment "Nige-ron-pa (Japan)"
 	genre "Role-playing (RPG)"
-	rom ( crc 3CC3E269 )
+	rom ( crc A9063D9E )
 )
 
 game (
 	comment "Oekaki Puzzle (Japan)"
 	genre "Puzzle"
-	rom ( crc CD657665 )
+	rom ( crc A9118E82 )
 )
 
 game (
@@ -406,7 +364,7 @@ game (
 )
 
 game (
-	comment "Pachi-slot Aruze Oukoku - Porcano 2 (Japan)"
+	comment "Pachi-Slot Aruze Oukoku - Porcano 2 (Japan)"
 	genre "Gambling"
 	rom ( crc 96DDFBE3 )
 )
@@ -414,19 +372,19 @@ game (
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Azteca (Japan) (v04)"
 	genre "Gambling"
-	rom ( crc BA74A414 )
+	rom ( crc 9FF16520 )
 )
 
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Azteca (Japan) (v03)"
 	genre "Gambling"
-	rom ( crc BA74A414 )
+	rom ( crc 2314440A )
 )
 
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Azteca (Japan) (v06)"
 	genre "Gambling"
-	rom ( crc BA74A414 )
+	rom ( crc C9B55E6B )
 )
 
 game (
@@ -450,13 +408,13 @@ game (
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - e-CUP (Japan) (v03)"
 	genre "Gambling"
-	rom ( crc 6571A5EF )
+	rom ( crc B5311753 )
 )
 
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Hanabi (Japan) (v03)"
 	genre "Gambling"
-	rom ( crc 54DD615E )
+	rom ( crc 4014FF42 )
 )
 
 game (
@@ -468,7 +426,7 @@ game (
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Hanabi (Japan) (v04)"
 	genre "Gambling"
-	rom ( crc 54DD615E )
+	rom ( crc 2A4F45AB )
 )
 
 game (
@@ -486,19 +444,19 @@ game (
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Ward of Lights (Japan) (v04)"
 	genre "Gambling"
-	rom ( crc 4A004B5E )
+	rom ( crc A54EC305 )
 )
 
 game (
 	comment "Pachinko Hisshou Guide - Pocket Parlor (Japan)"
 	genre "Gambling"
-	rom ( crc E43C4028 )
+	rom ( crc 543DC257 )
 )
 
 game (
 	comment "Pachinko Hisshou Guide - Pocket Parlor (Japan) (Beta)"
 	genre "Gambling"
-	rom ( crc E43C4028 )
+	rom ( crc CCF07C2F )
 )
 
 game (
@@ -510,55 +468,55 @@ game (
 game (
 	comment "Picture Puzzle (Europe)"
 	genre "Puzzle"
-	rom ( crc 0DBF93AC )
+	rom ( crc 6F2D35E6 )
 )
 
 game (
 	comment "Pocket Reversi (Europe) (vA1)"
 	genre "Puzzle"
-	rom ( crc 9250F099 )
+	rom ( crc 22C07C25 )
 )
 
 game (
 	comment "Pocket Reversi (Japan)"
 	genre "Puzzle"
-	rom ( crc 477D3A49 )
+	rom ( crc D115FEDF )
 )
 
 game (
 	comment "Pocket Reversi (Europe) (v03)"
 	genre "Puzzle"
-	rom ( crc 9250F099 )
+	rom ( crc 9589F2F2 )
 )
 
 game (
-	comment "Puyo Pop (World) (En,Ja) (v05)"
+	comment "Puyo Pop (Japan) (En,Ja) (v05)"
 	genre "Puzzle"
 	rom ( crc 3090B2FD )
 )
 
 game (
-	comment "Puyo Pop (World) (En,Ja) (v06)"
+	comment "Puyo Pop (USA) (En,Ja) (v06)"
 	genre "Puzzle"
-	rom ( crc 5C649D1E )
+	rom ( crc 5EA9559E )
 )
 
 game (
 	comment "Pocket Tennis Color - Pocket Sports Series (World) (En,Ja)"
 	genre "Sports"
-	rom ( crc 52F17827 )
+	rom ( crc E0B9AA22 )
 )
 
 game (
-	comment "Puzzle Bobble Mini (Japan, Europe) (En)"
+	comment "Puzzle Bobble Mini (Europe)"
 	genre "Strategy"
-	rom ( crc 23AABF1E )
+	rom ( crc D31312DC )
 )
 
 game (
-	comment "Puzzle Bobble Mini (Japan, Europe) (En,Ja) (Demo)"
+	comment "Puzzle Bobble Mini (Japan) (En)"
 	genre "Strategy"
-	rom ( crc 23AABF1E )
+	rom ( crc D6544F6C )
 )
 
 game (
@@ -580,15 +538,9 @@ game (
 )
 
 game (
-	comment "Rockman - Battle & Fighters (Japan) (Demo)"
-	genre "Fighting"
-	rom ( crc 16A98AC4 )
-)
-
-game (
 	comment "Rockman - Battle & Fighters (Japan)"
 	genre "Fighting"
-	rom ( crc 9C861E49 )
+	rom ( crc 3C010642 )
 )
 
 game (
@@ -630,7 +582,7 @@ game (
 game (
 	comment "SNK Gals' Fighters (Japan)"
 	genre "Fighting"
-	rom ( crc 34B30474 )
+	rom ( crc D73B5B9F )
 )
 
 game (
@@ -670,33 +622,21 @@ game (
 )
 
 game (
-	comment "SNK vs. Capcom - Gekitotsu Card Fighters - SNK Supporter Version (Japan) (Beta)"
-	genre "Strategy"
-	rom ( crc E70E3F1A )
-)
-
-game (
 	comment "SNK vs. Capcom - The Match of the Millennium (World) (En,Ja)"
 	genre "Fighting"
 	rom ( crc 682A7A7B )
 )
 
 game (
-	comment "Sonic The Hedgehog - Pocket Adventure (World)"
+	comment "Sonic The Hedgehog - Pocket Adventure (World) (En,Ja)"
 	genre "Platform"
 	rom ( crc 8BD22145 )
 )
 
 game (
-	comment "SNK vs. Capcom - The Match of the Millennium (Japan) (Demo)"
-	genre "Fighting"
-	rom ( crc 1E19E307 )
-)
-
-game (
-	comment "Sonic The Hedgehog - Pocket Adventure (World) (Beta) (1999-10-22)"
+	comment "Sonic The Hedgehog - Pocket Adventure (World) (Beta)"
 	genre "Platform"
-	rom ( crc D95D8E55 )
+	rom ( crc 45FC3BCA )
 )
 
 game (

--- a/metadat/genre/SNK - Neo Geo Pocket Color.dat
+++ b/metadat/genre/SNK - Neo Geo Pocket Color.dat
@@ -216,7 +216,7 @@ game (
 game (
 	comment "King of Fighters R-2 - Pocket Fighting Series (World) (En,Ja)"
 	genre "Fighting"
-	rom ( crc D5F69C02 )
+	rom ( crc 9BC63F27 )
 )
 
 game (
@@ -282,13 +282,13 @@ game (
 game (
 	comment "Metal Slug - 1st Mission (World) (En,Ja)"
 	genre "Shooter"
-	rom ( crc 4C224504 )
+	rom ( crc D29EC1BA )
 )
 
 game (
 	comment "Metal Slug - 2nd Mission (World) (En,Ja)"
 	genre "Shooter"
-	rom ( crc F4507FA5 )
+	rom ( crc 18E692A5 )
 )
 
 game (
@@ -600,7 +600,7 @@ game (
 game (
 	comment "Samurai Shodown! 2 - Pocket Fighting Series (World) (En,Ja)"
 	genre "Fighting"
-	rom ( crc CE88B26D )
+	rom ( crc 58A62FB2 )
 )
 
 game (
@@ -678,19 +678,19 @@ game (
 game (
 	comment "SNK vs. Capcom - The Match of the Millennium (World) (En,Ja)"
 	genre "Fighting"
-	rom ( crc A54C3026 )
+	rom ( crc 682A7A7B )
 )
 
 game (
 	comment "Sonic The Hedgehog - Pocket Adventure (World)"
 	genre "Platform"
-	rom ( crc 0AD6BCF7 )
+	rom ( crc 8BD22145 )
 )
 
 game (
 	comment "SNK vs. Capcom - The Match of the Millennium (Japan) (Demo)"
 	genre "Fighting"
-	rom ( crc A54C3026 )
+	rom ( crc 1E19E307 )
 )
 
 game (

--- a/metadat/maxusers/SNK - Neo Geo Pocket Color.dat
+++ b/metadat/maxusers/SNK - Neo Geo Pocket Color.dat
@@ -216,7 +216,7 @@ game (
 game (
 	comment "King of Fighters R-2 - Pocket Fighting Series (World) (En,Ja)"
 	users 2
-	rom ( crc D5F69C02 )
+	rom ( crc 9BC63F27 )
 )
 
 game (
@@ -270,13 +270,13 @@ game (
 game (
 	comment "Metal Slug - 1st Mission (World) (En,Ja)"
 	users 1
-	rom ( crc 4C224504 )
+	rom ( crc D29EC1BA )
 )
 
 game (
 	comment "Metal Slug - 2nd Mission (World) (En,Ja)"
 	users 1
-	rom ( crc F4507FA5 )
+	rom ( crc 18E692A5 )
 )
 
 game (
@@ -600,7 +600,7 @@ game (
 game (
 	comment "Samurai Shodown! 2 - Pocket Fighting Series (World) (En,Ja)"
 	users 2
-	rom ( crc CE88B26D )
+	rom ( crc 58A62FB2 )
 )
 
 game (
@@ -678,19 +678,19 @@ game (
 game (
 	comment "SNK vs. Capcom - The Match of the Millennium (World) (En,Ja)"
 	users 2
-	rom ( crc A54C3026 )
+	rom ( crc 682A7A7B )
 )
 
 game (
 	comment "Sonic The Hedgehog - Pocket Adventure (World)"
 	users 2
-	rom ( crc 0AD6BCF7 )
+	rom ( crc 8BD22145 )
 )
 
 game (
 	comment "SNK vs. Capcom - The Match of the Millennium (Japan) (Demo)"
 	users 2
-	rom ( crc A54C3026 )
+	rom ( crc 1E19E307 )
 )
 
 game (

--- a/metadat/maxusers/SNK - Neo Geo Pocket Color.dat
+++ b/metadat/maxusers/SNK - Neo Geo Pocket Color.dat
@@ -6,19 +6,19 @@ clrmamepro (
 game (
 	comment "Biomotor Unitron (Japan)"
 	users 2
-	rom ( crc DC07E2EF )
+	rom ( crc FCBBE494 )
 )
 
 game (
 	comment "Big Bang Pro Wrestling (Japan) (En,Ja)"
 	users 2
-	rom ( crc B783C372 )
+	rom ( crc F1716FDF )
 )
 
 game (
 	comment "Bakumatsu Rouman Tokubetsu Hen - Gekka no Kenshi - Tsuki ni Saku Hana, Chiri Yuku Hana (Japan)"
 	users 2
-	rom ( crc 5EB119BE )
+	rom ( crc BE913CFA )
 )
 
 game (
@@ -34,31 +34,25 @@ game (
 )
 
 game (
-	comment "Biomotor Unitron (Japan) (Demo)"
-	users 2
-	rom ( crc 3D515243 )
-)
-
-game (
 	comment "Cool Cool Jam (Japan)"
 	users 2
-	rom ( crc 9B2A8331 )
+	rom ( crc 0FD6F378 )
 )
 
 game (
 	comment "Cool Boarders Pocket (Japan, Europe) (En,Ja)"
 	users 1
-	rom ( crc 62476C26 )
+	rom ( crc 2ED72635 )
 )
 
 game (
 	comment "Bust-A-Move Pocket (USA)"
 	users 2
-	rom ( crc 2DC1A1A3 )
+	rom ( crc B073D601 )
 )
 
 game (
-	comment "Bust-A-Move Pocket (USA) (Demo)"
+	comment "Bust-A-Move Pocket (USA) (Beta)"
 	users 2
 	rom ( crc 78A1361D )
 )
@@ -78,7 +72,7 @@ game (
 game (
 	comment "Delta Warp (Japan) (En,Ja)"
 	users 2
-	rom ( crc ADD4FDFF )
+	rom ( crc 1273B10E )
 )
 
 game (
@@ -94,21 +88,9 @@ game (
 )
 
 game (
-	comment "Densha de Go! 2 on Neo Geo Pocket (Japan)"
+	comment "Densha de Go! 2 on NeoGeo Pocket (Japan)"
 	users 2
-	rom ( crc 0DA57257 )
-)
-
-game (
-	comment "Delta Warp (Japan) (Demo)"
-	users 2
-	rom ( crc A3C89788 )
-)
-
-game (
-	comment "Densha de Go! 2 on Neo Geo Pocket (Japan) (Beta)"
-	users 2
-	rom ( crc 2FC4623E )
+	rom ( crc A0334549 )
 )
 
 game (
@@ -168,7 +150,7 @@ game (
 game (
 	comment "Evolution - Eternal Dungeons (Europe) (v03)"
 	users 2
-	rom ( crc 3BF6BCC8 )
+	rom ( crc A60582F8 )
 )
 
 game (
@@ -190,7 +172,7 @@ game (
 )
 
 game (
-	comment "Fatal Fury F-Contact - Pocket Fighting Series (World) (En,Ja)"
+	comment "Fatal Fury - First Contact - Pocket Fighting Series (World) (En,Ja)"
 	users 2
 	rom ( crc E7E5D6E8 )
 )
@@ -210,7 +192,7 @@ game (
 game (
 	comment "Kikou Seiki Unitron - Sono Tsuide. Hikari Umareru Chi Yori. (Japan)"
 	users 2
-	rom ( crc C7C1FCF5 )
+	rom ( crc F029F1C0 )
 )
 
 game (
@@ -246,7 +228,7 @@ game (
 game (
 	comment "Last Blade, The - Beyond the Destiny (USA, Europe)"
 	users 2
-	rom ( crc 94FCFD1E )
+	rom ( crc 4238A840 )
 )
 
 game (
@@ -256,15 +238,9 @@ game (
 )
 
 game (
-	comment "Magical Drop Pocket (Japan) (Demo)"
-	users 2
-	rom ( crc D76F1A47 )
-)
-
-game (
 	comment "Memories Off - Pure (Japan)"
 	users 1
-	rom ( crc A7926E90 )
+	rom ( crc 7F919DDE )
 )
 
 game (
@@ -292,12 +268,6 @@ game (
 )
 
 game (
-	comment "Metal Slug - 2nd Mission (World) (En,Ja) (Demo)"
-	users 1
-	rom ( crc 8B1647D4 )
-)
-
-game (
 	comment "Neo Baccarat - Pocket Casino Series (Japan, Europe) (En) (v16)"
 	users 2
 	rom ( crc 22AAB454 )
@@ -318,23 +288,17 @@ game (
 game (
 	comment "Neo Derby Champ Daiyosou (Japan)"
 	users 1
-	rom ( crc 98C6C4FD )
+	rom ( crc 4760564A )
 )
 
 game (
-	comment "Neo Cherry Master Color - Pocket Casino Series (World) (En,Ja) (Demo)"
-	users 2
-	rom ( crc 2F6EB991 )
-)
-
-game (
-	comment "Neo Dragon's Wild - Real Casino Series (World) (En,Ja) (v11)"
+	comment "Neo Dragon's Wild - Pocket Casino Series (World) (En,Ja) (v11)"
 	users 1
 	rom ( crc 225FD7F9 )
 )
 
 game (
-	comment "Neo Dragon's Wild - Real Casino Series (World) (En,Ja) (v13)"
+	comment "Neo Dragon's Wild - Pocket Casino Series (World) (En,Ja) (v13)"
 	users 1
 	rom ( crc 5D028C99 )
 )
@@ -348,25 +312,19 @@ game (
 game (
 	comment "Neo Poke Pro Yakyuu (Japan) (v32)"
 	users 2
-	rom ( crc DF6435D7 )
+	rom ( crc C624388F )
 )
 
 game (
 	comment "Neo Poke Pro Yakyuu (Japan) (v1F)"
 	users 2
-	rom ( crc DF6435D7 )
+	rom ( crc 3CA883A5 )
 )
 
 game (
-	comment "Neo Turf Masters (World) (En,Ja)"
+	comment "Neo Turf Masters - Pocket Sports Series (World) (En,Ja)"
 	users 2
-	rom ( crc D83C7981 )
-)
-
-game (
-	comment "Neo Turf Masters (World) (En,Ja) (Demo)"
-	users 2
-	rom ( crc 9DCA6ED6 )
+	rom ( crc E0E853DD )
 )
 
 game (
@@ -378,13 +336,13 @@ game (
 game (
 	comment "Nige-ron-pa (Japan)"
 	users 1
-	rom ( crc 3CC3E269 )
+	rom ( crc A9063D9E )
 )
 
 game (
 	comment "Oekaki Puzzle (Japan)"
 	users 1
-	rom ( crc CD657665 )
+	rom ( crc A9118E82 )
 )
 
 game (
@@ -394,7 +352,7 @@ game (
 )
 
 game (
-	comment "Pachi-slot Aruze Oukoku - Porcano 2 (Japan)"
+	comment "Pachi-Slot Aruze Oukoku - Porcano 2 (Japan)"
 	users 1
 	rom ( crc 96DDFBE3 )
 )
@@ -402,19 +360,19 @@ game (
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Azteca (Japan) (v04)"
 	users 1
-	rom ( crc BA74A414 )
+	rom ( crc 9FF16520 )
 )
 
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Azteca (Japan) (v03)"
 	users 1
-	rom ( crc BA74A414 )
+	rom ( crc 2314440A )
 )
 
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Azteca (Japan) (v06)"
 	users 1
-	rom ( crc BA74A414 )
+	rom ( crc C9B55E6B )
 )
 
 game (
@@ -438,13 +396,13 @@ game (
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - e-CUP (Japan) (v03)"
 	users 1
-	rom ( crc 6571A5EF )
+	rom ( crc B5311753 )
 )
 
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Hanabi (Japan) (v03)"
 	users 1
-	rom ( crc 54DD615E )
+	rom ( crc 4014FF42 )
 )
 
 game (
@@ -456,7 +414,7 @@ game (
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Hanabi (Japan) (v04)"
 	users 1
-	rom ( crc 54DD615E )
+	rom ( crc 2A4F45AB )
 )
 
 game (
@@ -474,19 +432,19 @@ game (
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Ward of Lights (Japan) (v04)"
 	users 1
-	rom ( crc 4A004B5E )
+	rom ( crc A54EC305 )
 )
 
 game (
 	comment "Pachinko Hisshou Guide - Pocket Parlor (Japan)"
 	users 1
-	rom ( crc E43C4028 )
+	rom ( crc 543DC257 )
 )
 
 game (
 	comment "Pachinko Hisshou Guide - Pocket Parlor (Japan) (Beta)"
 	users 1
-	rom ( crc E43C4028 )
+	rom ( crc CCF07C2F )
 )
 
 game (
@@ -510,55 +468,55 @@ game (
 game (
 	comment "Picture Puzzle (Europe)"
 	users 1
-	rom ( crc 0DBF93AC )
+	rom ( crc 6F2D35E6 )
 )
 
 game (
 	comment "Pocket Reversi (Europe) (vA1)"
 	users 1
-	rom ( crc 9250F099 )
+	rom ( crc 22C07C25 )
 )
 
 game (
 	comment "Pocket Reversi (Japan)"
 	users 1
-	rom ( crc 477D3A49 )
+	rom ( crc D115FEDF )
 )
 
 game (
 	comment "Pocket Reversi (Europe) (v03)"
 	users 1
-	rom ( crc 9250F099 )
+	rom ( crc 9589F2F2 )
 )
 
 game (
-	comment "Puyo Pop (World) (En,Ja) (v05)"
+	comment "Puyo Pop (Japan) (En,Ja) (v05)"
 	users 1
 	rom ( crc 3090B2FD )
 )
 
 game (
-	comment "Puyo Pop (World) (En,Ja) (v06)"
+	comment "Puyo Pop (USA) (En,Ja) (v06)"
 	users 1
-	rom ( crc 5C649D1E )
+	rom ( crc 5EA9559E )
 )
 
 game (
 	comment "Pocket Tennis Color - Pocket Sports Series (World) (En,Ja)"
 	users 1
-	rom ( crc 52F17827 )
+	rom ( crc E0B9AA22 )
 )
 
 game (
-	comment "Puzzle Bobble Mini (Japan, Europe) (En)"
+	comment "Puzzle Bobble Mini (Europe)"
 	users 2
-	rom ( crc 23AABF1E )
+	rom ( crc D31312DC )
 )
 
 game (
-	comment "Puzzle Bobble Mini (Japan, Europe) (En,Ja) (Demo)"
+	comment "Puzzle Bobble Mini (Japan) (En)"
 	users 2
-	rom ( crc 23AABF1E )
+	rom ( crc D6544F6C )
 )
 
 game (
@@ -580,15 +538,9 @@ game (
 )
 
 game (
-	comment "Rockman - Battle & Fighters (Japan) (Demo)"
-	users 1
-	rom ( crc 16A98AC4 )
-)
-
-game (
 	comment "Rockman - Battle & Fighters (Japan)"
 	users 1
-	rom ( crc 9C861E49 )
+	rom ( crc 3C010642 )
 )
 
 game (
@@ -630,7 +582,7 @@ game (
 game (
 	comment "SNK Gals' Fighters (Japan)"
 	users 2
-	rom ( crc 34B30474 )
+	rom ( crc D73B5B9F )
 )
 
 game (
@@ -670,33 +622,21 @@ game (
 )
 
 game (
-	comment "SNK vs. Capcom - Gekitotsu Card Fighters - SNK Supporter Version (Japan) (Beta)"
-	users 2
-	rom ( crc E70E3F1A )
-)
-
-game (
 	comment "SNK vs. Capcom - The Match of the Millennium (World) (En,Ja)"
 	users 2
 	rom ( crc 682A7A7B )
 )
 
 game (
-	comment "Sonic The Hedgehog - Pocket Adventure (World)"
+	comment "Sonic The Hedgehog - Pocket Adventure (World) (En,Ja)"
 	users 2
 	rom ( crc 8BD22145 )
 )
 
 game (
-	comment "SNK vs. Capcom - The Match of the Millennium (Japan) (Demo)"
+	comment "Sonic The Hedgehog - Pocket Adventure (World) (Beta)"
 	users 2
-	rom ( crc 1E19E307 )
-)
-
-game (
-	comment "Sonic The Hedgehog - Pocket Adventure (World) (Beta) (1999-10-22)"
-	users 2
-	rom ( crc D95D8E55 )
+	rom ( crc 45FC3BCA )
 )
 
 game (

--- a/metadat/publisher/SNK - Neo Geo Pocket Color.dat
+++ b/metadat/publisher/SNK - Neo Geo Pocket Color.dat
@@ -204,7 +204,7 @@ game (
 game (
 	comment "King of Fighters R-2 - Pocket Fighting Series (World) (En,Ja)"
 	publisher "SNK"
-	rom ( crc D5F69C02 )
+	rom ( crc 9BC63F27 )
 )
 
 game (
@@ -270,13 +270,13 @@ game (
 game (
 	comment "Metal Slug - 1st Mission (World) (En,Ja)"
 	publisher "SNK"
-	rom ( crc 4C224504 )
+	rom ( crc D29EC1BA )
 )
 
 game (
 	comment "Metal Slug - 2nd Mission (World) (En,Ja)"
 	publisher "SNK"
-	rom ( crc F4507FA5 )
+	rom ( crc 18E692A5 )
 )
 
 game (
@@ -600,7 +600,7 @@ game (
 game (
 	comment "Samurai Shodown! 2 - Pocket Fighting Series (World) (En,Ja)"
 	publisher "SNK"
-	rom ( crc CE88B26D )
+	rom ( crc 58A62FB2 )
 )
 
 game (
@@ -678,19 +678,19 @@ game (
 game (
 	comment "SNK vs. Capcom - The Match of the Millennium (World) (En,Ja)"
 	publisher "Capcom"
-	rom ( crc A54C3026 )
+	rom ( crc 682A7A7B )
 )
 
 game (
 	comment "Sonic The Hedgehog - Pocket Adventure (World)"
 	publisher "SNK"
-	rom ( crc 0AD6BCF7 )
+	rom ( crc 8BD22145 )
 )
 
 game (
 	comment "SNK vs. Capcom - The Match of the Millennium (Japan) (Demo)"
 	publisher "Capcom"
-	rom ( crc A54C3026 )
+	rom ( crc 1E19E307 )
 )
 
 game (

--- a/metadat/publisher/SNK - Neo Geo Pocket Color.dat
+++ b/metadat/publisher/SNK - Neo Geo Pocket Color.dat
@@ -6,19 +6,19 @@ clrmamepro (
 game (
 	comment "Biomotor Unitron (Japan)"
 	publisher "SNK"
-	rom ( crc DC07E2EF )
+	rom ( crc FCBBE494 )
 )
 
 game (
 	comment "Big Bang Pro Wrestling (Japan) (En,Ja)"
 	publisher "SNK"
-	rom ( crc B783C372 )
+	rom ( crc F1716FDF )
 )
 
 game (
 	comment "Bakumatsu Rouman Tokubetsu Hen - Gekka no Kenshi - Tsuki ni Saku Hana, Chiri Yuku Hana (Japan)"
 	publisher "SNK"
-	rom ( crc 5EB119BE )
+	rom ( crc BE913CFA )
 )
 
 game (
@@ -34,31 +34,25 @@ game (
 )
 
 game (
-	comment "Biomotor Unitron (Japan) (Demo)"
-	publisher "SNK"
-	rom ( crc 3D515243 )
-)
-
-game (
 	comment "Cool Cool Jam (Japan)"
 	publisher "SNK"
-	rom ( crc 9B2A8331 )
+	rom ( crc 0FD6F378 )
 )
 
 game (
 	comment "Cool Boarders Pocket (Japan, Europe) (En,Ja)"
 	publisher "SNK"
-	rom ( crc 62476C26 )
+	rom ( crc 2ED72635 )
 )
 
 game (
 	comment "Bust-A-Move Pocket (USA)"
 	publisher "SNK"
-	rom ( crc 2DC1A1A3 )
+	rom ( crc B073D601 )
 )
 
 game (
-	comment "Bust-A-Move Pocket (USA) (Demo)"
+	comment "Bust-A-Move Pocket (USA) (Beta)"
 	publisher "SNK"
 	rom ( crc 78A1361D )
 )
@@ -78,7 +72,7 @@ game (
 game (
 	comment "Delta Warp (Japan) (En,Ja)"
 	publisher "SNK"
-	rom ( crc ADD4FDFF )
+	rom ( crc 1273B10E )
 )
 
 game (
@@ -91,12 +85,6 @@ game (
 	comment "Densetsu no Ogre Battle Gaiden - Zenobia no Ouji (Japan)"
 	publisher "Quest"
 	rom ( crc EEEEFD6A )
-)
-
-game (
-	comment "Delta Warp (Japan) (Demo)"
-	publisher "SNK"
-	rom ( crc A3C89788 )
 )
 
 game (
@@ -156,7 +144,7 @@ game (
 game (
 	comment "Evolution - Eternal Dungeons (Europe) (v03)"
 	publisher "SEGA"
-	rom ( crc 3BF6BCC8 )
+	rom ( crc A60582F8 )
 )
 
 game (
@@ -178,7 +166,7 @@ game (
 )
 
 game (
-	comment "Fatal Fury F-Contact - Pocket Fighting Series (World) (En,Ja)"
+	comment "Fatal Fury - First Contact - Pocket Fighting Series (World) (En,Ja)"
 	publisher "SNK"
 	rom ( crc E7E5D6E8 )
 )
@@ -198,7 +186,7 @@ game (
 game (
 	comment "Kikou Seiki Unitron - Sono Tsuide. Hikari Umareru Chi Yori. (Japan)"
 	publisher "SNK"
-	rom ( crc C7C1FCF5 )
+	rom ( crc F029F1C0 )
 )
 
 game (
@@ -234,7 +222,7 @@ game (
 game (
 	comment "Koi Koi Mahjong (Japan) (v08)"
 	publisher "Visco"
-	rom ( crc 021F7D0C )
+	rom ( crc 75FE164C )
 )
 
 game (
@@ -246,7 +234,7 @@ game (
 game (
 	comment "Last Blade, The - Beyond the Destiny (USA, Europe)"
 	publisher "SNK"
-	rom ( crc 94FCFD1E )
+	rom ( crc 4238A840 )
 )
 
 game (
@@ -256,15 +244,9 @@ game (
 )
 
 game (
-	comment "Magical Drop Pocket (Japan) (Demo)"
-	publisher "SNK"
-	rom ( crc D76F1A47 )
-)
-
-game (
 	comment "Memories Off - Pure (Japan)"
 	publisher "Kindle Imagine Develop"
-	rom ( crc A7926E90 )
+	rom ( crc 7F919DDE )
 )
 
 game (
@@ -292,12 +274,6 @@ game (
 )
 
 game (
-	comment "Metal Slug - 2nd Mission (World) (En,Ja) (Demo)"
-	publisher "SNK"
-	rom ( crc 8B1647D4 )
-)
-
-game (
 	comment "Neo Baccarat - Pocket Casino Series (Japan, Europe) (En) (v16)"
 	publisher "Dyna Corp."
 	rom ( crc 22AAB454 )
@@ -318,23 +294,17 @@ game (
 game (
 	comment "Neo Derby Champ Daiyosou (Japan)"
 	publisher "Dyna Corporation"
-	rom ( crc 98C6C4FD )
+	rom ( crc 4760564A )
 )
 
 game (
-	comment "Neo Cherry Master Color - Pocket Casino Series (World) (En,Ja) (Demo)"
-	publisher "SNK"
-	rom ( crc 2F6EB991 )
-)
-
-game (
-	comment "Neo Dragon's Wild - Real Casino Series (World) (En,Ja) (v11)"
+	comment "Neo Dragon's Wild - Pocket Casino Series (World) (En,Ja) (v11)"
 	publisher "SNK"
 	rom ( crc 225FD7F9 )
 )
 
 game (
-	comment "Neo Dragon's Wild - Real Casino Series (World) (En,Ja) (v13)"
+	comment "Neo Dragon's Wild - Pocket Casino Series (World) (En,Ja) (v13)"
 	publisher "SNK"
 	rom ( crc 5D028C99 )
 )
@@ -348,25 +318,19 @@ game (
 game (
 	comment "Neo Poke Pro Yakyuu (Japan) (v32)"
 	publisher "SNK"
-	rom ( crc DF6435D7 )
+	rom ( crc C624388F )
 )
 
 game (
 	comment "Neo Poke Pro Yakyuu (Japan) (v1F)"
 	publisher "SNK"
-	rom ( crc DF6435D7 )
+	rom ( crc 3CA883A5 )
 )
 
 game (
-	comment "Neo Turf Masters (World) (En,Ja)"
+	comment "Neo Turf Masters - Pocket Sports Series (World) (En,Ja)"
 	publisher "SNK"
-	rom ( crc D83C7981 )
-)
-
-game (
-	comment "Neo Turf Masters (World) (En,Ja) (Demo)"
-	publisher "SNK"
-	rom ( crc 9DCA6ED6 )
+	rom ( crc E0E853DD )
 )
 
 game (
@@ -378,13 +342,13 @@ game (
 game (
 	comment "Nige-ron-pa (Japan)"
 	publisher "Dennou Eizou"
-	rom ( crc 3CC3E269 )
+	rom ( crc A9063D9E )
 )
 
 game (
 	comment "Oekaki Puzzle (Japan)"
 	publisher "SNK"
-	rom ( crc CD657665 )
+	rom ( crc A9118E82 )
 )
 
 game (
@@ -394,7 +358,7 @@ game (
 )
 
 game (
-	comment "Pachi-slot Aruze Oukoku - Porcano 2 (Japan)"
+	comment "Pachi-Slot Aruze Oukoku - Porcano 2 (Japan)"
 	publisher "Aruze Corp"
 	rom ( crc 96DDFBE3 )
 )
@@ -402,19 +366,19 @@ game (
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Azteca (Japan) (v04)"
 	publisher "Aruze Corp"
-	rom ( crc BA74A414 )
+	rom ( crc 9FF16520 )
 )
 
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Azteca (Japan) (v03)"
 	publisher "Aruze Corp"
-	rom ( crc BA74A414 )
+	rom ( crc 2314440A )
 )
 
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Azteca (Japan) (v06)"
 	publisher "Aruze Corp"
-	rom ( crc BA74A414 )
+	rom ( crc C9B55E6B )
 )
 
 game (
@@ -438,13 +402,13 @@ game (
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - e-CUP (Japan) (v03)"
 	publisher "Aruze Corp"
-	rom ( crc 6571A5EF )
+	rom ( crc B5311753 )
 )
 
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Hanabi (Japan) (v03)"
 	publisher "Aruze Corp"
-	rom ( crc 54DD615E )
+	rom ( crc 4014FF42 )
 )
 
 game (
@@ -456,7 +420,7 @@ game (
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Hanabi (Japan) (v04)"
 	publisher "Aruze Corp"
-	rom ( crc 54DD615E )
+	rom ( crc 2A4F45AB )
 )
 
 game (
@@ -474,19 +438,19 @@ game (
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Ward of Lights (Japan) (v04)"
 	publisher "Aruze Corp"
-	rom ( crc 4A004B5E )
+	rom ( crc A54EC305 )
 )
 
 game (
 	comment "Pachinko Hisshou Guide - Pocket Parlor (Japan)"
 	publisher "Sankyo"
-	rom ( crc E43C4028 )
+	rom ( crc 543DC257 )
 )
 
 game (
 	comment "Pachinko Hisshou Guide - Pocket Parlor (Japan) (Beta)"
 	publisher "Sankyo"
-	rom ( crc E43C4028 )
+	rom ( crc CCF07C2F )
 )
 
 game (
@@ -510,55 +474,55 @@ game (
 game (
 	comment "Picture Puzzle (Europe)"
 	publisher "SNK"
-	rom ( crc 0DBF93AC )
+	rom ( crc 6F2D35E6 )
 )
 
 game (
 	comment "Pocket Reversi (Europe) (vA1)"
 	publisher "SNK"
-	rom ( crc 9250F099 )
+	rom ( crc 22C07C25 )
 )
 
 game (
 	comment "Pocket Reversi (Japan)"
 	publisher "SNK"
-	rom ( crc 477D3A49 )
+	rom ( crc D115FEDF )
 )
 
 game (
 	comment "Pocket Reversi (Europe) (v03)"
 	publisher "SNK"
-	rom ( crc 9250F099 )
+	rom ( crc 9589F2F2 )
 )
 
 game (
-	comment "Puyo Pop (World) (En,Ja) (v05)"
+	comment "Puyo Pop (Japan) (En,Ja) (v05)"
 	publisher "SNK"
 	rom ( crc 3090B2FD )
 )
 
 game (
-	comment "Puyo Pop (World) (En,Ja) (v06)"
+	comment "Puyo Pop (USA) (En,Ja) (v06)"
 	publisher "SNK"
-	rom ( crc 5C649D1E )
+	rom ( crc 5EA9559E )
 )
 
 game (
 	comment "Pocket Tennis Color - Pocket Sports Series (World) (En,Ja)"
 	publisher "SNK"
-	rom ( crc 52F17827 )
+	rom ( crc E0B9AA22 )
 )
 
 game (
-	comment "Puzzle Bobble Mini (Japan, Europe) (En)"
+	comment "Puzzle Bobble Mini (Europe)"
 	publisher "SNK"
-	rom ( crc 23AABF1E )
+	rom ( crc D31312DC )
 )
 
 game (
-	comment "Puzzle Bobble Mini (Japan, Europe) (En,Ja) (Demo)"
+	comment "Puzzle Bobble Mini (Japan) (En)"
 	publisher "SNK"
-	rom ( crc 23AABF1E )
+	rom ( crc D6544F6C )
 )
 
 game (
@@ -580,15 +544,9 @@ game (
 )
 
 game (
-	comment "Rockman - Battle & Fighters (Japan) (Demo)"
-	publisher "Capcom"
-	rom ( crc 16A98AC4 )
-)
-
-game (
 	comment "Rockman - Battle & Fighters (Japan)"
 	publisher "Capcom"
-	rom ( crc 9C861E49 )
+	rom ( crc 3C010642 )
 )
 
 game (
@@ -630,7 +588,7 @@ game (
 game (
 	comment "SNK Gals' Fighters (Japan)"
 	publisher "SNK"
-	rom ( crc 34B30474 )
+	rom ( crc D73B5B9F )
 )
 
 game (
@@ -670,33 +628,21 @@ game (
 )
 
 game (
-	comment "SNK vs. Capcom - Gekitotsu Card Fighters - SNK Supporter Version (Japan) (Beta)"
-	publisher "Capcom"
-	rom ( crc E70E3F1A )
-)
-
-game (
 	comment "SNK vs. Capcom - The Match of the Millennium (World) (En,Ja)"
 	publisher "Capcom"
 	rom ( crc 682A7A7B )
 )
 
 game (
-	comment "Sonic The Hedgehog - Pocket Adventure (World)"
+	comment "Sonic The Hedgehog - Pocket Adventure (World) (En,Ja)"
 	publisher "SNK"
 	rom ( crc 8BD22145 )
 )
 
 game (
-	comment "SNK vs. Capcom - The Match of the Millennium (Japan) (Demo)"
-	publisher "Capcom"
-	rom ( crc 1E19E307 )
-)
-
-game (
-	comment "Sonic The Hedgehog - Pocket Adventure (World) (Beta) (1999-10-22)"
+	comment "Sonic The Hedgehog - Pocket Adventure (World) (Beta)"
 	publisher "SNK"
-	rom ( crc D95D8E55 )
+	rom ( crc 45FC3BCA )
 )
 
 game (

--- a/metadat/releaseyear/SNK - Neo Geo Pocket Color.dat
+++ b/metadat/releaseyear/SNK - Neo Geo Pocket Color.dat
@@ -150,7 +150,7 @@ game (
 game (
 	comment "King of Fighters R-2 - Pocket Fighting Series (World) (En,Ja)"
 	releaseyear "1999"
-	rom ( crc D5F69C02 )
+	rom ( crc 9BC63F27 )
 )
 
 game (
@@ -210,13 +210,13 @@ game (
 game (
 	comment "Metal Slug - 1st Mission (World) (En,Ja)"
 	releaseyear "1999"
-	rom ( crc 4C224504 )
+	rom ( crc D29EC1BA )
 )
 
 game (
 	comment "Metal Slug - 2nd Mission (World) (En,Ja)"
 	releaseyear "2000"
-	rom ( crc F4507FA5 )
+	rom ( crc 18E692A5 )
 )
 
 game (
@@ -492,7 +492,7 @@ game (
 game (
 	comment "Samurai Shodown! 2 - Pocket Fighting Series (World) (En,Ja)"
 	releaseyear "1999"
-	rom ( crc CE88B26D )
+	rom ( crc 58A62FB2 )
 )
 
 game (
@@ -552,19 +552,19 @@ game (
 game (
 	comment "SNK vs. Capcom - The Match of the Millennium (World) (En,Ja)"
 	releaseyear "1999"
-	rom ( crc A54C3026 )
+	rom ( crc 682A7A7B )
 )
 
 game (
 	comment "Sonic The Hedgehog - Pocket Adventure (World)"
 	releaseyear "1999"
-	rom ( crc 0AD6BCF7 )
+	rom ( crc 8BD22145 )
 )
 
 game (
 	comment "SNK vs. Capcom - The Match of the Millennium (Japan) (Demo)"
 	releaseyear "1999"
-	rom ( crc A54C3026 )
+	rom ( crc 1E19E307 )
 )
 
 game (

--- a/metadat/releaseyear/SNK - Neo Geo Pocket Color.dat
+++ b/metadat/releaseyear/SNK - Neo Geo Pocket Color.dat
@@ -6,19 +6,19 @@ clrmamepro (
 game (
 	comment "Biomotor Unitron (Japan)"
 	releaseyear "1999"
-	rom ( crc DC07E2EF )
+	rom ( crc FCBBE494 )
 )
 
 game (
 	comment "Big Bang Pro Wrestling (Japan) (En,Ja)"
 	releaseyear "2000"
-	rom ( crc B783C372 )
+	rom ( crc F1716FDF )
 )
 
 game (
 	comment "Bakumatsu Rouman Tokubetsu Hen - Gekka no Kenshi - Tsuki ni Saku Hana, Chiri Yuku Hana (Japan)"
 	releaseyear "2000"
-	rom ( crc 5EB119BE )
+	rom ( crc BE913CFA )
 )
 
 game (
@@ -28,15 +28,9 @@ game (
 )
 
 game (
-	comment "Biomotor Unitron (Japan) (Demo)"
-	releaseyear "1999"
-	rom ( crc 3D515243 )
-)
-
-game (
 	comment "Cool Cool Jam (Japan)"
 	releaseyear "2000"
-	rom ( crc 9B2A8331 )
+	rom ( crc 0FD6F378 )
 )
 
 game (
@@ -48,7 +42,7 @@ game (
 game (
 	comment "Delta Warp (Japan) (En,Ja)"
 	releaseyear "2000"
-	rom ( crc ADD4FDFF )
+	rom ( crc 1273B10E )
 )
 
 game (
@@ -64,21 +58,9 @@ game (
 )
 
 game (
-	comment "Densha de Go! 2 on Neo Geo Pocket (Japan)"
+	comment "Densha de Go! 2 on NeoGeo Pocket (Japan)"
 	releaseyear "1999"
-	rom ( crc 0DA57257 )
-)
-
-game (
-	comment "Delta Warp (Japan) (Demo)"
-	releaseyear "2000"
-	rom ( crc A3C89788 )
-)
-
-game (
-	comment "Densha de Go! 2 on Neo Geo Pocket (Japan) (Beta)"
-	releaseyear "1999"
-	rom ( crc 2FC4623E )
+	rom ( crc A0334549 )
 )
 
 game (
@@ -124,7 +106,7 @@ game (
 )
 
 game (
-	comment "Fatal Fury F-Contact - Pocket Fighting Series (World) (En,Ja)"
+	comment "Fatal Fury - First Contact - Pocket Fighting Series (World) (En,Ja)"
 	releaseyear "1999"
 	rom ( crc E7E5D6E8 )
 )
@@ -144,7 +126,7 @@ game (
 game (
 	comment "Kikou Seiki Unitron - Sono Tsuide. Hikari Umareru Chi Yori. (Japan)"
 	releaseyear "2000"
-	rom ( crc C7C1FCF5 )
+	rom ( crc F029F1C0 )
 )
 
 game (
@@ -180,13 +162,13 @@ game (
 game (
 	comment "Koi Koi Mahjong (Japan) (v08)"
 	releaseyear "2000"
-	rom ( crc 021F7D0C )
+	rom ( crc 75FE164C )
 )
 
 game (
 	comment "Last Blade, The - Beyond the Destiny (USA, Europe)"
 	releaseyear "2000"
-	rom ( crc 94FCFD1E )
+	rom ( crc 4238A840 )
 )
 
 game (
@@ -196,15 +178,9 @@ game (
 )
 
 game (
-	comment "Magical Drop Pocket (Japan) (Demo)"
-	releaseyear "1999"
-	rom ( crc D76F1A47 )
-)
-
-game (
 	comment "Memories Off - Pure (Japan)"
 	releaseyear "2000"
-	rom ( crc A7926E90 )
+	rom ( crc 7F919DDE )
 )
 
 game (
@@ -232,12 +208,6 @@ game (
 )
 
 game (
-	comment "Metal Slug - 2nd Mission (World) (En,Ja) (Demo)"
-	releaseyear "2000"
-	rom ( crc 8B1647D4 )
-)
-
-game (
 	comment "Neo Baccarat - Pocket Casino Series (Japan, Europe) (En) (v16)"
 	releaseyear "2000"
 	rom ( crc 22AAB454 )
@@ -258,23 +228,17 @@ game (
 game (
 	comment "Neo Derby Champ Daiyosou (Japan)"
 	releaseyear "1999"
-	rom ( crc 98C6C4FD )
+	rom ( crc 4760564A )
 )
 
 game (
-	comment "Neo Cherry Master Color - Pocket Casino Series (World) (En,Ja) (Demo)"
-	releaseyear "1999"
-	rom ( crc 2F6EB991 )
-)
-
-game (
-	comment "Neo Dragon's Wild - Real Casino Series (World) (En,Ja) (v11)"
+	comment "Neo Dragon's Wild - Pocket Casino Series (World) (En,Ja) (v11)"
 	releaseyear "1999"
 	rom ( crc 225FD7F9 )
 )
 
 game (
-	comment "Neo Dragon's Wild - Real Casino Series (World) (En,Ja) (v13)"
+	comment "Neo Dragon's Wild - Pocket Casino Series (World) (En,Ja) (v13)"
 	releaseyear "1999"
 	rom ( crc 5D028C99 )
 )
@@ -288,19 +252,19 @@ game (
 game (
 	comment "Neo Poke Pro Yakyuu (Japan) (v32)"
 	releaseyear "1999"
-	rom ( crc DF6435D7 )
+	rom ( crc C624388F )
 )
 
 game (
 	comment "Neo Poke Pro Yakyuu (Japan) (v1F)"
 	releaseyear "1999"
-	rom ( crc DF6435D7 )
+	rom ( crc 3CA883A5 )
 )
 
 game (
-	comment "Neo Turf Masters (World) (En,Ja)"
+	comment "Neo Turf Masters - Pocket Sports Series (World) (En,Ja)"
 	releaseyear "1999"
-	rom ( crc D83C7981 )
+	rom ( crc E0E853DD )
 )
 
 game (
@@ -312,13 +276,13 @@ game (
 game (
 	comment "Nige-ron-pa (Japan)"
 	releaseyear "2000"
-	rom ( crc 3CC3E269 )
+	rom ( crc A9063D9E )
 )
 
 game (
 	comment "Oekaki Puzzle (Japan)"
 	releaseyear "2000"
-	rom ( crc CD657665 )
+	rom ( crc A9118E82 )
 )
 
 game (
@@ -328,7 +292,7 @@ game (
 )
 
 game (
-	comment "Pachi-slot Aruze Oukoku - Porcano 2 (Japan)"
+	comment "Pachi-Slot Aruze Oukoku - Porcano 2 (Japan)"
 	releaseyear "2000"
 	rom ( crc 96DDFBE3 )
 )
@@ -336,19 +300,19 @@ game (
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Azteca (Japan) (v04)"
 	releaseyear "2000"
-	rom ( crc BA74A414 )
+	rom ( crc 9FF16520 )
 )
 
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Azteca (Japan) (v03)"
 	releaseyear "2000"
-	rom ( crc BA74A414 )
+	rom ( crc 2314440A )
 )
 
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Azteca (Japan) (v06)"
 	releaseyear "2000"
-	rom ( crc BA74A414 )
+	rom ( crc C9B55E6B )
 )
 
 game (
@@ -372,13 +336,13 @@ game (
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - e-CUP (Japan) (v03)"
 	releaseyear "2001"
-	rom ( crc 6571A5EF )
+	rom ( crc B5311753 )
 )
 
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Hanabi (Japan) (v03)"
 	releaseyear "1999"
-	rom ( crc 54DD615E )
+	rom ( crc 4014FF42 )
 )
 
 game (
@@ -390,7 +354,7 @@ game (
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Hanabi (Japan) (v04)"
 	releaseyear "1999"
-	rom ( crc 54DD615E )
+	rom ( crc 2A4F45AB )
 )
 
 game (
@@ -408,19 +372,19 @@ game (
 game (
 	comment "Pachi-Slot Aruze Oukoku Pocket - Ward of Lights (Japan) (v04)"
 	releaseyear "2000"
-	rom ( crc 4A004B5E )
+	rom ( crc A54EC305 )
 )
 
 game (
 	comment "Pachinko Hisshou Guide - Pocket Parlor (Japan)"
 	releaseyear "1999"
-	rom ( crc E43C4028 )
+	rom ( crc 543DC257 )
 )
 
 game (
 	comment "Pachinko Hisshou Guide - Pocket Parlor (Japan) (Beta)"
 	releaseyear "1999"
-	rom ( crc E43C4028 )
+	rom ( crc CCF07C2F )
 )
 
 game (
@@ -444,25 +408,25 @@ game (
 game (
 	comment "Pocket Reversi (Japan)"
 	releaseyear "2000"
-	rom ( crc 477D3A49 )
+	rom ( crc D115FEDF )
 )
 
 game (
-	comment "Puyo Pop (World) (En,Ja) (v05)"
+	comment "Puyo Pop (Japan) (En,Ja) (v05)"
 	releaseyear "1999"
 	rom ( crc 3090B2FD )
 )
 
 game (
-	comment "Puyo Pop (World) (En,Ja) (v06)"
+	comment "Puyo Pop (USA) (En,Ja) (v06)"
 	releaseyear "1999"
-	rom ( crc 5C649D1E )
+	rom ( crc 5EA9559E )
 )
 
 game (
 	comment "Pocket Tennis Color - Pocket Sports Series (World) (En,Ja)"
 	releaseyear "1999"
-	rom ( crc 52F17827 )
+	rom ( crc E0B9AA22 )
 )
 
 game (
@@ -472,15 +436,9 @@ game (
 )
 
 game (
-	comment "Rockman - Battle & Fighters (Japan) (Demo)"
-	releaseyear "2000"
-	rom ( crc 16A98AC4 )
-)
-
-game (
 	comment "Rockman - Battle & Fighters (Japan)"
 	releaseyear "2000"
-	rom ( crc 9C861E49 )
+	rom ( crc 3C010642 )
 )
 
 game (
@@ -522,7 +480,7 @@ game (
 game (
 	comment "SNK Gals' Fighters (Japan)"
 	releaseyear "2000"
-	rom ( crc 34B30474 )
+	rom ( crc D73B5B9F )
 )
 
 game (
@@ -544,33 +502,21 @@ game (
 )
 
 game (
-	comment "SNK vs. Capcom - Gekitotsu Card Fighters - SNK Supporter Version (Japan) (Beta)"
-	releaseyear "1999"
-	rom ( crc E70E3F1A )
-)
-
-game (
 	comment "SNK vs. Capcom - The Match of the Millennium (World) (En,Ja)"
 	releaseyear "1999"
 	rom ( crc 682A7A7B )
 )
 
 game (
-	comment "Sonic The Hedgehog - Pocket Adventure (World)"
+	comment "Sonic The Hedgehog - Pocket Adventure (World) (En,Ja)"
 	releaseyear "1999"
 	rom ( crc 8BD22145 )
 )
 
 game (
-	comment "SNK vs. Capcom - The Match of the Millennium (Japan) (Demo)"
+	comment "Sonic The Hedgehog - Pocket Adventure (World) (Beta)"
 	releaseyear "1999"
-	rom ( crc 1E19E307 )
-)
-
-game (
-	comment "Sonic The Hedgehog - Pocket Adventure (World) (Beta) (1999-10-22)"
-	releaseyear "1999"
-	rom ( crc D95D8E55 )
+	rom ( crc 45FC3BCA )
 )
 
 game (


### PR DESCRIPTION
**Scope update (Aug 3):** after the Aug 1 No-Intro refresh this grew into a full resync of all 7 NGPC metadat files — every stale CRC remapped, titles updated to current No-Intro names, removed/duplicated entries dropped. Details in the comments below. The original description follows.

---


Six NGPC games are keyed in the metadata dats to CRCs from a **superseded No-Intro revision**. This repository's own `metadat/no-intro/SNK - Neo Geo Pocket Color.dat` already carries the current CRCs, so the metadata was internally inconsistent — current verified dumps get no genre, developer, publisher, etc.

| Game | old CRC | current CRC |
|---|---|---|
| King of Fighters R-2 - Pocket Fighting Series (World) (En,Ja) | `D5F69C02` | `9BC63F27` |
| Metal Slug - 1st Mission (World) (En,Ja) | `4C224504` | `D29EC1BA` |
| Metal Slug - 2nd Mission (World) (En,Ja) | `F4507FA5` | `18E692A5` |
| Samurai Shodown! 2 - Pocket Fighting Series (World) (En,Ja) | `CE88B26D` | `58A62FB2` |
| SNK vs. Capcom - The Match of the Millennium (World) (En,Ja) | `A54C3026` | `682A7A7B` |
| Sonic The Hedgehog - Pocket Adventure (World) | `0AD6BCF7` | `8BD22145` |

### Bonus fix

The **"Match of the Millennium (Japan) (Demo)"** entry was keyed to the *full game's* old CRC `A54C3026` (a 4 MB game and a 2 MB demo cannot share a CRC). It now uses its own current No-Intro CRC `1E19E307`.

### Scope & verification

- Updated across every affected category: `genre`, `developer`, `publisher`, `releaseyear`, `esrb`, `franchise`, `maxusers` (47 CRC fields in total).
- **Only CRC values changed** — no names, category values, or other entries touched.
- Every new CRC was verified **present** in `metadat/no-intro/SNK - Neo Geo Pocket Color.dat`, and every superseded CRC verified **absent** from it (i.e. fully superseded, not a coexisting variant).
- Entry names in the metadata dats already matched the No-Intro names exactly; only the CRC had drifted.
