### PR TITLE
Add genre/developer/publisher/franchise for 45 Nintendo DS games

### DIFF
--- a/metadat/developer/Nintendo - Nintendo DS.dat
+++ b/metadat/developer/Nintendo - Nintendo DS.dat
@@ -489,3 +489,267 @@ game (
 	developer "Game Freak"
 	rom ( crc D3E316EF )
 )
+
+game (
+	comment "Advance Wars - Days of Ruin (USA) (En,Fr,Es)"
+	developer "Intelligent Systems"
+	rom ( crc EAC313F3 )
+)
+
+game (
+	comment "Advance Wars - Dual Strike (USA, Australia)"
+	developer "Intelligent Systems"
+	rom ( crc 4D9A91E3 )
+)
+
+game (
+	comment "Age of Empires - The Age of Kings (Europe) (En,Fr,De)"
+	developer "Backbone Entertainment"
+	rom ( crc B5AECC63 )
+)
+
+game (
+	comment "Animal Crossing - Wild World (Europe) (En,Fr,De,Es,It)"
+	developer "Nintendo EAD"
+	rom ( crc C677970C )
+)
+
+game (
+	comment "Asphalt - Urban GT (USA) (En,Fr,Es)"
+	developer "Gameloft"
+	rom ( crc 4F604498 )
+)
+
+game (
+	comment "Bomberman (USA)"
+	developer "Racjin"
+	rom ( crc 4A51692E )
+)
+
+game (
+	comment "Bomberman Land Touch! (Europe) (En,Fr,De,Es,It)"
+	developer "Hudson Soft"
+	rom ( crc 7A3B375D )
+)
+
+game (
+	comment "Castlevania - Dawn of Sorrow (USA)"
+	developer "Konami"
+	rom ( crc 135737F6 )
+)
+
+game (
+	comment "Castlevania - Portrait of Ruin (Europe) (En,Fr,De,Es,It)"
+	developer "Konami"
+	rom ( crc 772BA12A )
+)
+
+game (
+	comment "Chrono Trigger (USA) (En,Fr)"
+	developer "Square Enix"
+	rom ( crc B3836946 )
+)
+
+game (
+	comment "Contra 4 (USA)"
+	developer "WayForward Technologies"
+	rom ( crc B9DF4B8E )
+)
+
+game (
+	comment "DK - Jungle Climber (USA)"
+	developer "Paon"
+	rom ( crc 038EED18 )
+)
+
+game (
+	comment "Dragon Quest Heroes - Rocket Slime (USA)"
+	developer "Tose"
+	rom ( crc 076053F0 )
+)
+
+game (
+	comment "Dragon Quest IX - Sentinels of the Starry Skies (USA) (En,Fr,Es)"
+	developer "Level-5"
+	rom ( crc AACE5E9C )
+)
+
+game (
+	comment "Elite Beat Agents (USA)"
+	developer "iNiS"
+	rom ( crc 26BC50A1 )
+)
+
+game (
+	comment "Grand Theft Auto - Chinatown Wars (USA) (En,Fr,De,Es,It)"
+	developer "Rockstar Leeds"
+	rom ( crc CC50CF7E )
+)
+
+game (
+	comment "Kirby - Canvas Curse (USA)"
+	developer "HAL Laboratory"
+	rom ( crc FE7DC5EE )
+)
+
+game (
+	comment "Legend of Zelda, The - Phantom Hourglass (USA) (En,Fr,Es)"
+	developer "Nintendo EAD"
+	rom ( crc 8B431C41 )
+)
+
+game (
+	comment "Legend of Zelda, The - Spirit Tracks (USA) (En,Fr,Es) (Rev 1)"
+	developer "Nintendo EAD"
+	rom ( crc 319A13E5 )
+)
+
+game (
+	comment "Lunar Knights (Europe) (En,Fr,De,Es,It)"
+	developer "Kojima Productions"
+	rom ( crc 84953087 )
+)
+
+game (
+	comment "Madagascar (USA)"
+	developer "Vicarious Visions"
+	rom ( crc 2EC117B7 )
+)
+
+game (
+	comment "Mario & Luigi - Partners in Time (Europe) (En,Fr,De,Es,It)"
+	developer "AlphaDream"
+	rom ( crc 3184FBC4 )
+)
+
+game (
+	comment "Mario Kart DS (Europe) (En,Fr,De,Es,It)"
+	developer "Nintendo EAD"
+	rom ( crc 94E8127E )
+)
+
+game (
+	comment "Mario vs. Donkey Kong 2 - March of the Minis (Europe) (En,Fr,De,Es,It)"
+	developer "Nintendo Software Technology"
+	rom ( crc 11652805 )
+)
+
+game (
+	comment "Meteos (Europe) (En,Fr,De,Es,It)"
+	developer "Q Entertainment"
+	rom ( crc 2ED041E2 )
+)
+
+game (
+	comment "Need for Speed - Underground 2 (USA) (En,Fr,De,Es,It)"
+	developer "Pocketeers"
+	rom ( crc C37AB273 )
+)
+
+game (
+	comment "New Super Mario Bros. (Europe) (En,Fr,De,Es,It)"
+	developer "Nintendo EAD"
+	rom ( crc F443F9BF )
+)
+
+game (
+	comment "Phoenix Wright - Ace Attorney (USA)"
+	developer "Capcom"
+	rom ( crc BE5FB8D8 )
+)
+
+game (
+	comment "Planet Puzzle League (USA)"
+	developer "Intelligent Systems"
+	rom ( crc E26F344A )
+)
+
+game (
+	comment "Pokemon Dash (USA)"
+	developer "Ambrella"
+	rom ( crc 0D8B2B06 )
+)
+
+game (
+	comment "Professor Layton and the Curious Village (USA, Australia)"
+	developer "Level-5"
+	rom ( crc 08DAC15E )
+)
+
+game (
+	comment "Professor Layton and the Unwound Future (USA)"
+	developer "Level-5"
+	rom ( crc B311E1EC )
+)
+
+game (
+	comment "Sonic Rush (Europe) (En,Ja,Fr,De,Es,It)"
+	developer "Dimps"
+	rom ( crc 0A0DEC19 )
+)
+
+game (
+	comment "Sonic Rush Adventure (Europe) (En,Ja,Fr,De,Es,It)"
+	developer "Dimps"
+	rom ( crc 0131034B )
+)
+
+game (
+	comment "Spider-Man 2 (USA)"
+	developer "Vicarious Visions"
+	rom ( crc 3B275B19 )
+)
+
+game (
+	comment "Spider-Man 3 (United Kingdom)"
+	developer "Vicarious Visions"
+	rom ( crc 49EB3DD7 )
+)
+
+game (
+	comment "Super Mario 64 DS (Europe) (En,Fr,De,Es,It)"
+	developer "Nintendo EAD"
+	rom ( crc 29715DEC )
+)
+
+game (
+	comment "Tony Hawk's American Sk8land (Europe) (En,Fr,De,Es,It)"
+	developer "Vicarious Visions"
+	rom ( crc EA283807 )
+)
+
+game (
+	comment "Tony Hawk's Downhill Jam (Europe) (En,Fr,De,Es,It)"
+	developer "Vicarious Visions"
+	rom ( crc ED75B040 )
+)
+
+game (
+	comment "WarioWare - Touched! (Europe) (En,Fr,De,Es,It)"
+	developer "Nintendo SPD, Intelligent Systems"
+	rom ( crc 8CAF8639 )
+)
+
+game (
+	comment "Worms - Open Warfare (USA)"
+	developer "Team17"
+	rom ( crc ECB40FD3 )
+)
+
+game (
+	comment "Worms - Open Warfare 2 (USA) (En,Fr)"
+	developer "Team17"
+	rom ( crc 500C0C53 )
+)
+
+game (
+	comment "Yoshi Touch & Go (Europe) (En,Fr,De,Es,It)"
+	developer "Nintendo EAD"
+	rom ( crc 1D829D6F )
+)
+
+game (
+	comment "Yu-Gi-Oh! - Nightmare Troubadour (USA)"
+	developer "Konami Computer Entertainment Japan"
+	rom ( crc 2CEFE04D )
+)

