### PR TITLE
cht: Fix two Game Boy cheat codes

### DIFF
--- a/cht/Nintendo - Game Boy Color/Legend of Zelda, The - Link's Awakening DX (USA, Europe) (Game Genie).cht
+++ b/cht/Nintendo - Game Boy Color/Legend of Zelda, The - Link's Awakening DX (USA, Europe) (Game Genie).cht
@@ -1,7 +1,7 @@
 cheats = 24 
 
 cheat0_desc = "Infinite Energy"
-cheat0_code = "FAO-999-4C1"
+cheat0_code = "FA0-999-4C1"
 cheat0_enable = false 
 
 cheat1_desc = "All Items You Get Start At Max Power"

--- a/cht/Nintendo - Game Boy/Donkey Kong (World) (GameShark).cht
+++ b/cht/Nintendo - Game Boy/Donkey Kong (World) (GameShark).cht
@@ -21,6 +21,6 @@ cheat4_code = "010?1ADD"
 cheat4_enable = false 
 
 cheat5_desc = "On The First Level No Enemies Come"
-cheat5_code = "0100D2C0+0101D3C0+0103D4C0+0100E3C0+0100E7CO"
+cheat5_code = "0100D2C0+0101D3C0+0103D4C0+0100E3C0"
 cheat5_enable = false 
 


### PR DESCRIPTION
## Fix two malformed Game Boy cheat codes

Two `cht/` entries contain non-hexadecimal characters. GB/GBC GameShark
and Game Genie codes are both strictly hexadecimal (confirmed against
mGBA's cheat parser, `src/gb/cheats.c`), so these codes fail to parse and
are silently ignored in-game.

### 1. Zelda: Link's Awakening DX — "Infinite Energy" (Game Genie)

`cht/Nintendo - Game Boy Color/Legend of Zelda, The - Link's Awakening DX (USA, Europe) (Game Genie).cht`

```
- FAO-999-4C1
+ FA0-999-4C1
```

The letter **O** is invalid in a Game Boy Game Genie code (hexadecimal
only) and is a mis-transcription of the digit **0**. The corrected code
`FA0-999-4C1` is attested in published Game Genie code lists.

(Note: this is specific to the *Game Boy* Game Genie, which is
hexadecimal — unlike the NES Game Genie, whose letter alphabet legitimately
includes `O`.)

### 2. Donkey Kong — "On The First Level No Enemies Come" (GameShark)

`cht/Nintendo - Game Boy/Donkey Kong (World) (GameShark).cht`

```
- 0100D2C0+0101D3C0+0103D4C0+0100E3C0+0100E7CO
+ 0100D2C0+0101D3C0+0103D4C0+0100E3C0
```

The fifth segment `0100E7CO` ends in the letter **O** and is malformed.
The authoritative code (gamehacking.org, codID 58275) consists of only
the four preceding segments — no `E7`-addressed segment exists there — so
the fifth segment is both spurious and unparseable. Because an
unparseable segment is already inert, removing it changes no runtime
behavior; it only removes the invalid data.

### Verification

- Format (hex-only, letter O/Y invalid): mGBA `src/gb/cheats.c` parser.
- Corrections: gamehacking.org and published Game Genie code lists.

Other suspected-malformed codes in these games were reviewed and left
untouched because a correct replacement could not be sourced (so a fix
would be guesswork), or because the characters were intentional
user-fillable placeholders (`??`, `XX`, `YY`), not defects.
