### PR TITLE
dat: Add Release Year to various Nintendo DS games

### DIFF
--- a/metadat/releaseyear/Nintendo - Nintendo DS.dat
+++ b/metadat/releaseyear/Nintendo - Nintendo DS.dat
@@ -1,0 +1,274 @@
+clrmamepro (
+	name "Nintendo - Nintendo DS"
+	description "Nintendo - Nintendo DS"
+)
+
+game (
+	comment "Advance Wars - Days of Ruin (USA) (En,Fr,Es)"
+	releaseyear "2008"
+	rom ( crc EAC313F3 )
+)
+
+game (
+	comment "Advance Wars - Dual Strike (USA, Australia)"
+	releaseyear "2005"
+	rom ( crc 4D9A91E3 )
+)
+
+game (
+	comment "Age of Empires - The Age of Kings (Europe) (En,Fr,De)"
+	releaseyear "2006"
+	rom ( crc B5AECC63 )
+)
+
+game (
+	comment "Animal Crossing - Wild World (Europe) (En,Fr,De,Es,It)"
+	releaseyear "2006"
+	rom ( crc C677970C )
+)
+
+game (
+	comment "Asphalt - Urban GT (USA) (En,Fr,Es)"
+	releaseyear "2004"
+	rom ( crc 4F604498 )
+)
+
+game (
+	comment "Bomberman (USA)"
+	releaseyear "2005"
+	rom ( crc 4A51692E )
+)
+
+game (
+	comment "Bomberman Land Touch! (Europe) (En,Fr,De,Es,It)"
+	releaseyear "2007"
+	rom ( crc 7A3B375D )
+)
+
+game (
+	comment "Castlevania - Dawn of Sorrow (USA)"
+	releaseyear "2005"
+	rom ( crc 135737F6 )
+)
+
+game (
+	comment "Castlevania - Portrait of Ruin (Europe) (En,Fr,De,Es,It)"
+	releaseyear "2007"
+	rom ( crc 772BA12A )
+)
+
+game (
+	comment "Chrono Trigger (USA) (En,Fr)"
+	releaseyear "2008"
+	rom ( crc B3836946 )
+)
+
+game (
+	comment "Contra 4 (USA)"
+	releaseyear "2007"
+	rom ( crc B9DF4B8E )
+)
+
+game (
+	comment "DK - Jungle Climber (USA)"
+	releaseyear "2007"
+	rom ( crc 038EED18 )
+)
+
+game (
+	comment "Dragon Quest Heroes - Rocket Slime (USA)"
+	releaseyear "2006"
+	rom ( crc 076053F0 )
+)
+
+game (
+	comment "Dragon Quest IX - Sentinels of the Starry Skies (USA) (En,Fr,Es)"
+	releaseyear "2010"
+	rom ( crc AACE5E9C )
+)
+
+game (
+	comment "Elite Beat Agents (USA)"
+	releaseyear "2006"
+	rom ( crc 26BC50A1 )
+)
+
+game (
+	comment "Grand Theft Auto - Chinatown Wars (USA) (En,Fr,De,Es,It)"
+	releaseyear "2009"
+	rom ( crc CC50CF7E )
+)
+
+game (
+	comment "Kirby - Canvas Curse (USA)"
+	releaseyear "2005"
+	rom ( crc FE7DC5EE )
+)
+
+game (
+	comment "Legend of Zelda, The - Phantom Hourglass (USA) (En,Fr,Es)"
+	releaseyear "2007"
+	rom ( crc 8B431C41 )
+)
+
+game (
+	comment "Legend of Zelda, The - Spirit Tracks (USA) (En,Fr,Es) (Rev 1)"
+	releaseyear "2009"
+	rom ( crc 319A13E5 )
+)
+
+game (
+	comment "Lunar Knights (Europe) (En,Fr,De,Es,It)"
+	releaseyear "2007"
+	rom ( crc 84953087 )
+)
+
+game (
+	comment "Madagascar (USA)"
+	releaseyear "2005"
+	rom ( crc 2EC117B7 )
+)
+
+game (
+	comment "Mario & Luigi - Partners in Time (Europe) (En,Fr,De,Es,It)"
+	releaseyear "2006"
+	rom ( crc 3184FBC4 )
+)
+
+game (
+	comment "Mario Kart DS (Europe) (En,Fr,De,Es,It)"
+	releaseyear "2005"
+	rom ( crc 94E8127E )
+)
+
+game (
+	comment "Mario vs. Donkey Kong 2 - March of the Minis (Europe) (En,Fr,De,Es,It)"
+	releaseyear "2007"
+	rom ( crc 11652805 )
+)
+
+game (
+	comment "Meteos (Europe) (En,Fr,De,Es,It)"
+	releaseyear "2005"
+	rom ( crc 2ED041E2 )
+)
+
+game (
+	comment "Need for Speed - Underground 2 (USA) (En,Fr,De,Es,It)"
+	releaseyear "2005"
+	rom ( crc C37AB273 )
+)
+
+game (
+	comment "New Super Mario Bros. (Europe) (En,Fr,De,Es,It)"
+	releaseyear "2006"
+	rom ( crc F443F9BF )
+)
+
+game (
+	comment "Phoenix Wright - Ace Attorney (USA)"
+	releaseyear "2005"
+	rom ( crc BE5FB8D8 )
+)
+
+game (
+	comment "Planet Puzzle League (USA)"
+	releaseyear "2007"
+	rom ( crc E26F344A )
+)
+
+game (
+	comment "Pokemon Dash (USA)"
+	releaseyear "2005"
+	rom ( crc 0D8B2B06 )
+)
+
+game (
+	comment "Professor Layton and the Curious Village (USA, Australia)"
+	releaseyear "2008"
+	rom ( crc 08DAC15E )
+)
+
+game (
+	comment "Professor Layton and the Unwound Future (USA)"
+	releaseyear "2010"
+	rom ( crc B311E1EC )
+)
+
+game (
+	comment "Sonic Rush (Europe) (En,Ja,Fr,De,Es,It)"
+	releaseyear "2005"
+	rom ( crc 0A0DEC19 )
+)
+
+game (
+	comment "Sonic Rush Adventure (Europe) (En,Ja,Fr,De,Es,It)"
+	releaseyear "2007"
+	rom ( crc 0131034B )
+)
+
+game (
+	comment "Spider-Man 2 (USA)"
+	releaseyear "2004"
+	rom ( crc 3B275B19 )
+)
+
+game (
+	comment "Spider-Man 3 (United Kingdom)"
+	releaseyear "2007"
+	rom ( crc 49EB3DD7 )
+)
+
+game (
+	comment "Star Wars - Episode III - Revenge of the Sith (Europe) (En,Fr,De,Es,It,Nl)"
+	releaseyear "2005"
+	rom ( crc 3F3F7DC8 )
+)
+
+game (
+	comment "Super Mario 64 DS (Europe) (En,Fr,De,Es,It)"
+	releaseyear "2005"
+	rom ( crc 29715DEC )
+)
+
+game (
+	comment "Tony Hawk's American Sk8land (Europe) (En,Fr,De,Es,It)"
+	releaseyear "2005"
+	rom ( crc EA283807 )
+)
+
+game (
+	comment "Tony Hawk's Downhill Jam (Europe) (En,Fr,De,Es,It)"
+	releaseyear "2006"
+	rom ( crc ED75B040 )
+)
+
+game (
+	comment "WarioWare - Touched! (Europe) (En,Fr,De,Es,It)"
+	releaseyear "2005"
+	rom ( crc 8CAF8639 )
+)
+
+game (
+	comment "Worms - Open Warfare (USA)"
+	releaseyear "2006"
+	rom ( crc ECB40FD3 )
+)
+
+game (
+	comment "Worms - Open Warfare 2 (USA) (En,Fr)"
+	releaseyear "2007"
+	rom ( crc 500C0C53 )
+)
+
+game (
+	comment "Yoshi Touch & Go (Europe) (En,Fr,De,Es,It)"
+	releaseyear "2005"
+	rom ( crc 1D829D6F )
+)
+
+game (
+	comment "Yu-Gi-Oh! - Nightmare Troubadour (USA)"
+	releaseyear "2005"
+	rom ( crc 2CEFE04D )
+)


### PR DESCRIPTION
## Add release years for Nintendo DS (new releaseyear dat)

The Nintendo DS platform had no `metadat/releaseyear` file. This adds one with **45** titles (companion to the genre/developer/publisher/franchise additions in a separate PR).

Each year is matched to the game by the **existing no-intro ROM CRC** and region-matched to the No-Intro name — `(USA)` → North American release year, `(Europe)` → European, and for multi-region dumps like `(USA, Australia)` the earliest listed region's year — consistent with the releaseyear dats for other platforms.

Sourced from Wikipedia and MobyGames (region-matched).
