### PR TITLE
Add NES Super Mario Bros. Game Genie codes

### DIFF
--- a/cht/Nintendo - Nintendo Entertainment System/Super Mario Bros. (World).cht
+++ b/cht/Nintendo - Nintendo Entertainment System/Super Mario Bros. (World).cht
@@ -1,4 +1,4 @@
-cheats = 678
+cheats = 725
 
 cheat0_desc = "Always Big"
 cheat0_code = "0754:00+0756:01"
@@ -2711,3 +2711,191 @@ cheat676_enable = false
 cheat677_desc = "Don't Get Stuck At The Top Of The Screen"
 cheat677_code = "AAYLYA+AAYOGP"
 cheat677_enable = false
+
+cheat678_desc = "Dying runs the fire-flower routine"
+cheat678_code = "IYVLIEPV"
+cheat678_enable = false
+
+cheat679_desc = "Mushroom and flower blocks give a star instead"
+cheat679_code = "SSKLEIXI"
+cheat679_enable = false
+
+cheat680_desc = "The flagpole skips the time-to-score countdown"
+cheat680_code = "XXVSGZZP"
+cheat680_enable = false
+
+cheat681_desc = "Throwing a fireball pushes Mario to the right"
+cheat681_code = "YISLZVNY"
+cheat681_enable = false
+
+cheat682_desc = "Pressing Start grants injury invulnerability for a long time"
+cheat682_code = "VOXETPYN"
+cheat682_enable = false
+
+cheat683_desc = "Throwing a fireball slams Mario downward"
+cheat683_code = "NPSLZVNN"
+cheat683_enable = false
+
+cheat684_desc = "Green Koopa Troopas move like Red Paratroopas"
+cheat684_code = "NYEKXPYN"
+cheat684_enable = false
+
+cheat685_desc = "Piranha Plants bob like Podoboos"
+cheat685_code = "OGXGSPUS"
+cheat685_enable = false
+
+cheat686_desc = "Mushroom and flower blocks grow a vine instead"
+cheat686_code = "NSKLEIXS"
+cheat686_enable = false
+
+cheat687_desc = "Every row of bricks is replaced with a jump spring"
+cheat687_code = "UIVOLVTZ"
+cheat687_enable = false
+
+cheat688_desc = "Every enemy becomes a Green Koopa when it lands from falling"
+cheat688_code = "TOSVPETP"
+cheat688_enable = false
+
+cheat689_desc = "Fire Flowers also award a 1-up"
+cheat689_code = "ZLUSEAYK"
+cheat689_enable = false
+
+cheat690_desc = "Getting hurt briefly lets you kill on contact"
+cheat690_code = "VOESUENO"
+cheat690_enable = false
+
+cheat691_desc = "Kicked shells move really slowly"
+cheat691_code = "PSVIOEYG"
+cheat691_enable = false
+
+cheat692_desc = "Lakitu throws Hammer Bros"
+cheat692_code = "TPKKIKTP"
+cheat692_enable = false
+
+cheat693_desc = "Lakitu throws FlyingCheepCheep"
+cheat693_code = "TPKKIKTP+GPKKLGIA"
+cheat693_enable = false
+
+cheat694_desc = "Lakitu throws GreenParatroopaFly"
+cheat694_code = "TPKKIKTP+APKKLGIA"
+cheat694_enable = false
+
+cheat695_desc = "Lakitu throws GreenParatroopaJump"
+cheat695_code = "TPKKIKTP+TAKKLGIE"
+cheat695_enable = false
+
+cheat696_desc = "Lakitu throws GreyCheepCheep"
+cheat696_code = "TPKKIKTP+ZAKKLGIE"
+cheat696_enable = false
+
+cheat697_desc = "Lakitu throws Podoboo"
+cheat697_code = "TPKKIKTP+GAKKLGIE"
+cheat697_enable = false
+
+cheat698_desc = "Lakitu throws RedKoopa"
+cheat698_code = "TPKKIKTP+LAKKLGIA"
+cheat698_enable = false
+
+cheat699_desc = "Lakitu throws Lakitu"
+cheat699_code = "TPKKIKTP+PPKKLGIA"
+cheat699_enable = false
+
+cheat700_desc = "Spiny Egg hatches into BulletBill_FrenzyVar"
+cheat700_code = "TOUTZATG+AEUTAAPE"
+cheat700_enable = false
+
+cheat701_desc = "Spiny Egg hatches into BuzzyBeetle"
+cheat701_code = "TOUTZATG+ZEUTAAPA"
+cheat701_enable = false
+
+cheat702_desc = "Spiny Egg hatches into FlyingCheepCheep"
+cheat702_code = "TOUTZATG+GOUTAAPA"
+cheat702_enable = false
+
+cheat703_desc = "Spiny Egg hatches into Goomba"
+cheat703_code = "TOUTZATG+TEUTAAPA"
+cheat703_enable = false
+
+cheat704_desc = "Spiny Egg hatches into GreenKoopa"
+cheat704_code = "TOUTZATG+AEUTAAPA"
+cheat704_enable = false
+
+cheat705_desc = "Spiny Egg hatches into GreenParatroopaFly"
+cheat705_code = "TOUTZATG+AOUTAAPA"
+cheat705_enable = false
+
+cheat706_desc = "Spiny Egg hatches into GreenParatroopaJump"
+cheat706_code = "TOUTZATG+TEUTAAPE"
+cheat706_enable = false
+
+cheat707_desc = "Spiny Egg hatches into GreyCheepCheep"
+cheat707_code = "TOUTZATG+ZEUTAAPE"
+cheat707_enable = false
+
+cheat708_desc = "Spiny Egg hatches into PiranhaPlant"
+cheat708_code = "TOUTZATG+IEUTAAPE"
+cheat708_enable = false
+
+cheat709_desc = "Spiny Egg hatches into Podoboo"
+cheat709_code = "TOUTZATG+GEUTAAPE"
+cheat709_enable = false
+
+cheat710_desc = "Spiny Egg hatches into RedCheepCheep"
+cheat710_code = "TOUTZATG+LEUTAAPE"
+cheat710_enable = false
+
+cheat711_desc = "Spiny Egg hatches into RedKoopa"
+cheat711_code = "TOUTZATG+LEUTAAPA"
+cheat711_enable = false
+
+cheat712_desc = "Spiny Egg hatches into RedParatroopa"
+cheat712_code = "TOUTZATG+YEUTAAPE"
+cheat712_enable = false
+
+cheat713_desc = "Spinies drop from the air repeatedly"
+cheat713_code = "NKUTZATK+AXUTAAPA"
+cheat713_enable = false
+
+cheat714_desc = "Up while standing makes Mario enter a secret pipe"
+cheat714_code = "AEVSUTGE+AENIUTTI+AENSOTAI"
+cheat714_enable = false
+
+cheat715_desc = "Up fires the fireworks blast sound"
+cheat715_code = "VYOUAOLE"
+cheat715_enable = false
+
+cheat716_desc = "Pressing Up on a secret pipe climbs an invisible vine into the sky"
+cheat716_code = "AEVSUTGE+PAEIEYLA"
+cheat716_enable = false
+
+cheat717_desc = "Pressing Up costs a life"
+cheat717_code = "AEVSUTGE+AENIUTTI+AENSOTAI+TAEIEYLA"
+cheat717_enable = false
+
+cheat718_desc = "Pressing Up makes Mario hide in the background"
+cheat718_code = "AEVSUTGE+AENIUTTI+AENSOTAI+YAEIEYLA"
+cheat718_enable = false
+
+cheat719_desc = "Hammer Bros throw spiny eggs"
+cheat719_code = "AKNKSPKP+NKNKVOXU+IEUKALPP+AENGALKY"
+cheat719_enable = false
+
+cheat720_desc = "Hammer Bros summon a bullet bill barrage"
+cheat720_code = "AKNKSPKP+NKNKVOXU+YPKGOYZP"
+cheat720_enable = false
+
+cheat721_desc = "Hammer Bros summon Bowser's fire breath"
+cheat721_code = "AKNKSPKP+NKNKVOXU+IPKGOYZP"
+cheat721_enable = false
+
+cheat722_desc = "Hammer Bros summon leaping cheep-cheeps"
+cheat722_code = "AKNKSPKP+NKNKVOXU+GPKGOYZP"
+cheat722_enable = false
+
+cheat723_desc = "Every free enemy slot clones the first enemy in the area"
+cheat723_code = "TPUGAOSG+AAUGPPTA"
+cheat723_enable = false
+
+cheat724_desc = "Fireballs stick to Mario then explode (fireball init latch inverted)"
+cheat724_code = "VNUUGTVI"
+cheat724_enable = false


### PR DESCRIPTION
Adds my newly-discovered Game Genie cheat codes for Super Mario Bros., covering enemy spawn and hatch behavior, changing what Hammer Bros and Lakitu throw, secret pipe and Up-button behavior, and other gameplay changes.