### PR TITLE
Add Better descriptions for some Digimon World DS (USA) cheats

### DIFF
--- a/cht/Nintendo - Nintendo DS/Digimon World DS (USA).cht
+++ b/cht/Nintendo - Nintendo DS/Digimon World DS (USA).cht
@@ -24,7 +24,7 @@ cheat6_desc = "Digimon Gallery Complete!"
 cheat6_code = "121E045E+0000FFFF+021E0460+FFFFFFFF+021E0464+FFFFFFFF+021E0468+FFFFFFFF+021E046C+FFFFFFFF+021E0470+FFFFFFFF+021E0474+FFFFFFFF+021E0478+FFFFFFFF+021E047C+FFFFFFFF+021E0480+FFFFFFFF+121E0484+0000FFFF"
 cheat6_enable = false
 
-cheat7_desc = "All Digimon 999% Scans"
+cheat7_desc = "All Digimon 999% Scans (Press SELECT)"
 cheat7_code = "94000130+FFFB0000+D5000000+3E700000+C0000000+0000013C+D6000000+021E0498+D2000000+00000000"
 cheat7_enable = false
 
@@ -32,11 +32,11 @@ cheat8_desc = "No Random Battles"
 cheat8_code = "221ABC59+00000000"
 cheat8_enable = false
 
-cheat9_desc = "No Random Battles (ASM)"
+cheat9_desc = "No Random Battles (ASM) (Activate: Press L + D-pad Up) (Deactivate: Press L + D-pad Down)"
 cheat9_code = "94000130+FDBF0000+02201670+E1A00000+D2000000+00000000+94000130+FD7F0000+02201670+E0810000+D2000000+00000000"
 cheat9_enable = false
 
-cheat10_desc = "Random Battles"
+cheat10_desc = "Random Battles (Press L) (Battle starts on next step)"
 cheat10_code = "94000130+FDFF0000+221ABC59+000000FF+D2000000+00000000"
 cheat10_enable = false
 


### PR DESCRIPTION
Knowing the precise button combinations to acitvate some commonly used cheats is ambiguous and requires browsing old forums. This should make it obvious to know from RetroArch itself.