### PR TITLE
metadat: repair whitespace defects in curated values

### DIFF
--- a/metadat/developer/Atari - 2600.dat
+++ b/metadat/developer/Atari - 2600.dat
@@ -1343,7 +1343,7 @@ game (
 
 game (
 	comment "Donkey Kong (USA)"
-	developer "Ikegami Tsushinki "
+	developer "Ikegami Tsushinki"
 	rom ( crc F331B069 )
 )
 
@@ -1523,7 +1523,7 @@ game (
 
 game (
 	comment "Final Approach (USA)"
-	developer "Apollo, Inc."
+	developer "Apollo, Inc."
 	rom ( crc FF23F469 )
 )
 
@@ -1745,7 +1745,7 @@ game (
 
 game (
 	comment "Guardian (USA)"
-	developer "Apollo, Inc."
+	developer "Apollo, Inc."
 	rom ( crc 121738F5 )
 )
 
@@ -1847,7 +1847,7 @@ game (
 
 game (
 	comment "Infiltrate (USA)"
-	developer "Apollo, Inc."
+	developer "Apollo, Inc."
 	rom ( crc 612BD4DA )
 )
 
@@ -2003,7 +2003,7 @@ game (
 
 game (
 	comment "Lochjaw (USA)"
-	developer "Apollo, Inc."
+	developer "Apollo, Inc."
 	rom ( crc B2A2FF31 )
 )
 
@@ -2021,7 +2021,7 @@ game (
 
 game (
 	comment "Looping (USA) (Proto)"
-	developer "Apollo, Inc."
+	developer "Apollo, Inc."
 	rom ( crc F9B23F09 )
 )
 
@@ -2033,7 +2033,7 @@ game (
 
 game (
 	comment "Lost Luggage (USA)"
-	developer "Apollo, Inc."
+	developer "Apollo, Inc."
 	rom ( crc 551BDD37 )
 )
 
@@ -2561,7 +2561,7 @@ game (
 
 game (
 	comment "Pompeii (USA) (Proto)"
-	developer "Apollo, Inc."
+	developer "Apollo, Inc."
 	rom ( crc 83D8A362 )
 )
 
@@ -2669,7 +2669,7 @@ game (
 
 game (
 	comment "Racquetball (USA)"
-	developer "Apollo, Inc."
+	developer "Apollo, Inc."
 	rom ( crc 7EEF9AC0 )
 )
 
@@ -2993,7 +2993,7 @@ game (
 
 game (
 	comment "Skeet Shoot (USA)"
-	developer "Apollo, Inc."
+	developer "Apollo, Inc."
 	rom ( crc 57D69B13 )
 )
 
@@ -3125,7 +3125,7 @@ game (
 
 game (
 	comment "Space Cavern (USA)"
-	developer "Apollo, Inc."
+	developer "Apollo, Inc."
 	rom ( crc 3B0FFD89 )
 )
 
@@ -3155,7 +3155,7 @@ game (
 
 game (
 	comment "Spacechase (USA)"
-	developer "Apollo, Inc."
+	developer "Apollo, Inc."
 	rom ( crc 2954D22D )
 )
 
@@ -3659,7 +3659,7 @@ game (
 
 game (
 	comment "Tooth Protectors (USA)"
-	developer "Camelot, Inc."
+	developer "Camelot, Inc."
 	rom ( crc FD8C81E5 )
 )
 
@@ -3803,7 +3803,7 @@ game (
 
 game (
 	comment "Wabbit (USA)"
-	developer "Apollo, Inc."
+	developer "Apollo, Inc."
 	rom ( crc 2D07ED77 )
 )
 

--- a/metadat/developer/Atari - 5200.dat
+++ b/metadat/developer/Atari - 5200.dat
@@ -311,7 +311,7 @@ game (
 
 game (
 	comment "Mr. Do!'s Castle (USA)"
-	developer "Universal "
+	developer "Universal"
 	rom ( crc AA55F9BE )
 )
 

--- a/metadat/developer/Bandai - WonderSwan.dat
+++ b/metadat/developer/Bandai - WonderSwan.dat
@@ -665,13 +665,13 @@ game (
 
 game (
 	comment "Trump Collection - Bottom-Up Teki Trump Seikatsu (Japan) (Rev 1)"
-	developer "Bottom Up Interactive"
+	developer "Bottom Up Interactive"
 	rom ( crc C283EC5F )
 )
 
 game (
 	comment "Trump Collection 2 - Bottom-Up Teki Sekaiisshuu no Tabi (Japan) (Rev 1)"
-	developer "Bottom Up Interactive"
+	developer "Bottom Up Interactive"
 	rom ( crc 64AAF392 )
 )
 

--- a/metadat/developer/Coleco - ColecoVision.dat
+++ b/metadat/developer/Coleco - ColecoVision.dat
@@ -521,7 +521,7 @@ game (
 
 game (
 	comment "Lady Bug (USA, Europe)"
-	developer "Universal "
+	developer "Universal"
 	rom ( crc 2C3097B8 )
 )
 
@@ -635,7 +635,7 @@ game (
 
 game (
 	comment "Mr. Do! (USA, Europe)"
-	developer "Universal "
+	developer "Universal"
 	rom ( crc 461AB6AD )
 )
 
@@ -653,7 +653,7 @@ game (
 
 game (
 	comment "Mr. Do!'s Castle (USA)"
-	developer "Universal "
+	developer "Universal"
 	rom ( crc 546F2C54 )
 )
 
@@ -851,7 +851,7 @@ game (
 
 game (
 	comment "Space Panic (USA, Europe)"
-	developer "Universal "
+	developer "Universal"
 	rom ( crc 5BDF2997 )
 )
 

--- a/metadat/developer/Magnavox - Odyssey 2.dat
+++ b/metadat/developer/Magnavox - Odyssey 2.dat
@@ -65,7 +65,7 @@ game (
 
 game (
 	comment "Blobbers, The (Europe)"
-	developer "GST Video"
+	developer "GST Video"
 	rom ( crc 9D72D4E9 )
 )
 
@@ -131,7 +131,7 @@ game (
 
 game (
 	comment "Comando Noturno (Brazil)"
-	developer "GST Video"
+	developer "GST Video"
 	rom ( crc 26517E77 )
 )
 
@@ -371,13 +371,13 @@ game (
 
 game (
 	comment "Martian Threat (Europe) (Proto) (Alt)"
-	developer "GST Video"
+	developer "GST Video"
 	rom ( crc 335481F1 )
 )
 
 game (
 	comment "Martian Threat (Europe) (Proto)"
-	developer "GST Video"
+	developer "GST Video"
 	rom ( crc 39E31BF0 )
 )
 
@@ -449,7 +449,7 @@ game (
 
 game (
 	comment "Nightfighter (Europe) (Proto)"
-	developer "GST Video"
+	developer "GST Video"
 	rom ( crc 7BE6F1EF )
 )
 
@@ -581,7 +581,7 @@ game (
 
 game (
 	comment "Shark Hunter (Europe) (Proto)"
-	developer "GST Video"
+	developer "GST Video"
 	rom ( crc DF36683F )
 )
 

--- a/metadat/developer/Mattel - Intellivision.dat
+++ b/metadat/developer/Mattel - Intellivision.dat
@@ -395,7 +395,7 @@ game (
 
 game (
 	comment "Lady Bug (USA, Europe)"
-	developer "Universal "
+	developer "Universal"
 	rom ( crc A6840736 )
 )
 

--- a/metadat/developer/Microsoft - MSX 2.dat
+++ b/metadat/developer/Microsoft - MSX 2.dat
@@ -93,7 +93,7 @@ game (
 
 game (
 	comment "AshGuine Story II - Kokuu no Gajou (Japan)"
-	developer "T&E; Soft"
+	developer "T&E Soft"
 	rom (
 		crc 47A82D74
 	)
@@ -525,7 +525,7 @@ game (
 
 game (
 	comment "Hydlide 3 - The Space Memories (Japan)"
-	developer "T&E; Soft"
+	developer "T&E Soft"
 	rom (
 		crc 00DB86C8
 	)

--- a/metadat/developer/Microsoft - MSX.dat
+++ b/metadat/developer/Microsoft - MSX.dat
@@ -389,7 +389,7 @@ game (
 
 game (
 	comment "Battle Cross (Japan)"
-	developer "Omori Electronics Corporation"
+	developer "Omori Electronics Corporation"
 	rom ( crc 25E675EA )
 )
 
@@ -1109,7 +1109,7 @@ game (
 
 game (
 	comment "Dragon Quest (Japan)"
-	developer "Armor Project"
+	developer "Armor Project"
 	rom ( crc 49F5478B )
 )
 
@@ -1169,7 +1169,7 @@ game (
 
 game (
 	comment "Dynamite Bowl (Japan)"
-	developer "Softvision Co., Ltd."
+	developer "Softvision Co., Ltd."
 	rom ( crc 47EC57DA )
 )
 
@@ -1247,7 +1247,7 @@ game (
 
 game (
 	comment "F16 Fighting Falcon (Japan)"
-	developer "Nexa Corporation"
+	developer "Nexa Corporation"
 	rom ( crc 70A0CB2C )
 )
 
@@ -2669,7 +2669,7 @@ game (
 
 game (
 	comment "Mouser (Japan)"
-	developer "Gebelli Software, Inc."
+	developer "Gebelli Software, Inc."
 	rom ( crc 06A64527 )
 )
 
@@ -2681,7 +2681,7 @@ game (
 
 game (
 	comment "Mr. Do (Japan)"
-	developer "Universal "
+	developer "Universal"
 	rom ( crc 4098D71D )
 )
 
@@ -3677,7 +3677,7 @@ game (
 
 game (
 	comment "Super Pierrot (Japan)"
-	developer "Universal "
+	developer "Universal"
 	rom ( crc F00B4BBC )
 )
 
@@ -3845,7 +3845,7 @@ game (
 
 game (
 	comment "Topple Zip (Japan)"
-	developer "MiCROViSion Inc."
+	developer "MiCROViSion Inc."
 	rom ( crc 190F4CE5 )
 )
 

--- a/metadat/developer/Microsoft - MSX2.dat
+++ b/metadat/developer/Microsoft - MSX2.dat
@@ -167,7 +167,7 @@ game (
 
 game (
 	comment "Dragon Quest (Japan)"
-	developer "Armor Project"
+	developer "Armor Project"
 	rom ( crc 7729E7A9 )
 )
 
@@ -209,7 +209,7 @@ game (
 
 game (
 	comment "Dynamite Bowl (Japan)"
-	developer "Softvision Co., Ltd."
+	developer "Softvision Co., Ltd."
 	rom ( crc 9935E9BD )
 )
 
@@ -221,7 +221,7 @@ game (
 
 game (
 	comment "Dynamite Bowl (Japan) (Alt)"
-	developer "Softvision Co., Ltd."
+	developer "Softvision Co., Ltd."
 	rom ( crc A4996AAA )
 )
 
@@ -617,7 +617,7 @@ game (
 
 game (
 	comment "Predator (Japan)"
-	developer "Source the Software House Ltd."
+	developer "Source the Software House Ltd."
 	rom ( crc E85A4A6B )
 )
 
@@ -911,7 +911,7 @@ game (
 
 game (
 	comment "Zombie Hunter (Japan)"
-	developer "Hi-Score Media Work Corp."
+	developer "Hi-Score Media Work Corp."
 	rom ( crc A29E6AB4 )
 )
 

--- a/metadat/developer/Nintendo - Game Boy Advance.dat
+++ b/metadat/developer/Nintendo - Game Boy Advance.dat
@@ -1703,7 +1703,7 @@ game (
 
 game (
 	comment "BattleBots - Beyond the BattleBox (Europe) (En,Fr,De)"
-	developer "Universal "
+	developer "Universal"
 	rom ( crc 60BFCC8E )
 )
 
@@ -1721,7 +1721,7 @@ game (
 
 game (
 	comment "BattleBots - Beyond the BattleBox (USA)"
-	developer "Universal "
+	developer "Universal"
 	rom ( crc 985B3704 )
 )
 
@@ -2885,13 +2885,13 @@ game (
 
 game (
 	comment "Chicken Little (USA, Europe) (En,Fr,De,Es,It,Nl)"
-	developer "Avalanche Software"
+	developer "Avalanche Software"
 	rom ( crc 1E86F5B0 )
 )
 
 game (
 	comment "Chicken Little (Japan)"
-	developer "Avalanche Software"
+	developer "Avalanche Software"
 	rom ( crc DCBD4991 )
 )
 
@@ -5765,7 +5765,7 @@ game (
 
 game (
 	comment "Final Fire Pro Wrestling - Yume no Dantai Unei! (Japan)"
-	developer "Spike Co"
+	developer "Spike Co"
 	rom ( crc A0093822 )
 )
 
@@ -5963,7 +5963,7 @@ game (
 
 game (
 	comment "Fire Pro Wrestling 2 (USA)"
-	developer "Spike Co"
+	developer "Spike Co"
 	rom ( crc B9CFC1D3 )
 )
 
@@ -12173,7 +12173,7 @@ game (
 
 game (
 	comment "Pixeline i Pixieland (Denmark)"
-	developer "Krea Medie"
+	developer "Krea Medie"
 	rom ( crc 20B72D17 )
 )
 

--- a/metadat/developer/Nintendo - Game Boy Color.dat
+++ b/metadat/developer/Nintendo - Game Boy Color.dat
@@ -431,7 +431,7 @@ game (
 
 game (
 	comment "Aventures de Buzz l'Eclair, Les (France)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 841674B0 )
 )
 
@@ -1019,7 +1019,7 @@ game (
 
 game (
 	comment "Buzz Lightyear of Star Command (USA, Europe)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 84E29B87 )
 )
 
@@ -1049,7 +1049,7 @@ game (
 
 game (
 	comment "Captain Buzz Lightyear - Star Command (Germany)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc F06D296C )
 )
 
@@ -6017,13 +6017,13 @@ game (
 
 game (
 	comment "R-Type DX (Japan) (En) (GB Compatible)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc 3623EBB6 )
 )
 
 game (
 	comment "R-Type DX (USA, Europe) (GB Compatible)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc FC1D4089 )
 )
 
@@ -8135,7 +8135,7 @@ game (
 
 game (
 	comment "Warlocked (USA)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc CFA0DF0F )
 )
 
@@ -8393,19 +8393,19 @@ game (
 
 game (
 	comment "Xtreme Wheels (Europe)"
-	developer "Spike Co"
+	developer "Spike Co"
 	rom ( crc E101246F )
 )
 
 game (
 	comment "Xtreme Wheels (USA)"
-	developer "Spike Co"
+	developer "Spike Co"
 	rom ( crc 129465DB )
 )
 
 game (
 	comment "Xtreme Wheels (Japan) (NP)"
-	developer "Spike Co"
+	developer "Spike Co"
 	rom ( crc 30132AB8 )
 )
 

--- a/metadat/developer/Nintendo - Game Boy.dat
+++ b/metadat/developer/Nintendo - Game Boy.dat
@@ -257,13 +257,13 @@ game (
 
 game (
 	comment "Alien 3 (Japan)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc E59049B2 )
 )
 
 game (
 	comment "Alien 3 (USA, Europe)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc EFFB960B )
 )
 
@@ -827,7 +827,7 @@ game (
 
 game (
 	comment "Beavis and Butt-head (USA, Europe)"
-	developer "Viacom New Media"
+	developer "Viacom New Media"
 	rom ( crc AF1AE123 )
 )
 
@@ -1379,19 +1379,19 @@ game (
 
 game (
 	comment "Castelian (USA) (Beta)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc A08CB239 )
 )
 
 game (
 	comment "Castelian (USA)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc F2D739E4 )
 )
 
 game (
 	comment "Castelian (Europe)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc 2F752404 )
 )
 
@@ -2183,25 +2183,25 @@ game (
 
 game (
 	comment "Dr. Franken (Europe) (En,Fr,De,Es,It,Nl,Sv)"
-	developer "Motivetime Ltd."
+	developer "Motivetime Ltd."
 	rom ( crc F13A60B8 )
 )
 
 game (
 	comment "Dr. Franken (Japan)"
-	developer "Motivetime Ltd."
+	developer "Motivetime Ltd."
 	rom ( crc 3D04B8E7 )
 )
 
 game (
 	comment "Dr. Franken (USA)"
-	developer "Motivetime Ltd."
+	developer "Motivetime Ltd."
 	rom ( crc D409375B )
 )
 
 game (
 	comment "Dr. Franken (Europe) (En,Fr,De,Es,It,Nl,Sv) (Beta)"
-	developer "Motivetime Ltd."
+	developer "Motivetime Ltd."
 	rom ( crc A65ADC31 )
 )
 
@@ -2675,7 +2675,7 @@ game (
 
 game (
 	comment "Fire Fighter (Europe)"
-	developer "Teeny Weeny Games, Ltd."
+	developer "Teeny Weeny Games, Ltd."
 	rom ( crc C46BBD49 )
 )
 
@@ -3263,13 +3263,13 @@ game (
 
 game (
 	comment "Heiankyo Alien (USA)"
-	developer "Live Planning"
+	developer "Live Planning"
 	rom ( crc 1495BBE5 )
 )
 
 game (
 	comment "Heiankyou Alien (Japan)"
-	developer "Live Planning"
+	developer "Live Planning"
 	rom ( crc 08BF29C9 )
 )
 
@@ -4229,7 +4229,7 @@ game (
 
 game (
 	comment "Kyoro-chan Land (Japan)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc E158D4DB )
 )
 
@@ -5735,7 +5735,7 @@ game (
 
 game (
 	comment "Ninja Spirit (USA) (Proto)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc 4573CE77 )
 )
 
@@ -5759,7 +5759,7 @@ game (
 
 game (
 	comment "Ninja Spirit (Europe) (Proto)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc 1D266DD2 )
 )
 
@@ -6221,7 +6221,7 @@ game (
 
 game (
 	comment "Picross 2 (Japan) (SGB Enhanced)"
-	developer "Creatures, Inc."
+	developer "Creatures, Inc."
 	rom ( crc F5AA5902 )
 )
 
@@ -6359,7 +6359,7 @@ game (
 
 game (
 	comment "Pocket Golf (Japan)"
-	developer "Bottom Up Interactive"
+	developer "Bottom Up Interactive"
 	rom ( crc 755152BB )
 )
 
@@ -7085,31 +7085,31 @@ game (
 
 game (
 	comment "Robin Hood - Prince of Thieves (Europe)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc 55BBA483 )
 )
 
 game (
 	comment "Robin Hood - Prince of Thieves (France)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc EF1A493A )
 )
 
 game (
 	comment "Robin Hood - Prince of Thieves (Germany)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc 0B2071A3 )
 )
 
 game (
 	comment "Robin Hood - Prince of Thieves (Spain)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc 7846DF7D )
 )
 
 game (
 	comment "Robin Hood - Prince of Thieves (USA)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc E5C8C2B1 )
 )
 
@@ -7271,7 +7271,7 @@ game (
 
 game (
 	comment "Saigo no Nindou (Japan)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc B864A3B6 )
 )
 
@@ -7319,7 +7319,7 @@ game (
 
 game (
 	comment "Scotland Yard (Japan)"
-	developer "Ravensburger Interactive Media GmbH"
+	developer "Ravensburger Interactive Media GmbH"
 	rom ( crc 4A0F5972 )
 )
 
@@ -7637,7 +7637,7 @@ game (
 
 game (
 	comment "Solitaire (Japan)"
-	developer "Odyssey Software, Inc."
+	developer "Odyssey Software, Inc."
 	rom ( crc 1119484A )
 )
 
@@ -7775,19 +7775,19 @@ game (
 
 game (
 	comment "Spider-Man 3 - Invasion of the Spider-Slayers (USA, Europe)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc CBB2F22C )
 )
 
 game (
 	comment "Spider-Man 3 - Invasion of the Spider-Slayers (USA, Europe) (Beta 1)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc DDD8EAB3 )
 )
 
 game (
 	comment "Spider-Man 3 - Invasion of the Spider-Slayers (USA, Europe) (Beta 2) (1993-04-11)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc BF2D1F10 )
 )
 
@@ -9605,7 +9605,7 @@ game (
 
 game (
 	comment "Zoids Densetsu (Japan)"
-	developer "Nova Co"
+	developer "Nova Co"
 	rom ( crc C32DCA06 )
 )
 

--- a/metadat/developer/Nintendo - Nintendo 64.dat
+++ b/metadat/developer/Nintendo - Nintendo 64.dat
@@ -47,7 +47,7 @@ game (
 
 game (
 	comment "64 Oozumou (Japan)"
-	developer "Bottom Up Interactive"
+	developer "Bottom Up Interactive"
 	rom ( crc A6DBF8AE )
 )
 
@@ -77,13 +77,13 @@ game (
 
 game (
 	comment "64 Oozumou 2 (Japan)"
-	developer "Bottom Up Interactive"
+	developer "Bottom Up Interactive"
 	rom ( crc 3CD5E271 )
 )
 
 game (
 	comment "64 Trump Collection - Alice no Wakuwaku Trump World (Japan)"
-	developer "Bottom Up Interactive"
+	developer "Bottom Up Interactive"
 	rom ( crc 34BBB95D )
 )
 
@@ -623,31 +623,31 @@ game (
 
 game (
 	comment "Bug's Life, A (Europe)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 0D101756 )
 )
 
 game (
 	comment "Bug's Life, A (France)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 2420C6FD )
 )
 
 game (
 	comment "Bug's Life, A (Germany)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc DE6CE3EF )
 )
 
 game (
 	comment "Bug's Life, A (Italy)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 04244AAC )
 )
 
 game (
 	comment "Bug's Life, A (USA)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 7C2F610D )
 )
 
@@ -3167,13 +3167,13 @@ game (
 
 game (
 	comment "Mortal Kombat Mythologies - Sub-Zero (Europe)"
-	developer "Avalanche Software"
+	developer "Avalanche Software"
 	rom ( crc 1063DA05 )
 )
 
 game (
 	comment "Mortal Kombat Mythologies - Sub-Zero (USA)"
-	developer "Avalanche Software"
+	developer "Avalanche Software"
 	rom ( crc F0F7D9E3 )
 )
 
@@ -3629,13 +3629,13 @@ game (
 
 game (
 	comment "Off Road Challenge (Europe)"
-	developer "Avalanche Software"
+	developer "Avalanche Software"
 	rom ( crc E1938232 )
 )
 
 game (
 	comment "Off Road Challenge (USA)"
-	developer "Avalanche Software"
+	developer "Avalanche Software"
 	rom ( crc 129BADCC )
 )
 
@@ -3689,7 +3689,7 @@ game (
 
 game (
 	comment "Onegai Monsters (Japan)"
-	developer "Bottom Up Interactive"
+	developer "Bottom Up Interactive"
 	rom ( crc FF03EC8A )
 )
 
@@ -4193,13 +4193,13 @@ game (
 
 game (
 	comment "Rampage 2 - Universal Tour (Europe)"
-	developer "Avalanche Software"
+	developer "Avalanche Software"
 	rom ( crc 0D4654A8 )
 )
 
 game (
 	comment "Rampage 2 - Universal Tour (USA)"
-	developer "Avalanche Software"
+	developer "Avalanche Software"
 	rom ( crc 75E8C2AD )
 )
 
@@ -4421,13 +4421,13 @@ game (
 
 game (
 	comment "Rugrats in Paris - The Movie (USA)"
-	developer "Avalanche Software"
+	developer "Avalanche Software"
 	rom ( crc 8F09AF37 )
 )
 
 game (
 	comment "Rugrats in Paris - The Movie (Europe)"
-	developer "Avalanche Software"
+	developer "Avalanche Software"
 	rom ( crc 17BD7518 )
 )
 
@@ -5255,7 +5255,7 @@ game (
 
 game (
 	comment "Toon Panic (Japan) (Proto)"
-	developer "Bottom Up Interactive"
+	developer "Bottom Up Interactive"
 	rom ( crc 55C88F04 )
 )
 
@@ -5357,7 +5357,7 @@ game (
 
 game (
 	comment "Toy Story 2 - Buzz l'Eclair a la Rescousse! (France)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 2AF45190 )
 )
 
@@ -5369,25 +5369,25 @@ game (
 
 game (
 	comment "Toy Story 2 - Buzz Lightyear to the Rescue! (Europe)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc C1C5B460 )
 )
 
 game (
 	comment "Toy Story 2 - Buzz Lightyear to the Rescue! (USA)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc F7A72276 )
 )
 
 game (
 	comment "Toy Story 2 - Buzz Lightyear to the Rescue! (USA) (Rev 1)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc A11F0F8E )
 )
 
 game (
 	comment "Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 33FD1561 )
 )
 
@@ -5399,7 +5399,7 @@ game (
 
 game (
 	comment "Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany) (Rev 1)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 1878086F )
 )
 
@@ -6263,19 +6263,19 @@ game (
 
 game (
 	comment "64 Oozumou (Japan)"
-	developer "Bottom Up Interactive"
+	developer "Bottom Up Interactive"
 	rom ( crc 742E31FB )
 )
 
 game (
 	comment "64 Oozumou 2 (Japan)"
-	developer "Bottom Up Interactive"
+	developer "Bottom Up Interactive"
 	rom ( crc C1BC6FD8 )
 )
 
 game (
 	comment "64 Trump Collection - Alice no Wakuwaku Trump World (Japan)"
-	developer "Bottom Up Interactive"
+	developer "Bottom Up Interactive"
 	rom ( crc DCA7F4EB )
 )
 
@@ -6809,7 +6809,7 @@ game (
 
 game (
 	comment "Bug's Life, A (France)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc E5429094 )
 )
 
@@ -6821,25 +6821,25 @@ game (
 
 game (
 	comment "Bug's Life, A (Europe)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 791881D4 )
 )
 
 game (
 	comment "Bug's Life, A (Germany)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 15A32836 )
 )
 
 game (
 	comment "Bug's Life, A (Italy)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 2D118764 )
 )
 
 game (
 	comment "Bug's Life, A (USA)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc CF2EA0B6 )
 )
 
@@ -9353,7 +9353,7 @@ game (
 
 game (
 	comment "Mortal Kombat Mythologies - Sub-Zero (Europe)"
-	developer "Avalanche Software"
+	developer "Avalanche Software"
 	rom ( crc EA21015A )
 )
 
@@ -9365,7 +9365,7 @@ game (
 
 game (
 	comment "Mortal Kombat Mythologies - Sub-Zero (USA)"
-	developer "Avalanche Software"
+	developer "Avalanche Software"
 	rom ( crc 51A07FD9 )
 )
 
@@ -9815,7 +9815,7 @@ game (
 
 game (
 	comment "Off Road Challenge (Europe)"
-	developer "Avalanche Software"
+	developer "Avalanche Software"
 	rom ( crc D9FE9EE7 )
 )
 
@@ -9827,7 +9827,7 @@ game (
 
 game (
 	comment "Off Road Challenge (USA)"
-	developer "Avalanche Software"
+	developer "Avalanche Software"
 	rom ( crc 1A45C5AB )
 )
 
@@ -9881,7 +9881,7 @@ game (
 
 game (
 	comment "Onegai Monsters (Japan)"
-	developer "Bottom Up Interactive"
+	developer "Bottom Up Interactive"
 	rom ( crc AC72A1C7 )
 )
 
@@ -10373,13 +10373,13 @@ game (
 
 game (
 	comment "Rampage 2 - Universal Tour (Europe)"
-	developer "Avalanche Software"
+	developer "Avalanche Software"
 	rom ( crc FA6E097B )
 )
 
 game (
 	comment "Rampage 2 - Universal Tour (USA)"
-	developer "Avalanche Software"
+	developer "Avalanche Software"
 	rom ( crc 7614EE0D )
 )
 
@@ -10619,13 +10619,13 @@ game (
 
 game (
 	comment "Rugrats in Paris - The Movie (Europe)"
-	developer "Avalanche Software"
+	developer "Avalanche Software"
 	rom ( crc CD74B07E )
 )
 
 game (
 	comment "Rugrats in Paris - The Movie (USA)"
-	developer "Avalanche Software"
+	developer "Avalanche Software"
 	rom ( crc A9CC2419 )
 )
 
@@ -11447,7 +11447,7 @@ game (
 
 game (
 	comment "Toon Panic (Japan) (Proto)"
-	developer "Bottom Up Interactive"
+	developer "Bottom Up Interactive"
 	rom ( crc CF396C4E )
 )
 
@@ -11549,7 +11549,7 @@ game (
 
 game (
 	comment "Toy Story 2 - Buzz l'Eclair a la Rescousse! (France)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc FB4BEA9A )
 )
 
@@ -11561,19 +11561,19 @@ game (
 
 game (
 	comment "Toy Story 2 - Buzz Lightyear to the Rescue! (Europe)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 59574CB9 )
 )
 
 game (
 	comment "Toy Story 2 - Buzz Lightyear to the Rescue! (USA)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc B9570841 )
 )
 
 game (
 	comment "Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc C5E4C89F )
 )
 
@@ -11591,7 +11591,7 @@ game (
 
 game (
 	comment "Toy Story 2 - Buzz Lightyear to the Rescue! (USA) (Rev 1)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc C81F3321 )
 )
 
@@ -11603,7 +11603,7 @@ game (
 
 game (
 	comment "Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany) (Rev 1)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc D1906DE4 )
 )
 

--- a/metadat/developer/Nintendo - Nintendo Entertainment System.dat
+++ b/metadat/developer/Nintendo - Nintendo Entertainment System.dat
@@ -2519,7 +2519,7 @@ game (
 
 game (
 	comment "Buggy Popper (Japan)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc 681B1B0E )
 )
 
@@ -2561,7 +2561,7 @@ game (
 
 game (
 	comment "Bump 'n' Jump (USA)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc 5768D6C8 )
 )
 
@@ -2801,7 +2801,7 @@ game (
 
 game (
 	comment "Castelian (Europe)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc 2B31AA0A )
 )
 
@@ -2825,7 +2825,7 @@ game (
 
 game (
 	comment "Castelian (USA)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc AE28C50A )
 )
 
@@ -9467,7 +9467,7 @@ game (
 
 game (
 	comment "Kyoro-chan Land (Japan)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc F6E7F035 )
 )
 
@@ -14117,7 +14117,7 @@ game (
 
 game (
 	comment "Ripple Island (Japan)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc F416286D )
 )
 
@@ -14885,7 +14885,7 @@ game (
 
 game (
 	comment "Secret Ties (USA) (Proto)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc 0F39FAB8 )
 )
 

--- a/metadat/developer/Nintendo - Super Nintendo Entertainment System.dat
+++ b/metadat/developer/Nintendo - Super Nintendo Entertainment System.dat
@@ -533,13 +533,13 @@ game (
 
 game (
 	comment "Albert Odyssey (Japan) (Rev 1)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc 46F29066 )
 )
 
 game (
 	comment "Albert Odyssey (Japan)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc 46CA01A9 )
 )
 
@@ -2147,19 +2147,19 @@ game (
 
 game (
 	comment "Bugs Bunny - Hachamecha Daibouken (Japan)"
-	developer "Viacom New Media"
+	developer "Viacom New Media"
 	rom ( crc 528B029B )
 )
 
 game (
 	comment "Bugs Bunny - Rabbit Rampage (Europe)"
-	developer "Viacom New Media"
+	developer "Viacom New Media"
 	rom ( crc 91B3DB54 )
 )
 
 game (
 	comment "Bugs Bunny - Rabbit Rampage (USA)"
-	developer "Viacom New Media"
+	developer "Viacom New Media"
 	rom ( crc 832C0CB6 )
 )
 
@@ -3905,19 +3905,19 @@ game (
 
 game (
 	comment "Dorke & Ymp (World) (Aftermarket) (Unl)"
-	developer "Norsehelm Production"
+	developer "Norsehelm Production"
 	rom ( crc C3FA8238 )
 )
 
 game (
 	comment "Dorque & Imp (Europe) (Proto) (Mine Level)"
-	developer "Norsehelm Production"
+	developer "Norsehelm Production"
 	rom ( crc 7ED703BB )
 )
 
 game (
 	comment "Dorque & Imp (Europe) (Proto) (Palace Level)"
-	developer "Norsehelm Production"
+	developer "Norsehelm Production"
 	rom ( crc 59E235BA )
 )
 
@@ -3929,7 +3929,7 @@ game (
 
 game (
 	comment "Dorque & Imp (Europe) (Proto) (Woods Level)"
-	developer "Norsehelm Production"
+	developer "Norsehelm Production"
 	rom ( crc 139F8C1E )
 )
 
@@ -6353,19 +6353,19 @@ game (
 
 game (
 	comment "GunForce (Japan) (En)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc EEAFD816 )
 )
 
 game (
 	comment "GunForce (USA)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc 6F5C5DC0 )
 )
 
 game (
 	comment "GunForce - Battle Fire Engulfed Terror Island (Europe) (Proto)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc 11AF8992 )
 )
 
@@ -7457,13 +7457,13 @@ game (
 
 game (
 	comment "Itchy & Scratchy Game, The (Europe)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc C402347A )
 )
 
 game (
 	comment "Itchy & Scratchy Game, The (USA)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc 95B65DFE )
 )
 
@@ -9155,7 +9155,7 @@ game (
 
 game (
 	comment "Last Action Hero (Europe)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc 91633D95 )
 )
 
@@ -9179,7 +9179,7 @@ game (
 
 game (
 	comment "Last Action Hero (USA)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc 88017DF9 )
 )
 
@@ -9539,7 +9539,7 @@ game (
 
 game (
 	comment "Lock On (USA)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc 84F7E078 )
 )
 
@@ -10253,13 +10253,13 @@ game (
 
 game (
 	comment "Mary Shelley's Frankenstein (USA)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc 91415D1E )
 )
 
 game (
 	comment "Mary Shelley's Frankenstein (USA) (Beta)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc 22E1403F )
 )
 
@@ -10631,31 +10631,31 @@ game (
 
 game (
 	comment "Mickey Mania (Europe)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 75FDDF27 )
 )
 
 game (
 	comment "Mickey Mania - The Timeless Adventures of Mickey Mouse (Japan)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc B6C13316 )
 )
 
 game (
 	comment "Mickey Mania - The Timeless Adventures of Mickey Mouse (USA)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 08806B5B )
 )
 
 game (
 	comment "Mickey Mania - The Timeless Adventures of Mickey Mouse (Japan) (Beta)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc B9C629B0 )
 )
 
 game (
 	comment "Mickey Mania - The Timeless Adventures of Mickey Mouse (USA) (Beta) (1994-07-18)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 7F768797 )
 )
 
@@ -11111,19 +11111,19 @@ game (
 
 game (
 	comment "Mr. Do! (Europe)"
-	developer "Universal "
+	developer "Universal"
 	rom ( crc CCEBB6E8 )
 )
 
 game (
 	comment "Mr. Do! (Japan)"
-	developer "Universal "
+	developer "Universal"
 	rom ( crc 3847CF64 )
 )
 
 game (
 	comment "Mr. Do! (USA)"
-	developer "Universal "
+	developer "Universal"
 	rom ( crc 1C1025E2 )
 )
 
@@ -11867,7 +11867,7 @@ game (
 
 game (
 	comment "Nickelodeon GUTS (USA)"
-	developer "Viacom New Media"
+	developer "Viacom New Media"
 	rom ( crc 233FEC8C )
 )
 
@@ -12017,7 +12017,7 @@ game (
 
 game (
 	comment "No Escape (USA)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc C1082880 )
 )
 
@@ -12809,19 +12809,19 @@ game (
 
 game (
 	comment "Phantom 2040 (Europe) (En,Fr,De)"
-	developer "Viacom New Media"
+	developer "Viacom New Media"
 	rom ( crc 14252650 )
 )
 
 game (
 	comment "Phantom 2040 (USA)"
-	developer "Viacom New Media"
+	developer "Viacom New Media"
 	rom ( crc 35E8FB28 )
 )
 
 game (
 	comment "Phantom 2040 (USA) (Beta)"
-	developer "Viacom New Media"
+	developer "Viacom New Media"
 	rom ( crc D498F1D7 )
 )
 
@@ -14495,7 +14495,7 @@ game (
 
 game (
 	comment "Rocko's Modern Life - Spunky's Dangerous Day (USA)"
-	developer "Viacom New Media"
+	developer "Viacom New Media"
 	rom ( crc 197B4CBA )
 )
 
@@ -15281,19 +15281,19 @@ game (
 
 game (
 	comment "Shien - The Blade Chaser (Japan)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc 17DB8D06 )
 )
 
 game (
 	comment "Shien's Revenge (USA)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc 5BB2E6C3 )
 )
 
 game (
 	comment "Shien's Revenge (USA) (Beta)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc C56D245F )
 )
 
@@ -15473,7 +15473,7 @@ game (
 
 game (
 	comment "Shinseiki Odysselya (Japan)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc B01EE410 )
 )
 
@@ -15485,13 +15485,13 @@ game (
 
 game (
 	comment "Shinseiki Odysselya (Japan) (Sample)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc DE7F3A8D )
 )
 
 game (
 	comment "Shinseiki Odysselya II (Japan)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc F253EC83 )
 )
 
@@ -16997,7 +16997,7 @@ game (
 
 game (
 	comment "Sugoroku Ginga Senki (Japan)"
-	developer "Bottom Up Interactive"
+	developer "Bottom Up Interactive"
 	rom ( crc EA0C55BC )
 )
 
@@ -17081,13 +17081,13 @@ game (
 
 game (
 	comment "Super Air Diver (Europe)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc 0B57C764 )
 )
 
 game (
 	comment "Super Air Diver (Japan)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc 971E74BA )
 )
 
@@ -17555,13 +17555,13 @@ game (
 
 game (
 	comment "Super Conflict (Europe)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc 0A699604 )
 )
 
 game (
 	comment "Super Conflict (USA)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc F254D5CF )
 )
 
@@ -19601,19 +19601,19 @@ game (
 
 game (
 	comment "Super Trump Collection (Japan)"
-	developer "Bottom Up Interactive"
+	developer "Bottom Up Interactive"
 	rom ( crc BB9F8083 )
 )
 
 game (
 	comment "Super Trump Collection 2 (Japan)"
-	developer "Bottom Up Interactive"
+	developer "Bottom Up Interactive"
 	rom ( crc 22711FC8 )
 )
 
 game (
 	comment "Super Tsumeshougi 1000 (Japan)"
-	developer "Bottom Up Interactive"
+	developer "Bottom Up Interactive"
 	rom ( crc F9AE2B76 )
 )
 
@@ -20393,19 +20393,19 @@ game (
 
 game (
 	comment "Terminator 2 - Judgment Day (Europe)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc 6EE8F433 )
 )
 
 game (
 	comment "Terminator 2 - Judgment Day (Europe) (Beta)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc AC933465 )
 )
 
 game (
 	comment "Terminator 2 - Judgment Day (USA)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc F729B19E )
 )
 
@@ -21791,7 +21791,7 @@ game (
 
 game (
 	comment "Vs. Collection (Japan)"
-	developer "Bottom Up Interactive"
+	developer "Bottom Up Interactive"
 	rom ( crc A9FCFD53 )
 )
 
@@ -22271,25 +22271,25 @@ game (
 
 game (
 	comment "Wolverine (Japan) (En)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc D9119D9B )
 )
 
 game (
 	comment "Wolverine - Adamantium Rage (Europe)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc 78FC0D86 )
 )
 
 game (
 	comment "Wolverine - Adamantium Rage (USA)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc 4E62D6BF )
 )
 
 game (
 	comment "Wolverine - Adamantium Rage (USA) (Beta)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc 98455315 )
 )
 

--- a/metadat/developer/Nintendo - Virtual Boy.dat
+++ b/metadat/developer/Nintendo - Virtual Boy.dat
@@ -245,7 +245,7 @@ game (
 
 game (
 	comment "Tron VB (World) (Demo) (Aftermarket) (Homebrew)"
-	developer "Alberto "
+	developer "Alberto"
 	rom ( crc 33C3E3A7 )
 )
 

--- a/metadat/developer/Sega - Game Gear.dat
+++ b/metadat/developer/Sega - Game Gear.dat
@@ -1835,7 +1835,7 @@ game (
 
 game (
 	comment "Last Action Hero (USA)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc 2D367C43 )
 )
 

--- a/metadat/developer/Sega - Master System - Mark III.dat
+++ b/metadat/developer/Sega - Master System - Mark III.dat
@@ -2429,13 +2429,13 @@ game (
 
 game (
 	comment "Psycho Fox (USA, Europe, Brazil) (En)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc 97993479 )
 )
 
 game (
 	comment "Psycho Fox (USA, Europe, Brazil) (En) (Beta)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc 4BF0E1CC )
 )
 
@@ -2645,7 +2645,7 @@ game (
 
 game (
 	comment "Sapo Xule vs. Os Invasores do Brejo (Brazil)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc 9A608327 )
 )
 

--- a/metadat/developer/Sega - Mega Drive - Genesis.dat
+++ b/metadat/developer/Sega - Mega Drive - Genesis.dat
@@ -1115,13 +1115,13 @@ game (
 
 game (
 	comment "Battle Mania (Japan)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc A76C4A29 )
 )
 
 game (
 	comment "Battle Mania (Japan) (Beta) (1991-05-28)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc BF0A017F )
 )
 
@@ -1205,13 +1205,13 @@ game (
 
 game (
 	comment "Beavis and Butt-Head (USA)"
-	developer "Viacom New Media"
+	developer "Viacom New Media"
 	rom ( crc F5D7B948 )
 )
 
 game (
 	comment "Beavis and Butt-Head (Europe)"
-	developer "Viacom New Media"
+	developer "Viacom New Media"
 	rom ( crc C7B6435E )
 )
 
@@ -1223,7 +1223,7 @@ game (
 
 game (
 	comment "Beavis and Butt-Head (USA) (Beta)"
-	developer "Viacom New Media"
+	developer "Viacom New Media"
 	rom ( crc 81ED5335 )
 )
 
@@ -2375,7 +2375,7 @@ game (
 
 game (
 	comment "Columns III (USA)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc DC678F6D )
 )
 
@@ -2387,7 +2387,7 @@ game (
 
 game (
 	comment "Columns III - Taiketsu! Columns World (Japan, Korea) (Ja)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc CD07462F )
 )
 
@@ -5591,7 +5591,7 @@ game (
 
 game (
 	comment "Itchy & Scratchy Game, The (USA) (Proto)"
-	developer "Bits Studios"
+	developer "Bits Studios"
 	rom ( crc 81B7725D )
 )
 
@@ -6101,7 +6101,7 @@ game (
 
 game (
 	comment "Kick Off 3 - European Challenge (Europe) (En,Fr,De,Es,It)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc BC37401A )
 )
 
@@ -6113,7 +6113,7 @@ game (
 
 game (
 	comment "Kick Off 3 - European Challenge (Europe) (Beta)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc B69A43B8 )
 )
 
@@ -6833,7 +6833,7 @@ game (
 
 game (
 	comment "Magical Hat no Buttobi Turbo! Daibouken (Japan)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc E43E853D )
 )
 
@@ -7271,31 +7271,31 @@ game (
 
 game (
 	comment "Mickey Mania (Europe)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc CB5A8B85 )
 )
 
 game (
 	comment "Mickey Mania - The Timeless Adventures of Mickey Mouse (Japan)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 23180CF7 )
 )
 
 game (
 	comment "Mickey Mania - The Timeless Adventures of Mickey Mouse (USA)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 629E5963 )
 )
 
 game (
 	comment "Mickey Mania - The Timeless Adventures of Mickey Mouse (USA) (Beta) (July, 1994)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 7FC1BDF0 )
 )
 
 game (
 	comment "Mickey Mania - The Timeless Adventures of Mickey Mouse (USA) (Beta) (September, 1994)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc BAB821F2 )
 )
 
@@ -9287,13 +9287,13 @@ game (
 
 game (
 	comment "Phantom 2040 (Europe) (En,Fr,De)"
-	developer "Viacom New Media"
+	developer "Viacom New Media"
 	rom ( crc B024882E )
 )
 
 game (
 	comment "Phantom 2040 (USA)"
-	developer "Viacom New Media"
+	developer "Viacom New Media"
 	rom ( crc FB36E1F3 )
 )
 
@@ -9665,19 +9665,19 @@ game (
 
 game (
 	comment "Puggsy (Europe)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 5D5C9ADE )
 )
 
 game (
 	comment "Puggsy (USA)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 70132168 )
 )
 
 game (
 	comment "Puggsy (USA) (Beta)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc E13ED54E )
 )
 
@@ -11195,55 +11195,55 @@ game (
 
 game (
 	comment "Sonic 3D Blast (USA, Europe, Korea) (En) (Beta) (1996-08-19)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 2C43F43A )
 )
 
 game (
 	comment "Sonic 3D Blast (USA, Europe, Korea) (En)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 44A2CA44 )
 )
 
 game (
 	comment "Sonic 3D Blast (USA, Europe, Korea) (En) (Beta) (1996-07-03)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 93B75E99 )
 )
 
 game (
 	comment "Sonic 3D Blast (USA, Europe, Korea) (En) (Beta) (1996-08-14)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc D64E7675 )
 )
 
 game (
 	comment "Sonic 3D Blast (USA, Europe, Korea) (En) (Beta) (1996-08-25)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 465BCFBD )
 )
 
 game (
 	comment "Sonic 3D Blast (USA, Europe, Korea) (En) (Beta) (1996-08-30)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 57640422 )
 )
 
 game (
 	comment "Sonic 3D Blast (USA, Europe, Korea) (En) (Beta) (1996-08-31)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 5933E453 )
 )
 
 game (
 	comment "Sonic 3D Blast (USA, Europe, Korea) (En) (Beta) (1996-09-04)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 2F2A4271 )
 )
 
 game (
 	comment "Sonic 3D Blast - Director's Cut (World) (Unl)"
-	developer "Travellers Tales"
+	developer "Travellers Tales"
 	rom ( crc 9767E840 )
 )
 
@@ -13523,13 +13523,13 @@ game (
 
 game (
 	comment "Trouble Shooter (USA)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc BECFC39B )
 )
 
 game (
 	comment "Trouble Shooter (USA) (Beta) (1991-09-12)"
-	developer "Tokai Engineering"
+	developer "Tokai Engineering"
 	rom ( crc 4AB3033C )
 )
 
@@ -15347,19 +15347,19 @@ game (
 
 game (
 	comment "Zoop (USA) (Beta)"
-	developer "Viacom New Media"
+	developer "Viacom New Media"
 	rom ( crc 2E28C13F )
 )
 
 game (
 	comment "Zoop (Europe)"
-	developer "Viacom New Media"
+	developer "Viacom New Media"
 	rom ( crc 0764139F )
 )
 
 game (
 	comment "Zoop (USA)"
-	developer "Viacom New Media"
+	developer "Viacom New Media"
 	rom ( crc FAA490DC )
 )
 

--- a/metadat/developer/Watara - Supervision.dat
+++ b/metadat/developer/Watara - Supervision.dat
@@ -245,7 +245,7 @@ game (
 
 game (
 	comment "Popo Team (USA, Europe)"
-	developer "Thin Chen Enterprise"
+	developer "Thin Chen Enterprise"
 	rom ( crc E11A756C )
 )
 

--- a/metadat/franchise/Nintendo - Nintendo 64.dat
+++ b/metadat/franchise/Nintendo - Nintendo 64.dat
@@ -3781,7 +3781,7 @@ game (
 
 game (
 	comment "Robotron 64 (Europe)"
-	franchise "Robotron "
+	franchise "Robotron"
 	rom (
 		crc 862ACD20
 	)
@@ -3789,7 +3789,7 @@ game (
 
 game (
 	comment "Robotron 64 (USA)"
-	franchise "Robotron "
+	franchise "Robotron"
 	rom (
 		crc 123D44CC
 	)

--- a/metadat/publisher/Atari - 2600.dat
+++ b/metadat/publisher/Atari - 2600.dat
@@ -1601,7 +1601,7 @@ game (
 
 game (
 	comment "Final Approach (USA)"
-	publisher "Apollo, Inc."
+	publisher "Apollo, Inc."
 	rom ( crc FF23F469 )
 )
 
@@ -1865,7 +1865,7 @@ game (
 
 game (
 	comment "Guardian (USA)"
-	publisher "Apollo, Inc."
+	publisher "Apollo, Inc."
 	rom ( crc 121738F5 )
 )
 
@@ -1997,7 +1997,7 @@ game (
 
 game (
 	comment "Infiltrate (USA)"
-	publisher "Apollo, Inc."
+	publisher "Apollo, Inc."
 	rom ( crc 612BD4DA )
 )
 
@@ -2171,7 +2171,7 @@ game (
 
 game (
 	comment "Kyphus (USA) (Proto)"
-	publisher "Apollo, Inc."
+	publisher "Apollo, Inc."
 	rom ( crc 79BD22E2 )
 )
 
@@ -2219,7 +2219,7 @@ game (
 
 game (
 	comment "Lochjaw (USA)"
-	publisher "Apollo, Inc."
+	publisher "Apollo, Inc."
 	rom ( crc B2A2FF31 )
 )
 
@@ -2249,7 +2249,7 @@ game (
 
 game (
 	comment "Lost Luggage (USA)"
-	publisher "Apollo, Inc."
+	publisher "Apollo, Inc."
 	rom ( crc 551BDD37 )
 )
 
@@ -2975,7 +2975,7 @@ game (
 
 game (
 	comment "Racquetball (USA)"
-	publisher "Apollo, Inc."
+	publisher "Apollo, Inc."
 	rom ( crc 7EEF9AC0 )
 )
 
@@ -3305,7 +3305,7 @@ game (
 
 game (
 	comment "Skeet Shoot (USA)"
-	publisher "Apollo, Inc."
+	publisher "Apollo, Inc."
 	rom ( crc 57D69B13 )
 )
 
@@ -3455,7 +3455,7 @@ game (
 
 game (
 	comment "Space Cavern (USA)"
-	publisher "Apollo, Inc."
+	publisher "Apollo, Inc."
 	rom ( crc 3B0FFD89 )
 )
 
@@ -3485,7 +3485,7 @@ game (
 
 game (
 	comment "Spacechase (USA)"
-	publisher "Apollo, Inc."
+	publisher "Apollo, Inc."
 	rom ( crc 2954D22D )
 )
 
@@ -4175,7 +4175,7 @@ game (
 
 game (
 	comment "Wabbit (USA)"
-	publisher "Apollo, Inc."
+	publisher "Apollo, Inc."
 	rom ( crc 2D07ED77 )
 )
 

--- a/metadat/publisher/Bandai - WonderSwan.dat
+++ b/metadat/publisher/Bandai - WonderSwan.dat
@@ -695,13 +695,13 @@ game (
 
 game (
 	comment "Trump Collection - Bottom-Up Teki Trump Seikatsu (Japan) (Rev 1)"
-	publisher "Bottom Up Interactive"
+	publisher "Bottom Up Interactive"
 	rom ( crc C283EC5F )
 )
 
 game (
 	comment "Trump Collection 2 - Bottom-Up Teki Sekaiisshuu no Tabi (Japan) (Rev 1)"
-	publisher "Bottom Up Interactive"
+	publisher "Bottom Up Interactive"
 	rom ( crc 64AAF392 )
 )
 

--- a/metadat/publisher/Magnavox - Odyssey 2.dat
+++ b/metadat/publisher/Magnavox - Odyssey 2.dat
@@ -65,7 +65,7 @@ game (
 
 game (
 	comment "Blobbers, The (Europe)"
-	publisher "N.V. Philips Gloeilampenfabrieken"
+	publisher "N.V. Philips Gloeilampenfabrieken"
 	rom ( crc 9D72D4E9 )
 )
 
@@ -77,7 +77,7 @@ game (
 
 game (
 	comment "Bombardeio Submarino + Tiro ao Alvo (Brazil)"
-	publisher "N.V. Philips Gloeilampenfabrieken"
+	publisher "N.V. Philips Gloeilampenfabrieken"
 	rom ( crc B1109A09 )
 )
 
@@ -203,7 +203,7 @@ game (
 
 game (
 	comment "Depth Charge + Marksman (Europe)"
-	publisher "N.V. Philips Gloeilampenfabrieken"
+	publisher "N.V. Philips Gloeilampenfabrieken"
 	rom ( crc 2DCB77F0 )
 )
 

--- a/metadat/publisher/Microsoft - MSX 2.dat
+++ b/metadat/publisher/Microsoft - MSX 2.dat
@@ -93,7 +93,7 @@ game (
 
 game (
 	comment "AshGuine Story II - Kokuu no Gajou (Japan)"
-	publisher "T&E; Soft"
+	publisher "T&E Soft"
 	rom (
 		crc 47A82D74
 	)
@@ -517,7 +517,7 @@ game (
 
 game (
 	comment "Hydlide 3 - The Space Memories (Japan)"
-	publisher "T&E; Soft"
+	publisher "T&E Soft"
 	rom (
 		crc 00DB86C8
 	)

--- a/metadat/publisher/Microsoft - MSX.dat
+++ b/metadat/publisher/Microsoft - MSX.dat
@@ -779,7 +779,7 @@ game (
 
 game (
 	comment "Captain Chef (Japan)"
-	publisher "Nippon Columbia "
+	publisher "Nippon Columbia"
 	rom ( crc 8E985857 )
 )
 
@@ -3725,7 +3725,7 @@ game (
 
 game (
 	comment "Peetan (Japan)"
-	publisher "Nippon Columbia "
+	publisher "Nippon Columbia"
 	rom ( crc 941069AE )
 )
 

--- a/metadat/publisher/Microsoft - MSX2.dat
+++ b/metadat/publisher/Microsoft - MSX2.dat
@@ -1127,7 +1127,7 @@ game (
 
 game (
 	comment "Zombie Hunter (Japan)"
-	publisher "Hi-Score Media Work Corp."
+	publisher "Hi-Score Media Work Corp."
 	rom ( crc A29E6AB4 )
 )
 

--- a/metadat/publisher/Nintendo - Game Boy Advance.dat
+++ b/metadat/publisher/Nintendo - Game Boy Advance.dat
@@ -1337,7 +1337,7 @@ game (
 
 game (
 	comment "ATV - Quad Power Racing (Europe) (En,Fr,De,Es,It) (Rev 1)"
-	publisher "Liquid Games"
+	publisher "Liquid Games"
 	rom ( crc 4B4E8BC7 )
 )
 
@@ -1355,7 +1355,7 @@ game (
 
 game (
 	comment "ATV - Quad Power Racing (USA, Europe)"
-	publisher "Liquid Games"
+	publisher "Liquid Games"
 	rom ( crc 9C1A7DCB )
 )
 
@@ -6227,7 +6227,7 @@ game (
 
 game (
 	comment "Formation Soccer 2002 (Japan)"
-	publisher "Spike Co"
+	publisher "Spike Co"
 	rom ( crc 47F663A0 )
 )
 
@@ -6953,7 +6953,7 @@ game (
 
 game (
 	comment "GT Racers (Europe) (En,Fr,De,Es,It)"
-	publisher "Liquid Games"
+	publisher "Liquid Games"
 	rom ( crc DACE7197 )
 )
 
@@ -6971,13 +6971,13 @@ game (
 
 game (
 	comment "GT Racers (Europe) (Beta) (2005-07-13)"
-	publisher "Liquid Games"
+	publisher "Liquid Games"
 	rom ( crc E027657A )
 )
 
 game (
 	comment "GT Racers (Europe) (Beta) (2005-10-14)"
-	publisher "Liquid Games"
+	publisher "Liquid Games"
 	rom ( crc A0F745A0 )
 )
 
@@ -12731,7 +12731,7 @@ game (
 
 game (
 	comment "Pixeline i Pixieland (Denmark)"
-	publisher "Krea Medie"
+	publisher "Krea Medie"
 	rom ( crc 20B72D17 )
 )
 
@@ -14483,7 +14483,7 @@ game (
 
 game (
 	comment "Scorpion King, The - Sword of Osiris (USA)"
-	publisher "Universal "
+	publisher "Universal"
 	rom ( crc 6E0A8585 )
 )
 
@@ -14501,7 +14501,7 @@ game (
 
 game (
 	comment "Scorpion King, The - Sword of Osiris (Europe) (En,Fr,De,Es,It)"
-	publisher "Universal "
+	publisher "Universal"
 	rom ( crc D5410D32 )
 )
 
@@ -17279,13 +17279,13 @@ game (
 
 game (
 	comment "Tokyo Xtreme Racer Advance (USA)"
-	publisher "Liquid Games"
+	publisher "Liquid Games"
 	rom ( crc AB272800 )
 )
 
 game (
 	comment "Tokyo Xtreme Racer Advance (Europe) (En,Fr,De,Es,It)"
-	publisher "Liquid Games"
+	publisher "Liquid Games"
 	rom ( crc BD5F5F4C )
 )
 
@@ -17651,19 +17651,19 @@ game (
 
 game (
 	comment "Trick Star (Europe) (En,Fr,De,Es,It)"
-	publisher "Liquid Games"
+	publisher "Liquid Games"
 	rom ( crc 961260AE )
 )
 
 game (
 	comment "Tringo (Europe) (En,Fr,De,Es,It)"
-	publisher "Liquid Games"
+	publisher "Liquid Games"
 	rom ( crc B5F7BF43 )
 )
 
 game (
 	comment "Tringo (USA)"
-	publisher "Liquid Games"
+	publisher "Liquid Games"
 	rom ( crc 2956A0DA )
 )
 

--- a/metadat/publisher/Nintendo - Game Boy Color.dat
+++ b/metadat/publisher/Nintendo - Game Boy Color.dat
@@ -1607,7 +1607,7 @@ game (
 
 game (
 	comment "Diva Starz (Europe)"
-	publisher "Universal "
+	publisher "Universal"
 	rom ( crc 4476E79F )
 )
 
@@ -1619,13 +1619,13 @@ game (
 
 game (
 	comment "Diva Starz (France)"
-	publisher "Universal "
+	publisher "Universal"
 	rom ( crc FC1B36D1 )
 )
 
 game (
 	comment "Diva Starz (Germany)"
-	publisher "Universal "
+	publisher "Universal"
 	rom ( crc 56095F86 )
 )
 
@@ -1637,7 +1637,7 @@ game (
 
 game (
 	comment "Diva Starz - Mall Mania (USA)"
-	publisher "Universal "
+	publisher "Universal"
 	rom ( crc EBE0ECD6 )
 )
 
@@ -5267,13 +5267,13 @@ game (
 
 game (
 	comment "Mummy Returns, The (Europe) (En,Fr,De,Es,It)"
-	publisher "Universal "
+	publisher "Universal"
 	rom ( crc 64052B9B )
 )
 
 game (
 	comment "Mummy Returns, The (USA)"
-	publisher "Universal "
+	publisher "Universal"
 	rom ( crc C997F45B )
 )
 

--- a/metadat/publisher/Nintendo - Game Boy.dat
+++ b/metadat/publisher/Nintendo - Game Boy.dat
@@ -767,7 +767,7 @@ game (
 
 game (
 	comment "BattleCity (Japan)"
-	publisher "Nova Co"
+	publisher "Nova Co"
 	rom ( crc A37A814A )
 )
 
@@ -2525,13 +2525,13 @@ game (
 
 game (
 	comment "Fastest Lap (USA)"
-	publisher "NTV International Corporation"
+	publisher "NTV International Corporation"
 	rom ( crc A9BA7875 )
 )
 
 game (
 	comment "Fastest Lap (Japan) (En)"
-	publisher "NTV International Corporation"
+	publisher "NTV International Corporation"
 	rom ( crc 59285F0A )
 )
 
@@ -3029,13 +3029,13 @@ game (
 
 game (
 	comment "George Foreman's KO Boxing (USA, Europe)"
-	publisher "Flying Edge, Inc."
+	publisher "Flying Edge, Inc."
 	rom ( crc 7F62456B )
 )
 
 game (
 	comment "Gerry Anderson's Thunderbirds (Japan)"
-	publisher "Universal "
+	publisher "Universal"
 	rom ( crc 149E9393 )
 )
 
@@ -5615,7 +5615,7 @@ game (
 
 game (
 	comment "NBA All-Star Challenge (USA, Europe)"
-	publisher "Flying Edge, Inc."
+	publisher "Flying Edge, Inc."
 	rom ( crc F25BA8BF )
 )
 
@@ -6575,7 +6575,7 @@ game (
 
 game (
 	comment "Pocket Golf (Japan)"
-	publisher "Bottom Up Interactive"
+	publisher "Bottom Up Interactive"
 	rom ( crc 755152BB )
 )
 
@@ -8231,7 +8231,7 @@ game (
 
 game (
 	comment "Sports Collection (Japan)"
-	publisher "Starbyte Software"
+	publisher "Starbyte Software"
 	rom ( crc 24DD09E0 )
 )
 
@@ -10145,13 +10145,13 @@ game (
 
 game (
 	comment "Zerd no Densetsu (Japan)"
-	publisher "Tokai Engineering"
+	publisher "Tokai Engineering"
 	rom ( crc 492EDB36 )
 )
 
 game (
 	comment "Zerd no Densetsu 2 - Xerd!! Gishin no Ryouiki (Japan)"
-	publisher "Tokai Engineering"
+	publisher "Tokai Engineering"
 	rom ( crc A197BDB7 )
 )
 
@@ -10187,19 +10187,19 @@ game (
 
 game (
 	comment "Zoop (USA, Europe)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc 14F8B6BB )
 )
 
 game (
 	comment "Zoop (Japan)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc 10E1A10C )
 )
 
 game (
 	comment "Zoop (USA, Europe) (Beta)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc 7B440074 )
 )
 

--- a/metadat/publisher/Nintendo - Nintendo 64.dat
+++ b/metadat/publisher/Nintendo - Nintendo 64.dat
@@ -47,7 +47,7 @@ game (
 
 game (
 	comment "64 Oozumou (Japan)"
-	publisher "Bottom Up Interactive"
+	publisher "Bottom Up Interactive"
 	rom ( crc A6DBF8AE )
 )
 
@@ -77,13 +77,13 @@ game (
 
 game (
 	comment "64 Oozumou 2 (Japan)"
-	publisher "Bottom Up Interactive"
+	publisher "Bottom Up Interactive"
 	rom ( crc 3CD5E271 )
 )
 
 game (
 	comment "64 Trump Collection - Alice no Wakuwaku Trump World (Japan)"
-	publisher "Bottom Up Interactive"
+	publisher "Bottom Up Interactive"
 	rom ( crc 34BBB95D )
 )
 
@@ -1097,7 +1097,7 @@ game (
 
 game (
 	comment "Die Hard 64 (USA) (Proto) (Level 1)"
-	publisher "Bits Studios"
+	publisher "Bits Studios"
 	rom ( crc 5E826037 )
 )
 
@@ -1109,13 +1109,13 @@ game (
 
 game (
 	comment "Die Hard 64 (USA) (Proto) (Level 2)"
-	publisher "Bits Studios"
+	publisher "Bits Studios"
 	rom ( crc D1D593CF )
 )
 
 game (
 	comment "Die Hard 64 (USA) (Proto) (Level 3)"
-	publisher "Bits Studios"
+	publisher "Bits Studios"
 	rom ( crc 70943925 )
 )
 
@@ -3695,7 +3695,7 @@ game (
 
 game (
 	comment "Onegai Monsters (Japan)"
-	publisher "Bottom Up Interactive"
+	publisher "Bottom Up Interactive"
 	rom ( crc FF03EC8A )
 )
 
@@ -5267,7 +5267,7 @@ game (
 
 game (
 	comment "Toon Panic (Japan) (Proto)"
-	publisher "Bottom Up Interactive"
+	publisher "Bottom Up Interactive"
 	rom ( crc 55C88F04 )
 )
 
@@ -6275,19 +6275,19 @@ game (
 
 game (
 	comment "64 Oozumou (Japan)"
-	publisher "Bottom Up Interactive"
+	publisher "Bottom Up Interactive"
 	rom ( crc 742E31FB )
 )
 
 game (
 	comment "64 Oozumou 2 (Japan)"
-	publisher "Bottom Up Interactive"
+	publisher "Bottom Up Interactive"
 	rom ( crc C1BC6FD8 )
 )
 
 game (
 	comment "64 Trump Collection - Alice no Wakuwaku Trump World (Japan)"
-	publisher "Bottom Up Interactive"
+	publisher "Bottom Up Interactive"
 	rom ( crc DCA7F4EB )
 )
 
@@ -7301,7 +7301,7 @@ game (
 
 game (
 	comment "Die Hard 64 (USA) (Proto) (Level 1)"
-	publisher "Bits Studios"
+	publisher "Bits Studios"
 	rom ( crc 5E826037 )
 )
 
@@ -7313,13 +7313,13 @@ game (
 
 game (
 	comment "Die Hard 64 (USA) (Proto) (Level 2)"
-	publisher "Bits Studios"
+	publisher "Bits Studios"
 	rom ( crc D1D593CF )
 )
 
 game (
 	comment "Die Hard 64 (USA) (Proto) (Level 3)"
-	publisher "Bits Studios"
+	publisher "Bits Studios"
 	rom ( crc 70943925 )
 )
 
@@ -9899,7 +9899,7 @@ game (
 
 game (
 	comment "Onegai Monsters (Japan)"
-	publisher "Bottom Up Interactive"
+	publisher "Bottom Up Interactive"
 	rom ( crc AC72A1C7 )
 )
 
@@ -11471,7 +11471,7 @@ game (
 
 game (
 	comment "Toon Panic (Japan) (Proto)"
-	publisher "Bottom Up Interactive"
+	publisher "Bottom Up Interactive"
 	rom ( crc CF396C4E )
 )
 

--- a/metadat/publisher/Nintendo - Nintendo Entertainment System.dat
+++ b/metadat/publisher/Nintendo - Nintendo Entertainment System.dat
@@ -449,7 +449,7 @@ game (
 
 game (
 	comment "Adventures of Lex and Grim, The (World) (Aftermarket) (Homebrew)"
-	publisher "Joey Echeverria, "
+	publisher "Joey Echeverria,"
 	rom ( crc 2FA23BBF )
 )
 
@@ -14993,7 +14993,7 @@ game (
 
 game (
 	comment "Secret Ties (USA) (Proto)"
-	publisher "Tokai Engineering"
+	publisher "Tokai Engineering"
 	rom ( crc 0F39FAB8 )
 )
 

--- a/metadat/publisher/Nintendo - Super Nintendo Entertainment System.dat
+++ b/metadat/publisher/Nintendo - Super Nintendo Entertainment System.dat
@@ -83,13 +83,13 @@ game (
 
 game (
 	comment "Aaahh!!! Real Monsters (USA)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc 27FF5BA1 )
 )
 
 game (
 	comment "Aaahh!!! Real Monsters (Europe)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc 946313FB )
 )
 
@@ -1463,13 +1463,13 @@ game (
 
 game (
 	comment "Beavis and Butt-Head (Europe)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc F77F160B )
 )
 
 game (
 	comment "Beavis and Butt-Head (USA)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc 15CF4BD5 )
 )
 
@@ -2861,7 +2861,7 @@ game (
 
 game (
 	comment "Congo - The Movie - Secret of Zinj (USA) (Proto)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc 2A075F4B )
 )
 
@@ -4421,7 +4421,7 @@ game (
 
 game (
 	comment "Edono Kiba (Japan)"
-	publisher "Micro World "
+	publisher "Micro World"
 	rom ( crc EEC5A5B1 )
 )
 
@@ -11849,7 +11849,7 @@ game (
 
 game (
 	comment "Nickelodeon GUTS (USA)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc 233FEC8C )
 )
 
@@ -12221,7 +12221,7 @@ game (
 
 game (
 	comment "Oraga Land Shusai - Best Farmer Shuukakusai (Japan)"
-	publisher "Tokai Engineering"
+	publisher "Tokai Engineering"
 	rom ( crc 32A4612F )
 )
 
@@ -12245,7 +12245,7 @@ game (
 
 game (
 	comment "Oraga Land Shusai - Best Farmer Shuukakusai (Japan) (Beta)"
-	publisher "Tokai Engineering"
+	publisher "Tokai Engineering"
 	rom ( crc 27CED447 )
 )
 
@@ -12791,19 +12791,19 @@ game (
 
 game (
 	comment "Phantom 2040 (Europe) (En,Fr,De)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc 14252650 )
 )
 
 game (
 	comment "Phantom 2040 (USA)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc 35E8FB28 )
 )
 
 game (
 	comment "Phantom 2040 (USA) (Beta)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc D498F1D7 )
 )
 
@@ -14477,7 +14477,7 @@ game (
 
 game (
 	comment "Rocko's Modern Life - Spunky's Dangerous Day (USA)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc 197B4CBA )
 )
 
@@ -15263,19 +15263,19 @@ game (
 
 game (
 	comment "Shien - The Blade Chaser (Japan)"
-	publisher "Tokai Engineering"
+	publisher "Tokai Engineering"
 	rom ( crc 17DB8D06 )
 )
 
 game (
 	comment "Shien's Revenge (USA)"
-	publisher "Tokai Engineering"
+	publisher "Tokai Engineering"
 	rom ( crc 5BB2E6C3 )
 )
 
 game (
 	comment "Shien's Revenge (USA) (Beta)"
-	publisher "Tokai Engineering"
+	publisher "Tokai Engineering"
 	rom ( crc C56D245F )
 )
 
@@ -15455,7 +15455,7 @@ game (
 
 game (
 	comment "Shinseiki Odysselya (Japan)"
-	publisher "Tokai Engineering"
+	publisher "Tokai Engineering"
 	rom ( crc B01EE410 )
 )
 
@@ -15467,13 +15467,13 @@ game (
 
 game (
 	comment "Shinseiki Odysselya (Japan) (Sample)"
-	publisher "Tokai Engineering"
+	publisher "Tokai Engineering"
 	rom ( crc DE7F3A8D )
 )
 
 game (
 	comment "Shinseiki Odysselya II (Japan)"
-	publisher "Tokai Engineering"
+	publisher "Tokai Engineering"
 	rom ( crc F253EC83 )
 )
 
@@ -16973,7 +16973,7 @@ game (
 
 game (
 	comment "Sugoroku Ginga Senki (Japan)"
-	publisher "Bottom Up Interactive"
+	publisher "Bottom Up Interactive"
 	rom ( crc EA0C55BC )
 )
 
@@ -17519,13 +17519,13 @@ game (
 
 game (
 	comment "Super Conflict (Europe)"
-	publisher "Tokai Engineering"
+	publisher "Tokai Engineering"
 	rom ( crc 0A699604 )
 )
 
 game (
 	comment "Super Conflict (USA)"
-	publisher "Tokai Engineering"
+	publisher "Tokai Engineering"
 	rom ( crc F254D5CF )
 )
 
@@ -19565,19 +19565,19 @@ game (
 
 game (
 	comment "Super Trump Collection (Japan)"
-	publisher "Bottom Up Interactive"
+	publisher "Bottom Up Interactive"
 	rom ( crc BB9F8083 )
 )
 
 game (
 	comment "Super Trump Collection 2 (Japan)"
-	publisher "Bottom Up Interactive"
+	publisher "Bottom Up Interactive"
 	rom ( crc 22711FC8 )
 )
 
 game (
 	comment "Super Tsumeshougi 1000 (Japan)"
-	publisher "Bottom Up Interactive"
+	publisher "Bottom Up Interactive"
 	rom ( crc F9AE2B76 )
 )
 
@@ -20543,7 +20543,7 @@ game (
 
 game (
 	comment "Time Slip (USA) (Beta)"
-	publisher "Tokai Engineering"
+	publisher "Tokai Engineering"
 	rom ( crc DE12F893 )
 )
 
@@ -20585,7 +20585,7 @@ game (
 
 game (
 	comment "Timeslip (Europe)"
-	publisher "Tokai Engineering"
+	publisher "Tokai Engineering"
 	rom ( crc ADAC8EFF )
 )
 
@@ -20603,7 +20603,7 @@ game (
 
 game (
 	comment "Timeslip (USA)"
-	publisher "Tokai Engineering"
+	publisher "Tokai Engineering"
 	rom ( crc 838D0304 )
 )
 
@@ -20765,7 +20765,7 @@ game (
 
 game (
 	comment "Tokoro's Mahjong (Japan)"
-	publisher "Tokai Engineering"
+	publisher "Tokai Engineering"
 	rom ( crc 49DBFF84 )
 )
 
@@ -20975,13 +20975,13 @@ game (
 
 game (
 	comment "Toy Story (Japan)"
-	publisher "Travellers Tales"
+	publisher "Travellers Tales"
 	rom ( crc D4AF7724 )
 )
 
 game (
 	comment "Toy Story (Europe) (En,Fr,De)"
-	publisher "Travellers Tales"
+	publisher "Travellers Tales"
 	rom ( crc B144D588 )
 )
 
@@ -20993,7 +20993,7 @@ game (
 
 game (
 	comment "Toy Story (USA)"
-	publisher "Travellers Tales"
+	publisher "Travellers Tales"
 	rom ( crc 8328822B )
 )
 
@@ -21755,7 +21755,7 @@ game (
 
 game (
 	comment "Vs. Collection (Japan)"
-	publisher "Bottom Up Interactive"
+	publisher "Bottom Up Interactive"
 	rom ( crc A9FCFD53 )
 )
 
@@ -23045,19 +23045,19 @@ game (
 
 game (
 	comment "Zoop (Europe)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc AFD45D27 )
 )
 
 game (
 	comment "Zoop (USA)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc 06F0E94C )
 )
 
 game (
 	comment "Zoop (USA) (Beta)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc 3758068A )
 )
 

--- a/metadat/publisher/Sega - Game Gear.dat
+++ b/metadat/publisher/Sega - Game Gear.dat
@@ -335,13 +335,13 @@ game (
 
 game (
 	comment "Beavis and Butt-Head (USA, Europe)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc A6BF865E )
 )
 
 game (
 	comment "Beavis and Butt-Head (USA, Europe) (Beta)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc 3858F14F )
 )
 
@@ -2903,7 +2903,7 @@ game (
 
 game (
 	comment "Phantom 2040 (USA, Europe)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc 281B1C3A )
 )
 
@@ -4811,13 +4811,13 @@ game (
 
 game (
 	comment "Zoop (USA)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc 3247FF8B )
 )
 
 game (
 	comment "Zoop (USA) (Beta) (1995-08-11)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc F397F041 )
 )
 

--- a/metadat/publisher/Sega - Mega Drive - Genesis.dat
+++ b/metadat/publisher/Sega - Mega Drive - Genesis.dat
@@ -1103,19 +1103,19 @@ game (
 
 game (
 	comment "Battle Mania (Japan)"
-	publisher "Tokai Engineering"
+	publisher "Tokai Engineering"
 	rom ( crc A76C4A29 )
 )
 
 game (
 	comment "Battle Mania (Japan) (Beta) (1991-05-28)"
-	publisher "Tokai Engineering"
+	publisher "Tokai Engineering"
 	rom ( crc BF0A017F )
 )
 
 game (
 	comment "Battle Mania Daiginjou (Japan, Korea) (Ja)"
-	publisher "Tokai Engineering"
+	publisher "Tokai Engineering"
 	rom ( crc 312FA0F2 )
 )
 
@@ -1193,13 +1193,13 @@ game (
 
 game (
 	comment "Beavis and Butt-Head (USA)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc F5D7B948 )
 )
 
 game (
 	comment "Beavis and Butt-Head (Europe)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc C7B6435E )
 )
 
@@ -1211,7 +1211,7 @@ game (
 
 game (
 	comment "Beavis and Butt-Head (USA) (Beta)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc 81ED5335 )
 )
 
@@ -1619,13 +1619,13 @@ game (
 
 game (
 	comment "Bram Stoker's Dracula (Europe)"
-	publisher "Travellers Tales"
+	publisher "Travellers Tales"
 	rom ( crc 9BA5A063 )
 )
 
 game (
 	comment "Bram Stoker's Dracula (USA)"
-	publisher "Travellers Tales"
+	publisher "Travellers Tales"
 	rom ( crc 077084A6 )
 )
 
@@ -2495,7 +2495,7 @@ game (
 
 game (
 	comment "Congo - The Game (USA) (Proto)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc 13746716 )
 )
 
@@ -8525,7 +8525,7 @@ game (
 
 game (
 	comment "No Escape (USA)"
-	publisher "Bits Studios"
+	publisher "Bits Studios"
 	rom ( crc 44EE5F20 )
 )
 
@@ -9269,13 +9269,13 @@ game (
 
 game (
 	comment "Phantom 2040 (Europe) (En,Fr,De)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc B024882E )
 )
 
 game (
 	comment "Phantom 2040 (USA)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc FB36E1F3 )
 )
 
@@ -11057,7 +11057,7 @@ game (
 
 game (
 	comment "Socket (USA)"
-	publisher "Tokai Engineering"
+	publisher "Tokai Engineering"
 	rom ( crc 3C14E15A )
 )
 
@@ -12725,7 +12725,7 @@ game (
 
 game (
 	comment "T2 - Terminator 2 - Judgment Day (USA, Europe)"
-	publisher "Bits Studios"
+	publisher "Bits Studios"
 	rom ( crc 2F75E896 )
 )
 
@@ -13217,7 +13217,7 @@ game (
 
 game (
 	comment "Time Dominator 1st (Japan, Korea) (Ja)"
-	publisher "Tokai Engineering"
+	publisher "Tokai Engineering"
 	rom ( crc 7EBA7A5C )
 )
 
@@ -13559,13 +13559,13 @@ game (
 
 game (
 	comment "Trouble Shooter (USA)"
-	publisher "Tokai Engineering"
+	publisher "Tokai Engineering"
 	rom ( crc BECFC39B )
 )
 
 game (
 	comment "Trouble Shooter (USA) (Beta) (1991-09-12)"
-	publisher "Tokai Engineering"
+	publisher "Tokai Engineering"
 	rom ( crc 4AB3033C )
 )
 
@@ -14219,19 +14219,19 @@ game (
 
 game (
 	comment "Whip Rush (USA)"
-	publisher "Tokai Engineering"
+	publisher "Tokai Engineering"
 	rom ( crc 7EB6B86B )
 )
 
 game (
 	comment "Whip Rush (USA) (Beta) (1990-01-29)"
-	publisher "Tokai Engineering"
+	publisher "Tokai Engineering"
 	rom ( crc FF39FC9F )
 )
 
 game (
 	comment "Whip Rush - Wakusei Voltegas no Nazo (Japan)"
-	publisher "Tokai Engineering"
+	publisher "Tokai Engineering"
 	rom ( crc 8084B4D1 )
 )
 
@@ -15389,19 +15389,19 @@ game (
 
 game (
 	comment "Zoop (USA) (Beta)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc 2E28C13F )
 )
 
 game (
 	comment "Zoop (Europe)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc 0764139F )
 )
 
 game (
 	comment "Zoop (USA)"
-	publisher "Viacom New Media"
+	publisher "Viacom New Media"
 	rom ( crc FAA490DC )
 )
 

--- a/metadat/serial/Casio - Loopy.dat
+++ b/metadat/serial/Casio - Loopy.dat
@@ -13,7 +13,7 @@ game (
 
 game (
 	comment "Dream Change - Kogane-chan no Fashion Party (Japan)"
-	serial "XK-403 "
+	serial "XK-403"
 	rom (
 		crc 0B850185
 	)


### PR DESCRIPTION
Three whitespace defects in the hand-maintained metadat categories.

**344 values contain a non-breaking space (U+00A0) where a normal space belongs** — `Apollo,<NBSP>Inc.`, `Bottom<NBSP>Up<NBSP>Interactive`, `Omori<NBSP>Electronics<NBSP>Corporation`. They look correct on screen and are indistinguishable from a space in a diff, but any exact-match grouping treats them as a different string, so one company silently splits into two buckets.

**31 values carry stray leading or trailing whitespace** — `developer "Universal "`, `developer "Ikegami Tsushinki "` — with the same effect.

**4 blocks carry a mangled HTML entity**, `T&E; Soft`, the residue of an `&amp;` decoded without its semicolon being consumed. The company is T&E Soft, spelled correctly elsewhere in the same files.

Whitespace and that entity only; no name is otherwise altered, and no block is added, dropped or reordered.

Reference dats imported from No-Intro, Redump and TOSEC are deliberately untouched — an edit there is undone by the next refresh, so only the hand-maintained categories are in scope.