--- a/metadat/franchise/Nintendo - Nintendo DS.dat
+++ b/metadat/franchise/Nintendo - Nintendo DS.dat
@@ -323,3 +323,261 @@ game (
 	franchise "Pokémon"
 	rom ( crc 33AF46D5 )
 )
+
+game (
+	comment "Advance Wars - Days of Ruin (USA) (En,Fr,Es)"
+	franchise "Advance Wars"
+	rom ( crc EAC313F3 )
+)
+
+game (
+	comment "Advance Wars - Dual Strike (USA, Australia)"
+	franchise "Advance Wars"
+	rom ( crc 4D9A91E3 )
+)
+
+game (
+	comment "Age of Empires - The Age of Kings (Europe) (En,Fr,De)"
+	franchise "Age of Empires"
+	rom ( crc B5AECC63 )
+)
+
+game (
+	comment "Animal Crossing - Wild World (Europe) (En,Fr,De,Es,It)"
+	franchise "Animal Crossing"
+	rom ( crc C677970C )
+)
+
+game (
+	comment "Asphalt - Urban GT (USA) (En,Fr,Es)"
+	franchise "Asphalt"
+	rom ( crc 4F604498 )
+)
+
+game (
+	comment "Bomberman (USA)"
+	franchise "Bomberman"
+	rom ( crc 4A51692E )
+)
+
+game (
+	comment "Bomberman Land Touch! (Europe) (En,Fr,De,Es,It)"
+	franchise "Bomberman"
+	rom ( crc 7A3B375D )
+)
+
+game (
+	comment "Castlevania - Dawn of Sorrow (USA)"
+	franchise "Castlevania"
+	rom ( crc 135737F6 )
+)
+
+game (
+	comment "Castlevania - Portrait of Ruin (Europe) (En,Fr,De,Es,It)"
+	franchise "Castlevania"
+	rom ( crc 772BA12A )
+)
+
+game (
+	comment "Chrono Trigger (USA) (En,Fr)"
+	franchise "Chrono"
+	rom ( crc B3836946 )
+)
+
+game (
+	comment "Contra 4 (USA)"
+	franchise "Contra"
+	rom ( crc B9DF4B8E )
+)
+
+game (
+	comment "DK - Jungle Climber (USA)"
+	franchise "Donkey Kong"
+	rom ( crc 038EED18 )
+)
+
+game (
+	comment "Dragon Quest Heroes - Rocket Slime (USA)"
+	franchise "Dragon Quest"
+	rom ( crc 076053F0 )
+)
+
+game (
+	comment "Dragon Quest IX - Sentinels of the Starry Skies (USA) (En,Fr,Es)"
+	franchise "Dragon Quest"
+	rom ( crc AACE5E9C )
+)
+
+game (
+	comment "Grand Theft Auto - Chinatown Wars (USA) (En,Fr,De,Es,It)"
+	franchise "Grand Theft Auto"
+	rom ( crc CC50CF7E )
+)
+
+game (
+	comment "Kirby - Canvas Curse (USA)"
+	franchise "Kirby"
+	rom ( crc FE7DC5EE )
+)
+
+game (
+	comment "Legend of Zelda, The - Phantom Hourglass (USA) (En,Fr,Es)"
+	franchise "The Legend of Zelda"
+	rom ( crc 8B431C41 )
+)
+
+game (
+	comment "Legend of Zelda, The - Spirit Tracks (USA) (En,Fr,Es) (Rev 1)"
+	franchise "The Legend of Zelda"
+	rom ( crc 319A13E5 )
+)
+
+game (
+	comment "Lunar Knights (Europe) (En,Fr,De,Es,It)"
+	franchise "Boktai"
+	rom ( crc 84953087 )
+)
+
+game (
+	comment "Madagascar (USA)"
+	franchise "Madagascar"
+	rom ( crc 2EC117B7 )
+)
+
+game (
+	comment "Mario & Luigi - Partners in Time (Europe) (En,Fr,De,Es,It)"
+	franchise "Mario"
+	rom ( crc 3184FBC4 )
+)
+
+game (
+	comment "Mario Kart DS (Europe) (En,Fr,De,Es,It)"
+	franchise "Mario Kart"
+	rom ( crc 94E8127E )
+)
+
+game (
+	comment "Mario vs. Donkey Kong 2 - March of the Minis (Europe) (En,Fr,De,Es,It)"
+	franchise "Mario vs. Donkey Kong"
+	rom ( crc 11652805 )
+)
+
+game (
+	comment "Need for Speed - Underground 2 (USA) (En,Fr,De,Es,It)"
+	franchise "Need for Speed"
+	rom ( crc C37AB273 )
+)
+
+game (
+	comment "New Super Mario Bros. (Europe) (En,Fr,De,Es,It)"
+	franchise "Super Mario"
+	rom ( crc F443F9BF )
+)
+
+game (
+	comment "Phoenix Wright - Ace Attorney (USA)"
+	franchise "Ace Attorney"
+	rom ( crc BE5FB8D8 )
+)
+
+game (
+	comment "Planet Puzzle League (USA)"
+	franchise "Puzzle League"
+	rom ( crc E26F344A )
+)
+
+game (
+	comment "Pokemon Dash (USA)"
+	franchise "Pokemon"
+	rom ( crc 0D8B2B06 )
+)
+
+game (
+	comment "Professor Layton and the Curious Village (USA, Australia)"
+	franchise "Professor Layton"
+	rom ( crc 08DAC15E )
+)
+
+game (
+	comment "Professor Layton and the Unwound Future (USA)"
+	franchise "Professor Layton"
+	rom ( crc B311E1EC )
+)
+
+game (
+	comment "Sonic Rush (Europe) (En,Ja,Fr,De,Es,It)"
+	franchise "Sonic the Hedgehog"
+	rom ( crc 0A0DEC19 )
+)
+
+game (
+	comment "Sonic Rush Adventure (Europe) (En,Ja,Fr,De,Es,It)"
+	franchise "Sonic the Hedgehog"
+	rom ( crc 0131034B )
+)
+
+game (
+	comment "Spider-Man 2 (USA)"
+	franchise "Spider-Man"
+	rom ( crc 3B275B19 )
+)
+
+game (
+	comment "Spider-Man 3 (United Kingdom)"
+	franchise "Spider-Man"
+	rom ( crc 49EB3DD7 )
+)
+
+game (
+	comment "Star Wars - Episode III - Revenge of the Sith (Europe) (En,Fr,De,Es,It,Nl)"
+	franchise "Star Wars"
+	rom ( crc 3F3F7DC8 )
+)
+
+game (
+	comment "Super Mario 64 DS (Europe) (En,Fr,De,Es,It)"
+	franchise "Super Mario"
+	rom ( crc 29715DEC )
+)
+
+game (
+	comment "Tony Hawk's American Sk8land (Europe) (En,Fr,De,Es,It)"
+	franchise "Tony Hawk's"
+	rom ( crc EA283807 )
+)
+
+game (
+	comment "Tony Hawk's Downhill Jam (Europe) (En,Fr,De,Es,It)"
+	franchise "Tony Hawk's"
+	rom ( crc ED75B040 )
+)
+
+game (
+	comment "WarioWare - Touched! (Europe) (En,Fr,De,Es,It)"
+	franchise "WarioWare"
+	rom ( crc 8CAF8639 )
+)
+
+game (
+	comment "Worms - Open Warfare (USA)"
+	franchise "Worms"
+	rom ( crc ECB40FD3 )
+)
+
+game (
+	comment "Worms - Open Warfare 2 (USA) (En,Fr)"
+	franchise "Worms"
+	rom ( crc 500C0C53 )
+)
+
+game (
+	comment "Yoshi Touch & Go (Europe) (En,Fr,De,Es,It)"
+	franchise "Yoshi"
+	rom ( crc 1D829D6F )
+)
+
+game (
+	comment "Yu-Gi-Oh! - Nightmare Troubadour (USA)"
+	franchise "Yu-Gi-Oh!"
+	rom ( crc 2CEFE04D )
+)

