### PR TITLE
metadat: fix doubled quote that makes 6 Arduboy entries unparseable

### DIFF
--- a/metadat/lost-level-archive/Arduboy Inc - Arduboy.dat
+++ b/metadat/lost-level-archive/Arduboy Inc - Arduboy.dat
@@ -146,7 +146,7 @@ game (
 
 game (
 	name "Tunnel Terror (World) (tomsk666)"
-	description ""Tunnel Terror (World) (tomsk666)"
+	description "Tunnel Terror (World) (tomsk666)"
 	rom ( name "Tunnel Terror (World) (tomsk666).hex" size 53453 crc 8bd52174 md5 261fc7523620b31920a1ca923a598f67 sha1 29f43d46eb39a970c23418506b523bc560a394b5 )
 )
 


### PR DESCRIPTION
`metadat/lost-level-archive/Arduboy Inc - Arduboy.dat` line 149 has a doubled opening quote:

```
	name "Tunnel Terror (World) (tomsk666)"
	description ""Tunnel Terror (World) (tomsk666)"
```

The stray second quote opens a string that never closes where it should, so everything after it is swallowed into one quoted value and the remaining entries in the file stop parsing. The file holds 29 games; a quote-aware parser sees 23. The six it cannot reach are Tunnel Terror itself, Vectramblex v1.00 and v1.01, Video Poker, Virus LQP-79 and Wolf & Eggs.

The fix removes the one extra character, leaving the description matching the name on the line above. With it applied the file parses to all 29 games, and `scripts/clrmamepro-sorter.py` accepts it.

Nothing else in the file is touched.