--- a/metadat/genre/Nintendo - Nintendo DS.dat
+++ b/metadat/genre/Nintendo - Nintendo DS.dat
@@ -215,3 +215,273 @@ game (
 	genre "Role-playing (RPG)"
 	rom ( crc 4F6E5580 )
 )
+
+game (
+	comment "Advance Wars - Days of Ruin (USA) (En,Fr,Es)"
+	genre "Strategy"
+	rom ( crc EAC313F3 )
+)
+
+game (
+	comment "Advance Wars - Dual Strike (USA, Australia)"
+	genre "Strategy"
+	rom ( crc 4D9A91E3 )
+)
+
+game (
+	comment "Age of Empires - The Age of Kings (Europe) (En,Fr,De)"
+	genre "Strategy"
+	rom ( crc B5AECC63 )
+)
+
+game (
+	comment "Animal Crossing - Wild World (Europe) (En,Fr,De,Es,It)"
+	genre "Simulation"
+	rom ( crc C677970C )
+)
+
+game (
+	comment "Asphalt - Urban GT (USA) (En,Fr,Es)"
+	genre "Racing"
+	rom ( crc 4F604498 )
+)
+
+game (
+	comment "Bomberman (USA)"
+	genre "Action"
+	rom ( crc 4A51692E )
+)
+
+game (
+	comment "Bomberman Land Touch! (Europe) (En,Fr,De,Es,It)"
+	genre "Puzzle"
+	rom ( crc 7A3B375D )
+)
+
+game (
+	comment "Castlevania - Dawn of Sorrow (USA)"
+	genre "Action"
+	rom ( crc 135737F6 )
+)
+
+game (
+	comment "Castlevania - Portrait of Ruin (Europe) (En,Fr,De,Es,It)"
+	genre "Platform"
+	rom ( crc 772BA12A )
+)
+
+game (
+	comment "Chrono Trigger (USA) (En,Fr)"
+	genre "Role-playing (RPG)"
+	rom ( crc B3836946 )
+)
+
+game (
+	comment "Contra 4 (USA)"
+	genre "Shooter"
+	rom ( crc B9DF4B8E )
+)
+
+game (
+	comment "DK - Jungle Climber (USA)"
+	genre "Platform"
+	rom ( crc 038EED18 )
+)
+
+game (
+	comment "Dragon Quest Heroes - Rocket Slime (USA)"
+	genre "Action"
+	rom ( crc 076053F0 )
+)
+
+game (
+	comment "Dragon Quest IX - Sentinels of the Starry Skies (USA) (En,Fr,Es)"
+	genre "Role-playing (RPG)"
+	rom ( crc AACE5E9C )
+)
+
+game (
+	comment "Elite Beat Agents (USA)"
+	genre "Music"
+	rom ( crc 26BC50A1 )
+)
+
+game (
+	comment "Grand Theft Auto - Chinatown Wars (USA) (En,Fr,De,Es,It)"
+	genre "Action"
+	rom ( crc CC50CF7E )
+)
+
+game (
+	comment "Kirby - Canvas Curse (USA)"
+	genre "Platform"
+	rom ( crc FE7DC5EE )
+)
+
+game (
+	comment "Legend of Zelda, The - Phantom Hourglass (USA) (En,Fr,Es)"
+	genre "Action"
+	rom ( crc 8B431C41 )
+)
+
+game (
+	comment "Legend of Zelda, The - Spirit Tracks (USA) (En,Fr,Es) (Rev 1)"
+	genre "Action"
+	rom ( crc 319A13E5 )
+)
+
+game (
+	comment "Lunar Knights (Europe) (En,Fr,De,Es,It)"
+	genre "Role-playing (RPG)"
+	rom ( crc 84953087 )
+)
+
+game (
+	comment "Madagascar (USA)"
+	genre "Platform"
+	rom ( crc 2EC117B7 )
+)
+
+game (
+	comment "Mario & Luigi - Partners in Time (Europe) (En,Fr,De,Es,It)"
+	genre "Role-playing (RPG)"
+	rom ( crc 3184FBC4 )
+)
+
+game (
+	comment "Mario Kart DS (Europe) (En,Fr,De,Es,It)"
+	genre "Racing"
+	rom ( crc 94E8127E )
+)
+
+game (
+	comment "Mario vs. Donkey Kong 2 - March of the Minis (Europe) (En,Fr,De,Es,It)"
+	genre "Puzzle"
+	rom ( crc 11652805 )
+)
+
+game (
+	comment "Meteos (Europe) (En,Fr,De,Es,It)"
+	genre "Puzzle"
+	rom ( crc 2ED041E2 )
+)
+
+game (
+	comment "Need for Speed - Underground 2 (USA) (En,Fr,De,Es,It)"
+	genre "Racing"
+	rom ( crc C37AB273 )
+)
+
+game (
+	comment "New Super Mario Bros. (Europe) (En,Fr,De,Es,It)"
+	genre "Platform"
+	rom ( crc F443F9BF )
+)
+
+game (
+	comment "Phoenix Wright - Ace Attorney (USA)"
+	genre "Adventure"
+	rom ( crc BE5FB8D8 )
+)
+
+game (
+	comment "Planet Puzzle League (USA)"
+	genre "Puzzle"
+	rom ( crc E26F344A )
+)
+
+game (
+	comment "Pokemon Dash (USA)"
+	genre "Racing"
+	rom ( crc 0D8B2B06 )
+)
+
+game (
+	comment "Professor Layton and the Curious Village (USA, Australia)"
+	genre "Puzzle"
+	rom ( crc 08DAC15E )
+)
+
+game (
+	comment "Professor Layton and the Unwound Future (USA)"
+	genre "Puzzle"
+	rom ( crc B311E1EC )
+)
+
+game (
+	comment "Sonic Rush (Europe) (En,Ja,Fr,De,Es,It)"
+	genre "Platform"
+	rom ( crc 0A0DEC19 )
+)
+
+game (
+	comment "Sonic Rush Adventure (Europe) (En,Ja,Fr,De,Es,It)"
+	genre "Platform"
+	rom ( crc 0131034B )
+)
+
+game (
+	comment "Spider-Man 2 (USA)"
+	genre "Action"
+	rom ( crc 3B275B19 )
+)
+
+game (
+	comment "Spider-Man 3 (United Kingdom)"
+	genre "Action"
+	rom ( crc 49EB3DD7 )
+)
+
+game (
+	comment "Star Wars - Episode III - Revenge of the Sith (Europe) (En,Fr,De,Es,It,Nl)"
+	genre "Action"
+	rom ( crc 3F3F7DC8 )
+)
+
+game (
+	comment "Super Mario 64 DS (Europe) (En,Fr,De,Es,It)"
+	genre "Platform"
+	rom ( crc 29715DEC )
+)
+
+game (
+	comment "Tony Hawk's American Sk8land (Europe) (En,Fr,De,Es,It)"
+	genre "Sports"
+	rom ( crc EA283807 )
+)
+
+game (
+	comment "Tony Hawk's Downhill Jam (Europe) (En,Fr,De,Es,It)"
+	genre "Sports"
+	rom ( crc ED75B040 )
+)
+
+game (
+	comment "WarioWare - Touched! (Europe) (En,Fr,De,Es,It)"
+	genre "Action"
+	rom ( crc 8CAF8639 )
+)
+
+game (
+	comment "Worms - Open Warfare (USA)"
+	genre "Strategy"
+	rom ( crc ECB40FD3 )
+)
+
+game (
+	comment "Worms - Open Warfare 2 (USA) (En,Fr)"
+	genre "Strategy"
+	rom ( crc 500C0C53 )
+)
+
+game (
+	comment "Yoshi Touch & Go (Europe) (En,Fr,De,Es,It)"
+	genre "Platform"
+	rom ( crc 1D829D6F )
+)
+
+game (
+	comment "Yu-Gi-Oh! - Nightmare Troubadour (USA)"
+	genre "Card"
+	rom ( crc 2CEFE04D )
+)

--- a/metadat/publisher/Nintendo - Nintendo DS.dat
+++ b/metadat/publisher/Nintendo - Nintendo DS.dat
@@ -215,3 +215,273 @@ game (
 	publisher "Nintendo"
 	rom ( crc 4F6E5580 )
 )
+
+game (
+	comment "Advance Wars - Days of Ruin (USA) (En,Fr,Es)"
+	publisher "Nintendo"
+	rom ( crc EAC313F3 )
+)
+
+game (
+	comment "Advance Wars - Dual Strike (USA, Australia)"
+	publisher "Nintendo"
+	rom ( crc 4D9A91E3 )
+)
+
+game (
+	comment "Age of Empires - The Age of Kings (Europe) (En,Fr,De)"
+	publisher "Majesco Entertainment"
+	rom ( crc B5AECC63 )
+)
+
+game (
+	comment "Animal Crossing - Wild World (Europe) (En,Fr,De,Es,It)"
+	publisher "Nintendo"
+	rom ( crc C677970C )
+)
+
+game (
+	comment "Asphalt - Urban GT (USA) (En,Fr,Es)"
+	publisher "Ubisoft"
+	rom ( crc 4F604498 )
+)
+
+game (
+	comment "Bomberman (USA)"
+	publisher "Ubisoft"
+	rom ( crc 4A51692E )
+)
+
+game (
+	comment "Bomberman Land Touch! (Europe) (En,Fr,De,Es,It)"
+	publisher "Rising Star Games"
+	rom ( crc 7A3B375D )
+)
+
+game (
+	comment "Castlevania - Dawn of Sorrow (USA)"
+	publisher "Konami"
+	rom ( crc 135737F6 )
+)
+
+game (
+	comment "Castlevania - Portrait of Ruin (Europe) (En,Fr,De,Es,It)"
+	publisher "Konami"
+	rom ( crc 772BA12A )
+)
+
+game (
+	comment "Chrono Trigger (USA) (En,Fr)"
+	publisher "Square Enix"
+	rom ( crc B3836946 )
+)
+
+game (
+	comment "Contra 4 (USA)"
+	publisher "Konami"
+	rom ( crc B9DF4B8E )
+)
+
+game (
+	comment "DK - Jungle Climber (USA)"
+	publisher "Nintendo"
+	rom ( crc 038EED18 )
+)
+
+game (
+	comment "Dragon Quest Heroes - Rocket Slime (USA)"
+	publisher "Square Enix"
+	rom ( crc 076053F0 )
+)
+
+game (
+	comment "Dragon Quest IX - Sentinels of the Starry Skies (USA) (En,Fr,Es)"
+	publisher "Nintendo"
+	rom ( crc AACE5E9C )
+)
+
+game (
+	comment "Elite Beat Agents (USA)"
+	publisher "Nintendo"
+	rom ( crc 26BC50A1 )
+)
+
+game (
+	comment "Grand Theft Auto - Chinatown Wars (USA) (En,Fr,De,Es,It)"
+	publisher "Rockstar Games"
+	rom ( crc CC50CF7E )
+)
+
+game (
+	comment "Kirby - Canvas Curse (USA)"
+	publisher "Nintendo"
+	rom ( crc FE7DC5EE )
+)
+
+game (
+	comment "Legend of Zelda, The - Phantom Hourglass (USA) (En,Fr,Es)"
+	publisher "Nintendo"
+	rom ( crc 8B431C41 )
+)
+
+game (
+	comment "Legend of Zelda, The - Spirit Tracks (USA) (En,Fr,Es) (Rev 1)"
+	publisher "Nintendo"
+	rom ( crc 319A13E5 )
+)
+
+game (
+	comment "Lunar Knights (Europe) (En,Fr,De,Es,It)"
+	publisher "Konami"
+	rom ( crc 84953087 )
+)
+
+game (
+	comment "Madagascar (USA)"
+	publisher "Activision"
+	rom ( crc 2EC117B7 )
+)
+
+game (
+	comment "Mario & Luigi - Partners in Time (Europe) (En,Fr,De,Es,It)"
+	publisher "Nintendo"
+	rom ( crc 3184FBC4 )
+)
+
+game (
+	comment "Mario Kart DS (Europe) (En,Fr,De,Es,It)"
+	publisher "Nintendo"
+	rom ( crc 94E8127E )
+)
+
+game (
+	comment "Mario vs. Donkey Kong 2 - March of the Minis (Europe) (En,Fr,De,Es,It)"
+	publisher "Nintendo"
+	rom ( crc 11652805 )
+)
+
+game (
+	comment "Meteos (Europe) (En,Fr,De,Es,It)"
+	publisher "Nintendo"
+	rom ( crc 2ED041E2 )
+)
+
+game (
+	comment "Need for Speed - Underground 2 (USA) (En,Fr,De,Es,It)"
+	publisher "Electronic Arts"
+	rom ( crc C37AB273 )
+)
+
+game (
+	comment "New Super Mario Bros. (Europe) (En,Fr,De,Es,It)"
+	publisher "Nintendo"
+	rom ( crc F443F9BF )
+)
+
+game (
+	comment "Phoenix Wright - Ace Attorney (USA)"
+	publisher "Capcom"
+	rom ( crc BE5FB8D8 )
+)
+
+game (
+	comment "Planet Puzzle League (USA)"
+	publisher "Nintendo"
+	rom ( crc E26F344A )
+)
+
+game (
+	comment "Pokemon Dash (USA)"
+	publisher "Nintendo"
+	rom ( crc 0D8B2B06 )
+)
+
+game (
+	comment "Professor Layton and the Curious Village (USA, Australia)"
+	publisher "Nintendo"
+	rom ( crc 08DAC15E )
+)
+
+game (
+	comment "Professor Layton and the Unwound Future (USA)"
+	publisher "Nintendo"
+	rom ( crc B311E1EC )
+)
+
+game (
+	comment "Sonic Rush (Europe) (En,Ja,Fr,De,Es,It)"
+	publisher "Sega"
+	rom ( crc 0A0DEC19 )
+)
+
+game (
+	comment "Sonic Rush Adventure (Europe) (En,Ja,Fr,De,Es,It)"
+	publisher "Sega"
+	rom ( crc 0131034B )
+)
+
+game (
+	comment "Spider-Man 2 (USA)"
+	publisher "Activision"
+	rom ( crc 3B275B19 )
+)
+
+game (
+	comment "Spider-Man 3 (United Kingdom)"
+	publisher "Activision"
+	rom ( crc 49EB3DD7 )
+)
+
+game (
+	comment "Star Wars - Episode III - Revenge of the Sith (Europe) (En,Fr,De,Es,It,Nl)"
+	publisher "Ubisoft"
+	rom ( crc 3F3F7DC8 )
+)
+
+game (
+	comment "Super Mario 64 DS (Europe) (En,Fr,De,Es,It)"
+	publisher "Nintendo"
+	rom ( crc 29715DEC )
+)
+
+game (
+	comment "Tony Hawk's American Sk8land (Europe) (En,Fr,De,Es,It)"
+	publisher "Activision"
+	rom ( crc EA283807 )
+)
+
+game (
+	comment "Tony Hawk's Downhill Jam (Europe) (En,Fr,De,Es,It)"
+	publisher "Activision"
+	rom ( crc ED75B040 )
+)
+
+game (
+	comment "WarioWare - Touched! (Europe) (En,Fr,De,Es,It)"
+	publisher "Nintendo"
+	rom ( crc 8CAF8639 )
+)
+
+game (
+	comment "Worms - Open Warfare (USA)"
+	publisher "THQ"
+	rom ( crc ECB40FD3 )
+)
+
+game (
+	comment "Worms - Open Warfare 2 (USA) (En,Fr)"
+	publisher "THQ"
+	rom ( crc 500C0C53 )
+)
+
+game (
+	comment "Yoshi Touch & Go (Europe) (En,Fr,De,Es,It)"
+	publisher "Nintendo"
+	rom ( crc 1D829D6F )
+)
+
+game (
+	comment "Yu-Gi-Oh! - Nightmare Troubadour (USA)"
+	publisher "Konami"
+	rom ( crc 2CEFE04D )
+)


### PR DESCRIPTION
## Add genre / developer / publisher / franchise for 45 Nintendo DS games

Adds metadata for 45 Nintendo DS titles that are present in the
`no-intro` reference but had **no** genre, developer, publisher, or
franchise entry.

- **genre**: 45 (from the database's existing controlled vocabulary)
- **developer**: 44
- **publisher**: 45
- **franchise**: 43 (set only where a title belongs to a recognized series)

Each entry is matched to the game by the **existing no-intro ROM CRC**,
and every value is region-matched to the No-Intro name (`(USA)` → NA
release, `(Europe)` → EU, etc.). No new titles, renames, or changes to
existing entries — this is purely additive.

### Sourcing

Values were sourced from Wikipedia and MobyGames (the latter via archived
snapshots where the live site blocked automated access), region-matched.
Genres map each title's descriptive genre onto the database's existing
vocabulary (e.g. action-adventure → "Action", rhythm → "Music",
Metroidvania → "Platform").

One field is intentionally omitted: the DS-specific *developer* of
Star Wars Episode III (only a single source credits it), while its
genre/publisher/franchise/year are included.
