### PR TITLE
cht: repair 924 Game Gear Game Genie codes broken by '+' separators

### DIFF
--- a/cht/Sega - Game Gear/Aladdin (World) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Aladdin (World) (Game Genie).cht
@@ -1,38 +1,38 @@
 cheats = 9 
 
 cheat0_desc = "Start With 1/2 Jewel In Life Gauge"
-cheat0_code = "012+9AD+F72"
+cheat0_code = "012-9AD-F72"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 1/2 Maximum Jewels In Life Gauge"
-cheat1_code = "032+9AD+F72"
+cheat1_code = "032-9AD-F72"
 cheat1_enable = false 
 
 cheat2_desc = "Don't Take Damage From Most Hits"
-cheat2_code = "3AE+DDC+2A2"
+cheat2_code = "3AE-DDC-2A2"
 cheat2_enable = false 
 
 cheat3_desc = "No Blinking After Being Hit"
-cheat3_code = "00F+46C+803"
+cheat3_code = "00F-46C-803"
 cheat3_enable = false 
 
 cheat4_desc = "Longer Blinking After Being Hit"
-cheat4_code = "CCF+46C+803"
+cheat4_code = "CCF-46C-803"
 cheat4_enable = false 
 
 cheat5_desc = "Infinite Blinking After Being Hit"
-cheat5_code = "3A2+ACE+2A2"
+cheat5_code = "3A2-ACE-2A2"
 cheat5_enable = false 
 
 cheat6_desc = "Invisibility"
-cheat6_code = "C92+01D+082"
+cheat6_code = "C92-01D-082"
 cheat6_enable = false 
 
 cheat7_desc = "Temporary Invisibility (When You Hit Something)"
-cheat7_code = "002+0BD+E6E"
+cheat7_code = "002-0BD-E6E"
 cheat7_enable = false 
 
 cheat8_desc = "Special Options Screen"
-cheat8_code = "3EB+8DB+2A2+01B+8EB+F7A+00B+8FB+E6D"
+cheat8_code = "3EB-8DB-2A2+01B-8EB-F7A+00B-8FB-E6D"
 cheat8_enable = false 
 

--- a/cht/Sega - Game Gear/Alien 3 (World) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Alien 3 (World) (Game Genie).cht
@@ -1,38 +1,38 @@
 cheats = 9 
 
 cheat0_desc = "Infinite Time (But Timer Still Counts Down)"
-cheat0_code = "00B+3D6+3BE"
+cheat0_code = "00B-3D6-3BE"
 cheat0_enable = false 
 
 cheat1_desc = "Infinite Energy"
-cheat1_code = "002+B1C+3B7"
+cheat1_code = "002-B1C-3B7"
 cheat1_enable = false 
 
 cheat2_desc = "Infinite Lives"
-cheat2_code = "00C+F2A+F79"
+cheat2_code = "00C-F2A-F79"
 cheat2_enable = false 
 
 cheat3_desc = "Infinite Ammo For Grenade Launcher On Pick-Up"
-cheat3_code = "008+0D7+3BE"
+cheat3_code = "008-0D7-3BE"
 cheat3_enable = false 
 
 cheat4_desc = "Infinite Ammo For Flamethrower On Pick-Up"
-cheat4_code = "002+6E6+19E"
+cheat4_code = "002-6E6-19E"
 cheat4_enable = false 
 
 cheat5_desc = "Infinite Ammo For Machine Gun On Pick-Up"
-cheat5_code = "006+4A7+19E"
+cheat5_code = "006-4A7-19E"
 cheat5_enable = false 
 
 cheat6_desc = "Start With 5 Lives"
-cheat6_code = "058+BA8+E66"
+cheat6_code = "058-BA8-E66"
 cheat6_enable = false 
 
 cheat7_desc = "Start With 7 Lives"
-cheat7_code = "078+BA8+E66"
+cheat7_code = "078-BA8-E66"
 cheat7_enable = false 
 
 cheat8_desc = "Start With 9 Lives"
-cheat8_code = "098+BA8+E66"
+cheat8_code = "098-BA8-E66"
 cheat8_enable = false 
 

--- a/cht/Sega - Game Gear/Alien Syndrome (World) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Alien Syndrome (World) (Game Genie).cht
@@ -1,22 +1,22 @@
 cheats = 5 
 
 cheat0_desc = "Start With 1 Life"
-cheat0_code = "010+75F+E66"
+cheat0_code = "010-75F-E66"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 5 Lives"
-cheat1_code = "050+75F+E66"
+cheat1_code = "050-75F-E66"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 9 Lives"
-cheat2_code = "090+75F+E66"
+cheat2_code = "090-75F-E66"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 500 Seconds"
-cheat3_code = "058+39F+E66"
+cheat3_code = "058-39F-E66"
 cheat3_enable = false 
 
 cheat4_desc = "Start With 900 Seconds"
-cheat4_code = "098+39F+E66"
+cheat4_code = "098-39F-E66"
 cheat4_enable = false 
 

--- a/cht/Sega - Game Gear/Arch Rivals (USA) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Arch Rivals (USA) (Game Genie).cht
@@ -1,26 +1,26 @@
 cheats = 6 
 
 cheat0_desc = "1-Minute Quarters"
-cheat0_code = "01C+ACF+F7A"
+cheat0_code = "01C-ACF-F7A"
 cheat0_enable = false 
 
 cheat1_desc = "3-Minute Quarters"
-cheat1_code = "03C+ACF+F7A"
+cheat1_code = "03C-ACF-F7A"
 cheat1_enable = false 
 
 cheat2_desc = "7-Minute Quarters"
-cheat2_code = "07C+ACF+F7A"
+cheat2_code = "07C-ACF-F7A"
 cheat2_enable = false 
 
 cheat3_desc = "Faster Timer"
-cheat3_code = "02E+2FE+E6E"
+cheat3_code = "02E-2FE-E6E"
 cheat3_enable = false 
 
 cheat4_desc = "Infinite Time"
-cheat4_code = "00E+2FE+E6E"
+cheat4_code = "00E-2FE-E6E"
 cheat4_enable = false 
 
 cheat5_desc = "Computer Opponents Can't Score"
-cheat5_code = "00F+7DE+3B7"
+cheat5_code = "00F-7DE-3B7"
 cheat5_enable = false 
 

--- a/cht/Sega - Game Gear/Ariel The Little Mermaid (Game Genie).cht
+++ b/cht/Sega - Game Gear/Ariel The Little Mermaid (Game Genie).cht
@@ -1,38 +1,38 @@
 cheats = 9 
 
 cheat0_desc = "Infinite Lives"
-cheat0_code = "006+109+19E"
+cheat0_code = "006-109-19E"
 cheat0_enable = false 
 
 cheat1_desc = "Collect 1 Polyp To Find Exit"
-cheat1_code = "AF5+AA9+19E"
+cheat1_code = "AF5-AA9-19E"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 3 Lives"
-cheat2_code = "027+4AF+F7A"
+cheat2_code = "027-4AF-F7A"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 8 Lives"
-cheat3_code = "077+4AF+F7A"
+cheat3_code = "077-4AF-F7A"
 cheat3_enable = false 
 
 cheat4_desc = "*Start With 10 Lives"
-cheat4_code = "097+4AF+F7A"
+cheat4_code = "097-4AF-F7A"
 cheat4_enable = false 
 
 cheat5_desc = "*Start With 26 Lives"
-cheat5_code = "197+4AF+F7A"
+cheat5_code = "197-4AF-F7A"
 cheat5_enable = false 
 
 cheat6_desc = "*Start With 51 Lives"
-cheat6_code = "327+4AF+F7A"
+cheat6_code = "327-4AF-F7A"
 cheat6_enable = false 
 
 cheat7_desc = "*Start With 99 Lives"
-cheat7_code = "627+4AF+F7A"
+cheat7_code = "627-4AF-F7A"
 cheat7_enable = false 
 
 cheat8_desc = "Infinite Keys"
-cheat8_code = "005+039+E6E"
+cheat8_code = "005-039-E6E"
 cheat8_enable = false 
 

--- a/cht/Sega - Game Gear/Ax Battler - A Legend of Golden Axe (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Ax Battler - A Legend of Golden Axe (USA, Europe) (Game Genie).cht
@@ -1,18 +1,18 @@
 cheats = 4 
 
 cheat0_desc = "Start With 1 Energy Bar"
-cheat0_code = "02C+OBF+F72"
+cheat0_code = "02C-0BF-F72"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 2 Energy Bars"
-cheat1_code = "04C+OBF+F72"
+cheat1_code = "04C-0BF-F72"
 cheat1_enable = false 
 
 cheat2_desc = "31 Vases On Pick-Up (Maximum)"
-cheat2_code = "3E7+23B+80E"
+cheat2_code = "3E7-23B-80E"
 cheat2_enable = false 
 
 cheat3_desc = "Hotels, Weapons, Etc. Cost Nothing"
-cheat3_code = "3A4+C1D+2A2"
+cheat3_code = "3A4-C1D-2A2"
 cheat3_enable = false 
 

--- a/cht/Sega - Game Gear/Ayrton Senna's Super Monaco GP II (World) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Ayrton Senna's Super Monaco GP II (World) (Game Genie).cht
@@ -1,10 +1,10 @@
 cheats = 2 
 
 cheat0_desc = "Can't Lose Or Gain Place"
-cheat0_code = "21B+60B+2A2"
+cheat0_code = "21B-60B-2A2"
 cheat0_enable = false 
 
 cheat1_desc = "Infinite Time"
-cheat1_code = "00B+3DF+3B7"
+cheat1_code = "00B-3DF-3B7"
 cheat1_enable = false 
 

--- a/cht/Sega - Game Gear/Bare Knuckle - Streets of Rage (World) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Bare Knuckle - Streets of Rage (World) (Game Genie).cht
@@ -1,15 +1,15 @@
 cheats = 19 
 
 cheat0_desc = "Start With 2 Lives"
-cheat0_code = "027+3CF+E66"
+cheat0_code = "027-3CF-E66"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 5 Lives"
-cheat1_code = "057+3CF+E66"
+cheat1_code = "057-3CF-E66"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 8 Lives"
-cheat2_code = "087+3CF+E66"
+cheat2_code = "087-3CF-E66"
 cheat2_enable = false 
 
 cheat3_desc = "Infinite Time"

--- a/cht/Sega - Game Gear/Bare Knuckle II - Streets of Rage 2 - Streets of Rage II (World) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Bare Knuckle II - Streets of Rage 2 - Streets of Rage II (World) (Game Genie).cht
@@ -1,58 +1,58 @@
 cheats = 14 
 
 cheat0_desc = "Start With Only 1 Life"
-cheat0_code = "012+BEF+E66"
+cheat0_code = "012-BEF-E66"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 6 Lives"
-cheat1_code = "062+BEF+E66"
+cheat1_code = "062-BEF-E66"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 9 Lives"
-cheat2_code = "092+BEF+E66"
+cheat2_code = "092-BEF-E66"
 cheat2_enable = false 
 
 cheat3_desc = "Infinite Lives"
-cheat3_code = "218+15C+91D"
+cheat3_code = "218-15C-91D"
 cheat3_enable = false 
 
 cheat4_desc = "Start 1st Life With 1/2 Energy"
-cheat4_code = "0BE+F79+B36"
+cheat4_code = "0BE-F79-B36"
 cheat4_enable = false 
 
 cheat5_desc = "Start 1st Life With 2X Energy"
-cheat5_code = "3CE+F79+B36"
+cheat5_code = "3CE-F79-B36"
 cheat5_enable = false 
 
 cheat6_desc = "Infinite Energy"
-cheat6_code = "21A+FBC+91D"
+cheat6_code = "21A-FBC-91D"
 cheat6_enable = false 
 
 cheat7_desc = "Infinite Time"
-cheat7_code = "00A+05B+E6E"
+cheat7_code = "00A-05B-E6E"
 cheat7_enable = false 
 
 cheat8_desc = "Start On Stage 2"
-cheat8_code = "012+C3F+E6E+832+C5F+F74"
+cheat8_code = "012-C3F-E6E+832-C5F-F74"
 cheat8_enable = false 
 
 cheat9_desc = "Start On Stage 3"
-cheat9_code = "022+C3F+E6E+832+C5F+F74"
+cheat9_code = "022-C3F-E6E+832-C5F-F74"
 cheat9_enable = false 
 
 cheat10_desc = "Start On Stage 4"
-cheat10_code = "032+C3F+E6E+832+C5F+F74"
+cheat10_code = "032-C3F-E6E+832-C5F-F74"
 cheat10_enable = false 
 
 cheat11_desc = "Start On Stage 5"
-cheat11_code = "042+C3F+E6E+832+C5F+F74"
+cheat11_code = "042-C3F-E6E+832-C5F-F74"
 cheat11_enable = false 
 
 cheat12_desc = "Start On Stage 6"
-cheat12_code = "052+C3F+E6E+832+C5F+F74"
+cheat12_code = "052-C3F-E6E+832-C5F-F74"
 cheat12_enable = false 
 
 cheat13_desc = "Mega-Power Attacks"
-cheat13_code = "3E8+83A+91D+098+84A+193+008+85A+E6F"
+cheat13_code = "3E8-83A-91D+098-84A-193+008-85A-E6F"
 cheat13_enable = false 
 

--- a/cht/Sega - Game Gear/Bartman Meets Radioactive Man (USA) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Bartman Meets Radioactive Man (USA) (Game Genie).cht
@@ -1,34 +1,34 @@
 cheats = 8 
 
 cheat0_desc = "Infinite Lives"
-cheat0_code = "004+E5E+3B7"
+cheat0_code = "004-E5E-3B7"
 cheat0_enable = false 
 
 cheat1_desc = "Infinite Energy"
-cheat1_code = "000+02C+F7A"
+cheat1_code = "000-02C-F7A"
 cheat1_enable = false 
 
 cheat2_desc = "Start With Mega-Energy"
-cheat2_code = "011+56C+B3A"
+cheat2_code = "011-56C-B3A"
 cheat2_enable = false 
 
 cheat3_desc = "One Hit & You're Invincible"
-cheat3_code = "00F+93F+3BE"
+cheat3_code = "00F-93F-3BE"
 cheat3_enable = false 
 
 cheat4_desc = "Don't Flash After Getting Hit"
-cheat4_code = "010+20C+C4A"
+cheat4_code = "010-20C-C4A"
 cheat4_enable = false 
 
 cheat5_desc = "Longer Flash After Getting Hit"
-cheat5_code = "190+20C+C4A"
+cheat5_code = "190-20C-C4A"
 cheat5_enable = false 
 
 cheat6_desc = "Most Enemies Can't Even Touch You"
-cheat6_code = "C9F+C3D+082"
+cheat6_code = "C9F-C3D-082"
 cheat6_enable = false 
 
 cheat7_desc = "Infinite Laser Bolts On Pick-Up"
-cheat7_code = "002+36C+19E"
+cheat7_code = "002-36C-19E"
 cheat7_enable = false 
 

--- a/cht/Sega - Game Gear/Batman Returns (World) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Batman Returns (World) (Game Genie).cht
@@ -1,62 +1,62 @@
 cheats = 15 
 
 cheat0_desc = "Start With 2 Lives"
-cheat0_code = "028+498+E66"
+cheat0_code = "028-498-E66"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 5 Lives"
-cheat1_code = "058+498+E66"
+cheat1_code = "058-498-E66"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 7 Lives"
-cheat2_code = "078+498+E66"
+cheat2_code = "078-498-E66"
 cheat2_enable = false 
 
 cheat3_desc = "Infinite Lives"
-cheat3_code = "00A+57A+E6E"
+cheat3_code = "00A-57A-E6E"
 cheat3_enable = false 
 
 cheat4_desc = "Infinite Special Items"
-cheat4_code = "004+758+19E"
+cheat4_code = "004-758-19E"
 cheat4_enable = false 
 
 cheat5_desc = "Start With 2 Energy Units (1st Life)"
-cheat5_code = "028+4E8+C42"
+cheat5_code = "028-4E8-C42"
 cheat5_enable = false 
 
 cheat6_desc = "Start With 6 Energy Units (1st Life)"
-cheat6_code = "068+4E8+C42"
+cheat6_code = "068-4E8-C42"
 cheat6_enable = false 
 
 cheat7_desc = "Start With 8 Energy Units (1st Life)"
-cheat7_code = "088+4E8+C42"
+cheat7_code = "088-4E8-C42"
 cheat7_enable = false 
 
 cheat8_desc = "Start With 2 Energy Units (After 1st Life)"
-cheat8_code = "02B+33A+C42"
+cheat8_code = "02B-33A-C42"
 cheat8_enable = false 
 
 cheat9_desc = "Start With 4 Energy Units (After 1st Life)"
-cheat9_code = "04B+33A+C42"
+cheat9_code = "04B-33A-C42"
 cheat9_enable = false 
 
 cheat10_desc = "Start With 8 Energy Units (After 1st Life)"
-cheat10_code = "08B+33A+C42"
+cheat10_code = "08B-33A-C42"
 cheat10_enable = false 
 
 cheat11_desc = "Start With 3 Special Items (1st Life)"
-cheat11_code = "038+538+E6E"
+cheat11_code = "038-538-E6E"
 cheat11_enable = false 
 
 cheat12_desc = "Start With 3 Special Items (After 1st Life)"
-cheat12_code = "03B+38A+E6E"
+cheat12_code = "03B-38A-E6E"
 cheat12_enable = false 
 
 cheat13_desc = "Start With 6 Special Items (After 1st Life)"
-cheat13_code = "06B+38A+E6E"
+cheat13_code = "06B-38A-E6E"
 cheat13_enable = false 
 
 cheat14_desc = "Start With 9 Special Items (After 1st Life)"
-cheat14_code = "09B+38A+E6E"
+cheat14_code = "09B-38A-E6E"
 cheat14_enable = false 
 

--- a/cht/Sega - Game Gear/Bram Stoker's Dracula (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Bram Stoker's Dracula (USA, Europe) (Game Genie).cht
@@ -1,74 +1,74 @@
 cheats = 18 
 
 cheat0_desc = "Start With 1 Life"
-cheat0_code = "002+4FA+E66"
+cheat0_code = "002-4FA-E66"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 2 Lives"
-cheat1_code = "012+4FA+E66"
+cheat1_code = "012-4FA-E66"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 6 Lives"
-cheat2_code = "052+4FA+E66"
+cheat2_code = "052-4FA-E66"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 10 Lives"
-cheat3_code = "092+4FA+E66"
+cheat3_code = "092-4FA-E66"
 cheat3_enable = false 
 
 cheat4_desc = "Infinite Lives"
-cheat4_code = "3A3+C8A+2A2"
+cheat4_code = "3A3-C8A-2A2"
 cheat4_enable = false 
 
 cheat5_desc = "Start With Energy At 1 (1st Life)"
-cheat5_code = "012+4AA+F7A"
+cheat5_code = "012-4AA-F7A"
 cheat5_enable = false 
 
 cheat6_desc = "Start With Energy At 6 (1st Life)"
-cheat6_code = "062+4AA+F7A"
+cheat6_code = "062-4AA-F7A"
 cheat6_enable = false 
 
 cheat7_desc = "Start With Energy At 9 (1st Life)"
-cheat7_code = "092+4AA+F7A"
+cheat7_code = "092-4AA-F7A"
 cheat7_enable = false 
 
 cheat8_desc = "Start With Energy At 1 (1st Life)"
-cheat8_code = "013+C0A+F7A"
+cheat8_code = "013-C0A-F7A"
 cheat8_enable = false 
 
 cheat9_desc = "Start With Energy At 6 (After 1st Life)"
-cheat9_code = "063+C0A+F7A"
+cheat9_code = "063-C0A-F7A"
 cheat9_enable = false 
 
 cheat10_desc = "Start With Energy At 9 (After 1st Life)"
-cheat10_code = "093+C0A+F7A"
+cheat10_code = "093-C0A-F7A"
 cheat10_enable = false 
 
 cheat11_desc = "After Pick-Up, Keep Weapons Until End Of Level (After 1st Life)"
-cheat11_code = "3A4+39C+2A2"
+cheat11_code = "3A4-39C-2A2"
 cheat11_enable = false 
 
 cheat12_desc = "Infinite Time (After 1st Life)"
-cheat12_code = "001+7BB+19E"
+cheat12_code = "001-7BB-19E"
 cheat12_enable = false 
 
 cheat13_desc = "Invincible (After 1st Life)"
-cheat13_code = "3A5+93C+2A2"
+cheat13_code = "3A5-93C-2A2"
 cheat13_enable = false 
 
 cheat14_desc = "Protection From Water & Spikes (After 1st Life)"
-cheat14_code = "C39+95E+E61"
+cheat14_code = "C39-95E-E61"
 cheat14_enable = false 
 
 cheat15_desc = "Slow Side Scroll"
-cheat15_code = "002+2FD+XXX"
+cheat15_code = "002-2FD-XXX"
 cheat15_enable = false 
 
 cheat16_desc = "View Ending"
-cheat16_code = "5CB+2AA+XXX"
+cheat16_code = "5CB-2AA-XXX"
 cheat16_enable = false 
 
 cheat17_desc = "Moon Jump"
-cheat17_code = "01B+4DC+XXX"
+cheat17_code = "01B-4DC-XXX"
 cheat17_enable = false 
 

--- a/cht/Sega - Game Gear/Bubble Bobble (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Bubble Bobble (USA, Europe) (Game Genie).cht
@@ -1,22 +1,22 @@
 cheats = 5 
 
 cheat0_desc = "Start With 1 Life"
-cheat0_code = "01F+0BE+F72"
+cheat0_code = "01F-0BE-F72"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 9 Lives"
-cheat1_code = "09F+0BE+F72"
+cheat1_code = "09F-0BE-F72"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 15 Lives"
-cheat2_code = "0FF+0BE+F72"
+cheat2_code = "0FF-0BE-F72"
 cheat2_enable = false 
 
 cheat3_desc = "Start With Letters "X" & "T""
-cheat3_code = "00F+12E+5D4"
+cheat3_code = "00F-12E-5D4"
 cheat3_enable = false 
 
 cheat4_desc = "Almost Invincible"
-cheat4_code = "FF0+4B7+E6A+FF9+607+E6A"
+cheat4_code = "FF0-4B7-E6A+FF9-607-E6A"
 cheat4_enable = false 
 

--- a/cht/Sega - Game Gear/Castle of Illusion Starring Mickey Mouse (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Castle of Illusion Starring Mickey Mouse (USA, Europe) (Game Genie).cht
@@ -1,34 +1,34 @@
 cheats = 8 
 
 cheat0_desc = "Infinite Lives"
-cheat0_code = "008+A6E+E6E"
+cheat0_code = "008-A6E-E6E"
 cheat0_enable = false 
 
 cheat1_desc = "Infinite Energy"
-cheat1_code = "003+64C+E69"
+cheat1_code = "003-64C-E69"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 2 Energy Stars"
-cheat2_code = "029+76F+E66"
+cheat2_code = "029-76F-E66"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 4 Energy Stars"
-cheat3_code = "049+76F+E66"
+cheat3_code = "049-76F-E66"
 cheat3_enable = false 
 
 cheat4_desc = "Start With 5 Energy Stars"
-cheat4_code = "059+76F+E66"
+cheat4_code = "059-76F-E66"
 cheat4_enable = false 
 
 cheat5_desc = "Timer Starts At 300"
-cheat5_code = "036+C1E+F7A"
+cheat5_code = "036-C1E-F7A"
 cheat5_enable = false 
 
 cheat6_desc = "Timer Starts At 500"
-cheat6_code = "056+C1E+F7A"
+cheat6_code = "056-C1E-F7A"
 cheat6_enable = false 
 
 cheat7_desc = "Timer Starts At 600"
-cheat7_code = "066+C1E+F7A"
+cheat7_code = "066-C1E-F7A"
 cheat7_enable = false 
 

--- a/cht/Sega - Game Gear/Chuck Rock (World) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Chuck Rock (World) (Game Genie).cht
@@ -1,34 +1,34 @@
 cheats = 8 
 
 cheat0_desc = "Start With 1 Life"
-cheat0_code = "008+52E+E66"
+cheat0_code = "008-52E-E66"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 2 Lives"
-cheat1_code = "018+52E+E66"
+cheat1_code = "018-52E-E66"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 6 Lives"
-cheat2_code = "058+52E+E66"
+cheat2_code = "058-52E-E66"
 cheat2_enable = false 
 
 cheat3_desc = "Start With Mega Energy (1st Life)"
-cheat3_code = "88A+5CE+F72"
+cheat3_code = "88A-5CE-F72"
 cheat3_enable = false 
 
 cheat4_desc = "Start On Level 2"
-cheat4_code = "02E+EBF+E6A"
+cheat4_code = "02E-EBF-E6A"
 cheat4_enable = false 
 
 cheat5_desc = "Start On Level 3"
-cheat5_code = "03E+EBF+E6A"
+cheat5_code = "03E-EBF-E6A"
 cheat5_enable = false 
 
 cheat6_desc = "Start On Level 4"
-cheat6_code = "04E+EBF+E6A"
+cheat6_code = "04E-EBF-E6A"
 cheat6_enable = false 
 
 cheat7_desc = "Start With Lots Of Lives (Ignore Counter)"
-cheat7_code = "3AB+0EE+19D"
+cheat7_code = "3AB-0EE-19D"
 cheat7_enable = false 
 

--- a/cht/Sega - Game Gear/Cliffhanger (USA) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Cliffhanger (USA) (Game Genie).cht
@@ -1,58 +1,58 @@
 cheats = 14 
 
 cheat0_desc = "Start With 2 Lives"
-cheat0_code = "011+98E+E62"
+cheat0_code = "011-98E-E62"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 5 Lives"
-cheat1_code = "041+98E+E62"
+cheat1_code = "041-98E-E62"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 10 Lives"
-cheat2_code = "091+98E+E62"
+cheat2_code = "091-98E-E62"
 cheat2_enable = false 
 
 cheat3_desc = "Infinite Lives"
-cheat3_code = "012+73E+B39"
+cheat3_code = "012-73E-B39"
 cheat3_enable = false 
 
 cheat4_desc = "Start With 1 Energy Bar"
-cheat4_code = "011+A3E+A2A"
+cheat4_code = "011-A3E-A2A"
 cheat4_enable = false 
 
 cheat5_desc = "Start With 5 Energy Bars"
-cheat5_code = "051+A3E+A2A"
+cheat5_code = "051-A3E-A2A"
 cheat5_enable = false 
 
 cheat6_desc = "One Hit Kills"
-cheat6_code = "018+9AE+B39"
+cheat6_code = "018-9AE-B39"
 cheat6_enable = false 
 
 cheat7_desc = "1 Continue"
-cheat7_code = "011+80E+E66"
+cheat7_code = "011-80E-E66"
 cheat7_enable = false 
 
 cheat8_desc = "5 Continues"
-cheat8_code = "051+80E+E66"
+cheat8_code = "051-80E-E66"
 cheat8_enable = false 
 
 cheat9_desc = "9 Continues"
-cheat9_code = "091+80E+E66"
+cheat9_code = "091-80E-E66"
 cheat9_enable = false 
 
 cheat10_desc = "Invincibility"
-cheat10_code = "C90+C6A+E69"
+cheat10_code = "C90-C6A-E69"
 cheat10_enable = false 
 
 cheat11_desc = "Start On Level 2"
-cheat11_code = "031+85E+E6A"
+cheat11_code = "031-85E-E6A"
 cheat11_enable = false 
 
 cheat12_desc = "Start On Level 3"
-cheat12_code = "061+85E+E6A"
+cheat12_code = "061-85E-E6A"
 cheat12_enable = false 
 
 cheat13_desc = "Start On Level 4"
-cheat13_code = "081+85E+E6A"
+cheat13_code = "081-85E-E6A"
 cheat13_enable = false 
 

--- a/cht/Sega - Game Gear/Clutch Hitter (USA) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Clutch Hitter (USA) (Game Genie).cht
@@ -1,30 +1,30 @@
 cheats = 7 
 
 cheat0_desc = "Strikes Aren't Called"
-cheat0_code = "005+109+19A"
+cheat0_code = "005-109-19A"
 cheat0_enable = false 
 
 cheat1_desc = "2 Strikes & You're Out"
-cheat1_code = "025+129+E66"
+cheat1_code = "025-129-E66"
 cheat1_enable = false 
 
 cheat2_desc = "4 Strikes & You're Out"
-cheat2_code = "045+129+E66"
+cheat2_code = "045-129-E66"
 cheat2_enable = false 
 
 cheat3_desc = "1 Ball & You Walk"
-cheat3_code = "015+3B9+F7A"
+cheat3_code = "015-3B9-F7A"
 cheat3_enable = false 
 
 cheat4_desc = "2 Balls & You Walk"
-cheat4_code = "025+3B9+F7A"
+cheat4_code = "025-3B9-F7A"
 cheat4_enable = false 
 
 cheat5_desc = "Balls Aren't Counted"
-cheat5_code = "005+399+19A"
+cheat5_code = "005-399-19A"
 cheat5_enable = false 
 
 cheat6_desc = "No Scoring"
-cheat6_code = "008+E99+19A+008+F89+19A"
+cheat6_code = "008-E99-19A+008-F89-19A"
 cheat6_enable = false 
 

--- a/cht/Sega - Game Gear/Crystal Warriors (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Crystal Warriors (USA, Europe) (Game Genie).cht
@@ -1,22 +1,22 @@
 cheats = 5 
 
 cheat0_desc = "Iris Starts With 50 HP"
-cheat0_code = "96D+335+6EA"
+cheat0_code = "96D-335-6EA"
 cheat0_enable = false 
 
 cheat1_desc = "Iris Starts With 50 MP"
-cheat1_code = "96D+345+802"
+cheat1_code = "96D-345-802"
 cheat1_enable = false 
 
 cheat2_desc = "Iris Starts With 50 AP"
-cheat2_code = "96D+355+A22"
+cheat2_code = "96D-355-A22"
 cheat2_enable = false 
 
 cheat3_desc = "Iris Starts With 50 DP"
-cheat3_code = "96D+365+C42"
+cheat3_code = "96D-365-C42"
 cheat3_enable = false 
 
 cheat4_desc = "Iris Starts With 50 LK"
-cheat4_code = "96D+375+C42"
+cheat4_code = "96D-375-C42"
 cheat4_enable = false 
 

--- a/cht/Sega - Game Gear/Desert Speedtrap Starring Road Runner and Wile E. Coyote (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Desert Speedtrap Starring Road Runner and Wile E. Coyote (USA, Europe) (Game Genie).cht
@@ -1,74 +1,74 @@
 cheats = 18 
 
 cheat0_desc = "Infinite Hits"
-cheat0_code = "212+39B+19D"
+cheat0_code = "212-39B-19D"
 cheat0_enable = false 
 
 cheat1_desc = "2 Energy Points Allowed For 1st Life Only"
-cheat1_code = "014+74E+E66"
+cheat1_code = "014-74E-E66"
 cheat1_enable = false 
 
 cheat2_desc = "3 Energy Points Allowed For 1st Life Only"
-cheat2_code = "024+74E+E66"
+cheat2_code = "024-74E-E66"
 cheat2_enable = false 
 
 cheat3_desc = "1 Energy Point Allowed For 1st Life Only"
-cheat3_code = "004+74E+E66"
+cheat3_code = "004-74E-E66"
 cheat3_enable = false 
 
 cheat4_desc = "10 Energy Points Allowed For 1st Life Only (May Mess Up Energy Bar)"
-cheat4_code = "094+74E+E66"
+cheat4_code = "094-74E-E66"
 cheat4_enable = false 
 
 cheat5_desc = "Start With 2 Lives"
-cheat5_code = "015+3AF+E62"
+cheat5_code = "015-3AF-E62"
 cheat5_enable = false 
 
 cheat6_desc = "Start With 6 Lives"
-cheat6_code = "065+3AF+E62"
+cheat6_code = "065-3AF-E62"
 cheat6_enable = false 
 
 cheat7_desc = "Start With 9 Lives"
-cheat7_code = "095+3AF+E62"
+cheat7_code = "095-3AF-E62"
 cheat7_enable = false 
 
 cheat8_desc = "Infinite Timer"
-cheat8_code = "001+59B+A2A"
+cheat8_code = "001-59B-A2A"
 cheat8_enable = false 
 
 cheat9_desc = "Start With 1 Credit"
-cheat9_code = "015+0FF+E66"
+cheat9_code = "015-0FF-E66"
 cheat9_enable = false 
 
 cheat10_desc = "Start With 5 Credits"
-cheat10_code = "055+0FF+E66"
+cheat10_code = "055-0FF-E66"
 cheat10_enable = false 
 
 cheat11_desc = "Start With 7 Credits"
-cheat11_code = "075+0FF+E66"
+cheat11_code = "075-0FF-E66"
 cheat11_enable = false 
 
 cheat12_desc = "Start With 9 Credits"
-cheat12_code = "095+0FF+E66"
+cheat12_code = "095-0FF-E66"
 cheat12_enable = false 
 
 cheat13_desc = "Enemies Can't Hurt"
-cheat13_code = "C31+A8B+E61"
+cheat13_code = "C31-A8B-E61"
 cheat13_enable = false 
 
 cheat14_desc = "Start On Level 3"
-cheat14_code = "035+0FF+E66+325+13F+082"
+cheat14_code = "035-0FF-E66+325-13F-082"
 cheat14_enable = false 
 
 cheat15_desc = "Start On Level 6"
-cheat15_code = "065+0FF+E66+325+13F+082"
+cheat15_code = "065-0FF-E66+325-13F-082"
 cheat15_enable = false 
 
 cheat16_desc = "Start On Level 9"
-cheat16_code = "095+0FF+E66+325+13F+082"
+cheat16_code = "095-0FF-E66+325-13F-082"
 cheat16_enable = false 
 
 cheat17_desc = "Start On Last Level"
-cheat17_code = "0E5+0FF+E66+325+13F+082"
+cheat17_code = "0E5-0FF-E66+325-13F-082"
 cheat17_enable = false 
 

--- a/cht/Sega - Game Gear/Desert Strike (Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Desert Strike (Europe) (Game Genie).cht
@@ -1,82 +1,82 @@
 cheats = 20 
 
 cheat0_desc = "Start With 1 Hellfire"
-cheat0_code = "01E+03E+C4A"
+cheat0_code = "01E-03E-C4A"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 5 Hellfires"
-cheat1_code = "05E+03E+C4A"
+cheat1_code = "05E-03E-C4A"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 9 Hellfires"
-cheat2_code = "09E+03E+C4A"
+cheat2_code = "09E-03E-C4A"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 1 Hydras"
-cheat3_code = "01E+08E+3BA"
+cheat3_code = "01E-08E-3BA"
 cheat3_enable = false 
 
 cheat4_desc = "Start With 56 Hydras"
-cheat4_code = "56E+08E+3BA"
+cheat4_code = "56E-08E-3BA"
 cheat4_enable = false 
 
 cheat5_desc = "Start With 99 Hydras"
-cheat5_code = "99E+0DE+3BA"
+cheat5_code = "99E-0DE-3BA"
 cheat5_enable = false 
 
 cheat6_desc = "Start With 178 Guns"
-cheat6_code = "01E+0DE+A2E"
+cheat6_code = "01E-0DE-A2E"
 cheat6_enable = false 
 
 cheat7_desc = "Start With 678 Guns"
-cheat7_code = "06E+0DE+A2E"
+cheat7_code = "06E-0DE-A2E"
 cheat7_enable = false 
 
 cheat8_desc = "Start With 9,978 Guns"
-cheat8_code = "99E+0DE+A2E"
+cheat8_code = "99E-0DE-A2E"
 cheat8_enable = false 
 
 cheat9_desc = "Start With 100 Fuel Load"
-cheat9_code = "01E+12E+08B+01E+1CE+E6E"
+cheat9_code = "01E-12E-08B+01E-1CE-E6E"
 cheat9_enable = false 
 
 cheat10_desc = "Start With 5,500 Fuel Load"
-cheat10_code = "55E+12E+08B+55E+1CE+E6E"
+cheat10_code = "55E-12E-08B+55E-1CE-E6E"
 cheat10_enable = false 
 
 cheat11_desc = "Start With 9,900 Fuel Load"
-cheat11_code = "99E+12E+1CE+99E+1CE+E6E"
+cheat11_code = "99E-12E-1CE+99E-1CE-E6E"
 cheat11_enable = false 
 
 cheat12_desc = "Start With 300 Armor"
-cheat12_code = "03E+2BE+F72"
+cheat12_code = "03E-2BE-F72"
 cheat12_enable = false 
 
 cheat13_desc = "Start With 600 Armor"
-cheat13_code = "06E+2BE+F72"
+cheat13_code = "06E-2BE-F72"
 cheat13_enable = false 
 
 cheat14_desc = "Start With 9900 Armor"
-cheat14_code = "99E+2BE+F72"
+cheat14_code = "99E-2BE-F72"
 cheat14_enable = false 
 
 cheat15_desc = "Infinite Fuel"
-cheat15_code = "002+E97+E6E"
+cheat15_code = "002-E97-E6E"
 cheat15_enable = false 
 
 cheat16_desc = "Infinite Armor"
-cheat16_code = "3A9+807+2A2"
+cheat16_code = "3A9-807-2A2"
 cheat16_enable = false 
 
 cheat17_desc = "Infinite Hydras"
-cheat17_code = "005+B07+E6E"
+cheat17_code = "005-B07-E6E"
 cheat17_enable = false 
 
 cheat18_desc = "Infinite Hellfires"
-cheat18_code = "004+CF7+E6E"
+cheat18_code = "004-CF7-E6E"
 cheat18_enable = false 
 
 cheat19_desc = "Infinite Guns"
-cheat19_code = "006+FC7+E6E"
+cheat19_code = "006-FC7-E6E"
 cheat19_enable = false 
 

--- a/cht/Sega - Game Gear/Devilish (World) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Devilish (World) (Game Genie).cht
@@ -1,62 +1,62 @@
 cheats = 15 
 
 cheat0_desc = "Infinite Balls"
-cheat0_code = "00C+EDA+19E"
+cheat0_code = "00C-EDA-19E"
 cheat0_enable = false 
 
 cheat1_desc = "Infinite Credits"
-cheat1_code = "3A3+A6E+2A2"
+cheat1_code = "3A3-A6E-2A2"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 2 Balls"
-cheat2_code = "011+76D+E62"
+cheat2_code = "011-76D-E62"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 7 Balls"
-cheat3_code = "061+76D+E62"
+cheat3_code = "061-76D-E62"
 cheat3_enable = false 
 
 cheat4_desc = "Start With 9 Balls"
-cheat4_code = "081+76D+E62"
+cheat4_code = "081-76D-E62"
 cheat4_enable = false 
 
 cheat5_desc = "Start With 2 Credits"
-cheat5_code = "012+9AE+E62"
+cheat5_code = "012-9AE-E62"
 cheat5_enable = false 
 
 cheat6_desc = "Start With 6 Credits"
-cheat6_code = "052+9AE+E62"
+cheat6_code = "052-9AE-E62"
 cheat6_enable = false 
 
 cheat7_desc = "Start With 8 Credits"
-cheat7_code = "072+9AE+E62"
+cheat7_code = "072-9AE-E62"
 cheat7_enable = false 
 
 cheat8_desc = "Start On Stage 2 - Under Passage"
-cheat8_code = "022+E2E+E6E"
+cheat8_code = "022-E2E-E6E"
 cheat8_enable = false 
 
 cheat9_desc = "Start On Stage 3 - Waterfalls"
-cheat9_code = "032+E2E+E6E"
+cheat9_code = "032-E2E-E6E"
 cheat9_enable = false 
 
 cheat10_desc = "Start On Stage 4 - Old Castle"
-cheat10_code = "042+E2E+E6E"
+cheat10_code = "042-E2E-E6E"
 cheat10_enable = false 
 
 cheat11_desc = "Start On Stage 5 - Prairie"
-cheat11_code = "052+E2E+E6E"
+cheat11_code = "052-E2E-E6E"
 cheat11_enable = false 
 
 cheat12_desc = "Start On Stage 6 - Volcano"
-cheat12_code = "062+E2E+E6E"
+cheat12_code = "062-E2E-E6E"
 cheat12_enable = false 
 
 cheat13_desc = "Start On Stage 7 - World of Ice"
-cheat13_code = "072+E2E+E6E"
+cheat13_code = "072-E2E-E6E"
 cheat13_enable = false 
 
 cheat14_desc = "Start On Stage 8 - Evil Temple"
-cheat14_code = "082+E2E+E6E"
+cheat14_code = "082-E2E-E6E"
 cheat14_enable = false 
 

--- a/cht/Sega - Game Gear/Double Dragon (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Double Dragon (USA, Europe) (Game Genie).cht
@@ -1,74 +1,74 @@
 cheats = 18 
 
 cheat0_desc = "Start With 2 Lives"
-cheat0_code = "012+19F+E66"
+cheat0_code = "012-19F-E66"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 6 Lives"
-cheat1_code = "052+19F+E66"
+cheat1_code = "052-19F-E66"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 10 Lives"
-cheat2_code = "092+19F+E66"
+cheat2_code = "092-19F-E66"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 1 Energy Bar For First Knockdown Only"
-cheat3_code = "012+21F+F76"
+cheat3_code = "012-21F-F76"
 cheat3_enable = false 
 
 cheat4_desc = "Start With Two Energy Bars For First Knockdown Only"
-cheat4_code = "022+21F+F76"
+cheat4_code = "022-21F-F76"
 cheat4_enable = false 
 
 cheat5_desc = "Start With Lots Of Energy"
-cheat5_code = "00F+03F+3BF"
+cheat5_code = "00F-03F-3BF"
 cheat5_enable = false 
 
 cheat6_desc = "Pick Up Gun & Keep Until End Of Level"
-cheat6_code = "00C+B6F+3BE"
+cheat6_code = "00C-B6F-3BE"
 cheat6_enable = false 
 
 cheat7_desc = "Gun Has 1 Bullet"
-cheat7_code = "013+D9C+DD6"
+cheat7_code = "013-D9C-DD6"
 cheat7_enable = false 
 
 cheat8_desc = "Gun Has 5 Bullets"
-cheat8_code = "053+D9C+DD6"
+cheat8_code = "053-D9C-DD6"
 cheat8_enable = false 
 
 cheat9_desc = "Gun Has 9 Bullets"
-cheat9_code = "093+D9C+DD6"
+cheat9_code = "093-D9C-DD6"
 cheat9_enable = false 
 
 cheat10_desc = "2 Lives After 1st Continue"
-cheat10_code = "017+EAD+E66"
+cheat10_code = "017-EAD-E66"
 cheat10_enable = false 
 
 cheat11_desc = "6 Lives After 1st Continue"
-cheat11_code = "057+EAD+E66"
+cheat11_code = "057-EAD-E66"
 cheat11_enable = false 
 
 cheat12_desc = "10 Lives After 1st Continue"
-cheat12_code = "097+EAD+E66"
+cheat12_code = "097-EAD-E66"
 cheat12_enable = false 
 
 cheat13_desc = "Infinite Continues"
-cheat13_code = "007+E5D+3B7"
+cheat13_code = "007-E5D-3B7"
 cheat13_enable = false 
 
 cheat14_desc = "Start With 1 Energy Bar (After 1st Life)"
-cheat14_code = "014+37F+F76"
+cheat14_code = "014-37F-F76"
 cheat14_enable = false 
 
 cheat15_desc = "Start With 1.5 Energy Bars (After 1st Life)"
-cheat15_code = "024+37F+F76"
+cheat15_code = "024-37F-F76"
 cheat15_enable = false 
 
 cheat16_desc = "Start With 2 Energy Bars (After 1st Life)"
-cheat16_code = "034+37F+F76"
+cheat16_code = "034-37F-F76"
 cheat16_enable = false 
 
 cheat17_desc = "Nasties Warp All Over The Place (Very Hard To Kill)"
-cheat17_code = "AFD+0AE+F70"
+cheat17_code = "AFD-0AE-F70"
 cheat17_enable = false 
 

--- a/cht/Sega - Game Gear/Dragon Crystal (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Dragon Crystal (USA, Europe) (Game Genie).cht
@@ -1,94 +1,94 @@
 cheats = 23 
 
 cheat0_desc = "Infinite Hit Points"
-cheat0_code = "214+EBA+6E2"
+cheat0_code = "214-EBA-6E2"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 75 Hit Points"
-cheat1_code = "4BF+FAF+7FB"
+cheat1_code = "4BF-FAF-7FB"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 150 Hit Points"
-cheat2_code = "96F+FAF+7FB"
+cheat2_code = "96F-FAF-7FB"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 125 Hit Points"
-cheat3_code = "7DF+FAF+7FB"
+cheat3_code = "7DF-FAF-7FB"
 cheat3_enable = false 
 
 cheat4_desc = "Start With 50 Food"
-cheat4_code = "50F+F5F+2AA"
+cheat4_code = "50F-F5F-2AA"
 cheat4_enable = false 
 
 cheat5_desc = "Start With 75 Food"
-cheat5_code = "75F+F5F+2AA"
+cheat5_code = "75F-F5F-2AA"
 cheat5_enable = false 
 
 cheat6_desc = "Start With Maximum Food (99)"
-cheat6_code = "99F+F5F+2AA"
+cheat6_code = "99F-F5F-2AA"
 cheat6_enable = false 
 
 cheat7_desc = "Infinite Food"
-cheat7_code = "3AE+FBD+2A2"
+cheat7_code = "3AE-FBD-2A2"
 cheat7_enable = false 
 
 cheat8_desc = "Start On Floor 2 As Ranger"
-cheat8_code = "02F+EDF+E6E"
+cheat8_code = "02F-EDF-E6E"
 cheat8_enable = false 
 
 cheat9_desc = "Start On Floor 3 As Soldier"
-cheat9_code = "03F+EDF+E6E"
+cheat9_code = "03F-EDF-E6E"
 cheat9_enable = false 
 
 cheat10_desc = "Start On Floor 4 As Warrior"
-cheat10_code = "04F+EDF+E6E"
+cheat10_code = "04F-EDF-E6E"
 cheat10_enable = false 
 
 cheat11_desc = "Start On Floor 5 As Fighter"
-cheat11_code = "05F+EDF+E6E"
+cheat11_code = "05F-EDF-E6E"
 cheat11_enable = false 
 
 cheat12_desc = "Start On Floor 6 As Swordsman"
-cheat12_code = "06F+EDF+E6E"
+cheat12_code = "06F-EDF-E6E"
 cheat12_enable = false 
 
 cheat13_desc = "Start On Floor 7 As Veteran"
-cheat13_code = "07F+EDF+E6E"
+cheat13_code = "07F-EDF-E6E"
 cheat13_enable = false 
 
 cheat14_desc = "Start On Floor 8 As Knight"
-cheat14_code = "08F+EDF+E6E"
+cheat14_code = "08F-EDF-E6E"
 cheat14_enable = false 
 
 cheat15_desc = "Start On Floor 9 As Champion"
-cheat15_code = "09F+EDF+E6E"
+cheat15_code = "09F-EDF-E6E"
 cheat15_enable = false 
 
 cheat16_desc = "Start On Floor 10 As Hero"
-cheat16_code = "0AF+EDF+E6E"
+cheat16_code = "0AF-EDF-E6E"
 cheat16_enable = false 
 
 cheat17_desc = "Start On Floor 11 As Master"
-cheat17_code = "0BF+EDF+E6E"
+cheat17_code = "0BF-EDF-E6E"
 cheat17_enable = false 
 
 cheat18_desc = "Start On Floor 12 As Paladin"
-cheat18_code = "0CF+EDF+E6E"
+cheat18_code = "0CF-EDF-E6E"
 cheat18_enable = false 
 
 cheat19_desc = "Start On Floor 13 As Warlord"
-cheat19_code = "0DF+EDF+E6E"
+cheat19_code = "0DF-EDF-E6E"
 cheat19_enable = false 
 
 cheat20_desc = "Start On Floor 14 As Dragon Lord"
-cheat20_code = "0EF+EDF+E6E"
+cheat20_code = "0EF-EDF-E6E"
 cheat20_enable = false 
 
 cheat21_desc = "Start On Floor 15 As Avatar"
-cheat21_code = "0FF+EDF+E6E"
+cheat21_code = "0FF-EDF-E6E"
 cheat21_enable = false 
 
 cheat22_desc = "Start On Floor 16 As Master Lord"
-cheat22_code = "10F+EDF+E6E"
+cheat22_code = "10F-EDF-E6E"
 cheat22_enable = false 
 

--- a/cht/Sega - Game Gear/Dynamite Headdy (World) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Dynamite Headdy (World) (Game Genie).cht
@@ -1,26 +1,26 @@
 cheats = 6 
 
 cheat0_desc = "Start With 1 Lives"
-cheat0_code = "014+FAF+E66"
+cheat0_code = "014-FAF-E66"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 5 Lives"
-cheat1_code = "054+FAF+E66"
+cheat1_code = "054-FAF-E66"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 9 Lives"
-cheat2_code = "094+FAF+E66"
+cheat2_code = "094-FAF-E66"
 cheat2_enable = false 
 
 cheat3_desc = "Infinite Lives"
-cheat3_code = "008+E2D+E69"
+cheat3_code = "008-E2D-E69"
 cheat3_enable = false 
 
 cheat4_desc = "Infinite Energy"
-cheat4_code = "004+56C+D5A"
+cheat4_code = "004-56C-D5A"
 cheat4_enable = false 
 
 cheat5_desc = "Start On Toys In The Hood"
-cheat5_code = "344+F3F+3BE+344+EFF+3BE"
+cheat5_code = "344-F3F-3BE+344-EFF-3BE"
 cheat5_enable = false 
 

--- a/cht/Sega - Game Gear/Ecco - The Tides of Time (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Ecco - The Tides of Time (USA, Europe) (Game Genie).cht
@@ -1,110 +1,110 @@
 cheats = 27 
 
 cheat0_desc = "Start On Vents Of Medusa"
-cheat0_code = "014+20B+C4A+884+22B+2A2+004+27B+3BA"
+cheat0_code = "014-20B-C4A+884-22B-2A2+004-27B-3BA"
 cheat0_enable = false 
 
 cheat1_desc = "Start On Maze Of Stone"
-cheat1_code = "024+20B+C4A+884+22B+2A2+004+27B+3BA"
+cheat1_code = "024-20B-C4A+884-22B-2A2+004-27B-3BA"
 cheat1_enable = false 
 
 cheat2_desc = "Start On Sea Of Darkness"
-cheat2_code = "034+20B+C4A+884+22B+2A2+004+27B+3BA"
+cheat2_code = "034-20B-C4A+884-22B-2A2+004-27B-3BA"
 cheat2_enable = false 
 
 cheat3_desc = "Start On DDD Swimming"
-cheat3_code = "044+20B+C4A+884+22B+2A2+004+27B+3BA"
+cheat3_code = "044-20B-C4A+884-22B-2A2+004-27B-3BA"
 cheat3_enable = false 
 
 cheat4_desc = "Start On Skyway"
-cheat4_code = "054+20B+C4A+884+22B+2A2+004+27B+3BA"
+cheat4_code = "054-20B-C4A+884-22B-2A2+004-27B-3BA"
 cheat4_enable = false 
 
 cheat5_desc = "Start On Tube of Medusa"
-cheat5_code = "064+20B+C4A+884+22B+2A2+004+27B+3BA"
+cheat5_code = "064-20B-C4A+884-22B-2A2+004-27B-3BA"
 cheat5_enable = false 
 
 cheat6_desc = "Start On DDD Swimming #2"
-cheat6_code = "074+20B+C4A+884+22B+2A2+004+27B+3BA"
+cheat6_code = "074-20B-C4A+884-22B-2A2+004-27B-3BA"
 cheat6_enable = false 
 
 cheat7_desc = "Start On Getaway"
-cheat7_code = "084+20B+C4A+884+22B+2A2+004+27B+3BA"
+cheat7_code = "084-20B-C4A+884-22B-2A2+004-27B-3BA"
 cheat7_enable = false 
 
 cheat8_desc = "Start On Asterite Cave"
-cheat8_code = "094+20B+C4A+884+22B+2A2+004+27B+3BA"
+cheat8_code = "094-20B-C4A+884-22B-2A2+004-27B-3BA"
 cheat8_enable = false 
 
 cheat9_desc = "Start On The Eye"
-cheat9_code = "0A4+20B+C4A+884+22B+2A2+004+27B+3BA"
+cheat9_code = "0A4-20B-C4A+884-22B-2A2+004-27B-3BA"
 cheat9_enable = false 
 
 cheat10_desc = "Start On Deep Ridge"
-cheat10_code = "0B4+20B+C4A+884+22B+2A2+004+27B+3BA"
+cheat10_code = "0B4-20B-C4A+884-22B-2A2+004-27B-3BA"
 cheat10_enable = false 
 
 cheat11_desc = "Start On Sea of Birds"
-cheat11_code = "0C4+20B+C4A+884+22B+2A2+004+27B+3BA"
+cheat11_code = "0C4-20B-C4A+884-22B-2A2+004-27B-3BA"
 cheat11_enable = false 
 
 cheat12_desc = "Start On Convergence"
-cheat12_code = "0D4+20B+C4A+884+22B+2A2+004+27B+3BA"
+cheat12_code = "0D4-20B-C4A+884-22B-2A2+004-27B-3BA"
 cheat12_enable = false 
 
 cheat13_desc = "Start On DDD Swimming #3"
-cheat13_code = "0E4+20B+C4A+884+22B+2A2+004+27B+3BA"
+cheat13_code = "0E4-20B-C4A+884-22B-2A2+004-27B-3BA"
 cheat13_enable = false 
 
 cheat14_desc = "Start On Vortex Future"
-cheat14_code = "0F4+20B+C4A+884+22B+2A2+004+27B+3BA"
+cheat14_code = "0F4-20B-C4A+884-22B-2A2+004-27B-3BA"
 cheat14_enable = false 
 
 cheat15_desc = "Start On Globe Holder"
-cheat15_code = "104+20B+C4A+884+22B+2A2+004+27B+3BA"
+cheat15_code = "104-20B-C4A+884-22B-2A2+004-27B-3BA"
 cheat15_enable = false 
 
 cheat16_desc = "Start On Convergence #2"
-cheat16_code = "114+20B+C4A+884+22B+2A2+004+27B+3BA"
+cheat16_code = "114-20B-C4A+884-22B-2A2+004-27B-3BA"
 cheat16_enable = false 
 
 cheat17_desc = "Start On DDD Swimming #4"
-cheat17_code = "124+20B+C4A+884+22B+2A2+004+27B+3BA"
+cheat17_code = "124-20B-C4A+884-22B-2A2+004-27B-3BA"
 cheat17_enable = false 
 
 cheat18_desc = "Start On New Machine"
-cheat18_code = "134+20B+C4A+884+22B+2A2+004+27B+3BA"
+cheat18_code = "134-20B-C4A+884-22B-2A2+004-27B-3BA"
 cheat18_enable = false 
 
 cheat19_desc = "Start On Vortex Queen"
-cheat19_code = "144+20B+C4A+884+22B+2A2+004+27B+3BA"
+cheat19_code = "144-20B-C4A+884-22B-2A2+004-27B-3BA"
 cheat19_enable = false 
 
 cheat20_desc = "Start On Semi-Ending Part 1"
-cheat20_code = "154+20B+C4A+884+22B+2A2+004+27B+3BA"
+cheat20_code = "154-20B-C4A+884-22B-2A2+004-27B-3BA"
 cheat20_enable = false 
 
 cheat21_desc = "Start On Semi-Ending Part 2"
-cheat21_code = "164+20B+C4A+884+22B+2A2+004+27B+3BA"
+cheat21_code = "164-20B-C4A+884-22B-2A2+004-27B-3BA"
 cheat21_enable = false 
 
 cheat22_desc = "Start On Atlantis"
-cheat22_code = "174+20B+C4A+884+22B+2A2+004+27B+3BA"
+cheat22_code = "174-20B-C4A+884-22B-2A2+004-27B-3BA"
 cheat22_enable = false 
 
 cheat23_desc = "Infinite Air"
-cheat23_code = "366+8C6+5DD+3E6+8E6+D56"
+cheat23_code = "366-8C6-5DD+3E6-8E6-D56"
 cheat23_enable = false 
 
 cheat24_desc = "Jumping Out Of The Water Sets Your Energy To Half"
-cheat24_code = "109+CF6+6E6"
+cheat24_code = "109-CF6-6E6"
 cheat24_enable = false 
 
 cheat25_desc = "Infinite Energy"
-cheat25_code = "21D+3C7+6E2"
+cheat25_code = "21D-3C7-6E2"
 cheat25_enable = false 
 
 cheat26_desc = "Most Fish Don't Give You Energy"
-cheat26_code = "006+9FB+C4A"
+cheat26_code = "006-9FB-C4A"
 cheat26_enable = false 
 

--- a/cht/Sega - Game Gear/Factory Panic (Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Factory Panic (Europe) (Game Genie).cht
@@ -1,38 +1,38 @@
 cheats = 9 
 
 cheat0_desc = "Infinite Timer"
-cheat0_code = "00C+12F+3BE"
+cheat0_code = "00C-12F-3BE"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 2 Lives"
-cheat1_code = "029+72F+E66"
+cheat1_code = "029-72F-E66"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 5 Lives"
-cheat2_code = "059+72F+E66"
+cheat2_code = "059-72F-E66"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 8 Lives"
-cheat3_code = "089+72F+E66"
+cheat3_code = "089-72F-E66"
 cheat3_enable = false 
 
 cheat4_desc = "Infinite Lives"
-cheat4_code = "000+6AC+E65"
+cheat4_code = "000-6AC-E65"
 cheat4_enable = false 
 
 cheat5_desc = "Start With 1 Continue"
-cheat5_code = "029+77F+F72"
+cheat5_code = "029-77F-F72"
 cheat5_enable = false 
 
 cheat6_desc = "Start With 3 Continues"
-cheat6_code = "049+77F+F72"
+cheat6_code = "049-77F-F72"
 cheat6_enable = false 
 
 cheat7_desc = "Start With 8 Continues"
-cheat7_code = "099+77F+F72"
+cheat7_code = "099-77F-F72"
 cheat7_enable = false 
 
 cheat8_desc = "Infinite Continues"
-cheat8_code = "006+C1F+E65"
+cheat8_code = "006-C1F-E65"
 cheat8_enable = false 
 

--- a/cht/Sega - Game Gear/Fantasy Zone (World) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Fantasy Zone (World) (Game Genie).cht
@@ -1,42 +1,42 @@
 cheats = 10 
 
 cheat0_desc = "Start With 2 Lives"
-cheat0_code = "010+A3F+E62"
+cheat0_code = "010-A3F-E62"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 5 Lives"
-cheat1_code = "040+A3F+E62"
+cheat1_code = "040-A3F-E62"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 8 Lives"
-cheat2_code = "070+A3F+E62"
+cheat2_code = "070-A3F-E62"
 cheat2_enable = false 
 
 cheat3_desc = "Infinite Lives"
-cheat3_code = "3A1+8EF+2A2"
+cheat3_code = "3A1-8EF-2A2"
 cheat3_enable = false 
 
 cheat4_desc = "Start On Level 2"
-cheat4_code = "3E0+E5F+2A2+010+E6F+D5E+000+C7F+E69"
+cheat4_code = "3E0-E5F-2A2+010-E6F-D5E+000-C7F-E69"
 cheat4_enable = false 
 
 cheat5_desc = "Start On Level 3"
-cheat5_code = "3E0+E5F+2A2+020+E6F+D5E+000+C7F+E69"
+cheat5_code = "3E0-E5F-2A2+020-E6F-D5E+000-C7F-E69"
 cheat5_enable = false 
 
 cheat6_desc = "Start On Level 4"
-cheat6_code = "3E0+E5F+2A2+030+E6F+D5E+000+C7F+E69"
+cheat6_code = "3E0-E5F-2A2+030-E6F-D5E+000-C7F-E69"
 cheat6_enable = false 
 
 cheat7_desc = "Start On Level 5"
-cheat7_code = "3E0+E5F+2A2+040+E6F+D5E+000+C7F+E69"
+cheat7_code = "3E0-E5F-2A2+040-E6F-D5E+000-C7F-E69"
 cheat7_enable = false 
 
 cheat8_desc = "Start On Level 6"
-cheat8_code = "3E0+E5F+2A2+050+E6F+D5E+000+C7F+E69"
+cheat8_code = "3E0-E5F-2A2+050-E6F-D5E+000-C7F-E69"
 cheat8_enable = false 
 
 cheat9_desc = "Start On Level 7"
-cheat9_code = "3E0+E5F+2A2+060+E6F+D5E+000+C7F+E69"
+cheat9_code = "3E0-E5F-2A2+060-E6F-D5E+000-C7F-E69"
 cheat9_enable = false 
 

--- a/cht/Sega - Game Gear/Fatal Fury Special (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Fatal Fury Special (USA, Europe) (Game Genie).cht
@@ -1,78 +1,78 @@
 cheats = 19 
 
 cheat0_desc = "Faster Timer"
-cheat0_code = "03C+38B+E6E"
+cheat0_code = "03C-38B-E6E"
 cheat0_enable = false 
 
 cheat1_desc = "Infinite Time"
-cheat1_code = "00C+38B+E6E"
+cheat1_code = "00C-38B-E6E"
 cheat1_enable = false 
 
 cheat2_desc = "Start Rounds With 10 Seconds"
-cheat2_code = "21C+75E+91D+10C+71E+195+04C+73C+3B8"
+cheat2_code = "21C-75E-91D+10C-71E-195+04C-73C-3B8"
 cheat2_enable = false 
 
 cheat3_desc = "Start Rounds With 20 Seconds"
-cheat3_code = "21C+75E+91D+20C+71E+195+04C+73C+3B8"
+cheat3_code = "21C-75E-91D+20C-71E-195+04C-73C-3B8"
 cheat3_enable = false 
 
 cheat4_desc = "Start Rounds With 30 Seconds"
-cheat4_code = "21C+75E+91D+30C+71E+195+04C+73C+3B8"
+cheat4_code = "21C-75E-91D+30C-71E-195+04C-73C-3B8"
 cheat4_enable = false 
 
 cheat5_desc = "Start Rounds With 40 Seconds"
-cheat5_code = "21C+75E+91D+40C+71E+195+04C+73C+3B8"
+cheat5_code = "21C-75E-91D+40C-71E-195+04C-73C-3B8"
 cheat5_enable = false 
 
 cheat6_desc = "Start Rounds With 50 Seconds"
-cheat6_code = "21C+75E+91D+50C+71E+195+04C+73C+3B8"
+cheat6_code = "21C-75E-91D+50C-71E-195+04C-73C-3B8"
 cheat6_enable = false 
 
 cheat7_desc = "Both Players Start With 1/4 Energy"
-cheat7_code = "12C+24E+E6B"
+cheat7_code = "12C-24E-E6B"
 cheat7_enable = false 
 
 cheat8_desc = "Both Players Start With 1/2 Energy"
-cheat8_code = "20C+24E+E6B"
+cheat8_code = "20C-24E-E6B"
 cheat8_enable = false 
 
 cheat9_desc = "Both Players Start With 3/4 Energy"
-cheat9_code = "2DC+24E+E6B"
+cheat9_code = "2DC-24E-E6B"
 cheat9_enable = false 
 
 cheat10_desc = "Only Take Damage From Some Projectile Special Moves"
-cheat10_code = "118+109+E61"
+cheat10_code = "118-109-E61"
 cheat10_enable = false 
 
 cheat11_desc = "Terry's Throw Does Very Little Damage"
-cheat11_code = "003+814+D5A"
+cheat11_code = "003-814-D5A"
 cheat11_enable = false 
 
 cheat12_desc = "Terry's Throw Kills"
-cheat12_code = "773+814+D5A"
+cheat12_code = "773-814-D5A"
 cheat12_enable = false 
 
 cheat13_desc = "Terry's Standing Punch Doesn't Do Damage"
-cheat13_code = "005+59D+F7A"
+cheat13_code = "005-59D-F7A"
 cheat13_enable = false 
 
 cheat14_desc = "Terry's Standing Punch Kills"
-cheat14_code = "775+59D+F7A"
+cheat14_code = "775-59D-F7A"
 cheat14_enable = false 
 
 cheat15_desc = "Terry's Standing Kick Doesn't Do Damage"
-cheat15_code = "005+61D+C4A"
+cheat15_code = "005-61D-C4A"
 cheat15_enable = false 
 
 cheat16_desc = "Terry's Standing Kick Kills"
-cheat16_code = "775+61D+C4A"
+cheat16_code = "775-61D-C4A"
 cheat16_enable = false 
 
 cheat17_desc = "Terry's Crouching Kick Doesn't Do Damage"
-cheat17_code = "005+71D+F72"
+cheat17_code = "005-71D-F72"
 cheat17_enable = false 
 
 cheat18_desc = "Terry's Crouching Kick Kills"
-cheat18_code = "775+71D+F72"
+cheat18_code = "775-71D-F72"
 cheat18_enable = false 
 

--- a/cht/Sega - Game Gear/G-LOC - Air Battle (World) (Game Genie).cht
+++ b/cht/Sega - Game Gear/G-LOC - Air Battle (World) (Game Genie).cht
@@ -1,22 +1,22 @@
 cheats = 5 
 
 cheat0_desc = "Infinite Missiles"
-cheat0_code = "002+E5E+E6E"
+cheat0_code = "002-E5E-E6E"
 cheat0_enable = false 
 
 cheat1_desc = "Each Enemy Target Counts As 5"
-cheat1_code = "050+16E+EFE"
+cheat1_code = "050-16E-EFE"
 cheat1_enable = false 
 
 cheat2_desc = "Each Enemy Target Counts As 8"
-cheat2_code = "080+16E+EFE"
+cheat2_code = "080-16E-EFE"
 cheat2_enable = false 
 
 cheat3_desc = "Each Enemy Target Counts As 10"
-cheat3_code = "0A0+16E+EFE"
+cheat3_code = "0A0-16E-EFE"
 cheat3_enable = false 
 
 cheat4_desc = "Turn On Code To Complete A Level"
-cheat4_code = "C3F+80A+A21"
+cheat4_code = "C3F-80A-A21"
 cheat4_enable = false 
 

--- a/cht/Sega - Game Gear/GP Rider (World) (Game Genie).cht
+++ b/cht/Sega - Game Gear/GP Rider (World) (Game Genie).cht
@@ -1,14 +1,14 @@
 cheats = 3 
 
 cheat0_desc = "0 To Max Speed Instantly"
-cheat0_code = "215+2CC+4C2+022+5EC+E69"
+cheat0_code = "215-2CC-4C2+022-5EC-E69"
 cheat0_enable = false 
 
 cheat1_desc = "Infinite Time"
-cheat1_code = "00B+C1C+3BE"
+cheat1_code = "00B-C1C-3BE"
 cheat1_enable = false 
 
 cheat2_desc = "Always Rank First In Qualifying Race"
-cheat2_code = "AF6+2CE+08F"
+cheat2_code = "AF6-2CE-08F"
 cheat2_enable = false 
 

--- a/cht/Sega - Game Gear/George Foreman's KO Boxing (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/George Foreman's KO Boxing (USA, Europe) (Game Genie).cht
@@ -1,34 +1,34 @@
 cheats = 8 
 
 cheat0_desc = "Infinite Superpunches"
-cheat0_code = "21C+04C+2A2"
+cheat0_code = "21C-04C-2A2"
 cheat0_enable = false 
 
 cheat1_desc = "Both Boxers Start With 3/4 Energy"
-cheat1_code = "602+CEE+E68"
+cheat1_code = "602-CEE-E68"
 cheat1_enable = false 
 
 cheat2_desc = "Both Boxers Start With 1/2 Energy"
-cheat2_code = "402+CEE+E68"
+cheat2_code = "402-CEE-E68"
 cheat2_enable = false 
 
 cheat3_desc = "Both Boxers Start With 1/4 Energy"
-cheat3_code = "202+CEE+E68"
+cheat3_code = "202-CEE-E68"
 cheat3_enable = false 
 
 cheat4_desc = "Infinite Ring Timer"
-cheat4_code = "000+BED+19E"
+cheat4_code = "000-BED-19E"
 cheat4_enable = false 
 
 cheat5_desc = "2-Minute Rounds"
-cheat5_code = "02F+59E+E66"
+cheat5_code = "02F-59E-E66"
 cheat5_enable = false 
 
 cheat6_desc = "4-Minute Rounds"
-cheat6_code = "04F+59E+E66"
+cheat6_code = "04F-59E-E66"
 cheat6_enable = false 
 
 cheat7_desc = "6-Minute Rounds"
-cheat7_code = "06F+59E+E66"
+cheat7_code = "06F-59E-E66"
 cheat7_enable = false 
 

--- a/cht/Sega - Game Gear/Incredible Crash Dummies, The (World) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Incredible Crash Dummies, The (World) (Game Genie).cht
@@ -1,7 +1,7 @@
 cheats = 19 
 
 cheat0_desc = "Start With 1 Life"
-cheat0_code = "01C+40F+F7E"
+cheat0_code = "01C-40F-F7E"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 1 Lives"
@@ -13,7 +13,7 @@ cheat2_code = "03C-40F-F7E"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 5 Lives"
-cheat3_code = "05C+40F+F7E"
+cheat3_code = "05C-40F-F7E"
 cheat3_enable = false 
 
 cheat4_desc = "Start With 7 Lives"
@@ -21,7 +21,7 @@ cheat4_code = "07C-40F-F7E"
 cheat4_enable = false 
 
 cheat5_desc = "Start With 9 Lives"
-cheat5_code = "09C+40F+F7E"
+cheat5_code = "09C-40F-F7E"
 cheat5_enable = false 
 
 cheat6_desc = "Infinite Lives"
@@ -73,6 +73,6 @@ cheat17_code = "3EC-29F-082+04C-2AF-E62+00C-2BF-E69"
 cheat17_enable = false 
 
 cheat18_desc = "Fire Has No Effect On Crash Dummies"
-cheat18_code = "00B+E1A+E69"
+cheat18_code = "00B-E1A-E69"
 cheat18_enable = false 
 

--- a/cht/Sega - Game Gear/Indiana Jones and the Last Crusade (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Indiana Jones and the Last Crusade (USA, Europe) (Game Genie).cht
@@ -1,26 +1,26 @@
 cheats = 6 
 
 cheat0_desc = "Start With 5 Lives"
-cheat0_code = "041+42F+F72"
+cheat0_code = "041-42F-F72"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 9 Lives"
-cheat1_code = "081+42F+F72"
+cheat1_code = "081-42F-F72"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 11 Lives"
-cheat2_code = "0A1+42F+F72"
+cheat2_code = "0A1-42F-F72"
 cheat2_enable = false 
 
 cheat3_desc = "Infinite Lives"
-cheat3_code = "002+9FF+3BE"
+cheat3_code = "002-9FF-3BE"
 cheat3_enable = false 
 
 cheat4_desc = "Infinite Whips"
-cheat4_code = "002+839+19E"
+cheat4_code = "002-839-19E"
 cheat4_enable = false 
 
 cheat5_desc = "Infinite Time"
-cheat5_code = "00A+3EE+3BE"
+cheat5_code = "00A-3EE-3BE"
 cheat5_enable = false 
 

--- a/cht/Sega - Game Gear/Journey from Darkness - Strider Returns (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Journey from Darkness - Strider Returns (USA, Europe) (Game Genie).cht
@@ -1,74 +1,74 @@
 cheats = 18 
 
 cheat0_desc = "Loads Of Bad Guys"
-cheat0_code = "001+49C+19E+213+BEC+2A2"
+cheat0_code = "001-49C-19E+213-BEC-2A2"
 cheat0_enable = false 
 
 cheat1_desc = "Only 1 Animal Enemy In Game"
-cheat1_code = "C91+4AC+2A2+000+71C+195"
+cheat1_code = "C91-4AC-2A2+000-71C-195"
 cheat1_enable = false 
 
 cheat2_desc = "Infinite Time"
-cheat2_code = "00E+4AA+19E"
+cheat2_code = "00E-4AA-19E"
 cheat2_enable = false 
 
 cheat3_desc = "Infinite Lives"
-cheat3_code = "3AB+A2F+2A2"
+cheat3_code = "3AB-A2F-2A2"
 cheat3_enable = false 
 
 cheat4_desc = "Start With 2 Lives"
-cheat4_code = "015+F8F+F7E"
+cheat4_code = "015-F8F-F7E"
 cheat4_enable = false 
 
 cheat5_desc = "Start With 4 Lives"
-cheat5_code = "035+F8F+F7E"
+cheat5_code = "035-F8F-F7E"
 cheat5_enable = false 
 
 cheat6_desc = "Start With 8 Lives"
-cheat6_code = "075+F8F+F7E"
+cheat6_code = "075-F8F-F7E"
 cheat6_enable = false 
 
 cheat7_desc = "Start With 10 Lives"
-cheat7_code = "095+F8F+F7E"
+cheat7_code = "095-F8F-F7E"
 cheat7_enable = false 
 
 cheat8_desc = "Infinite Energy"
-cheat8_code = "3A6+73A+2A2"
+cheat8_code = "3A6-73A-2A2"
 cheat8_enable = false 
 
 cheat9_desc = "Start With Energy At 1"
-cheat9_code = "007+3BF+6EB"
+cheat9_code = "007-3BF-6EB"
 cheat9_enable = false 
 
 cheat10_desc = "Start With Energy At 3"
-cheat10_code = "107+3BF+6EB"
+cheat10_code = "107-3BF-6EB"
 cheat10_enable = false 
 
 cheat11_desc = "Start With Energy At 6"
-cheat11_code = "207+3BF+6EB"
+cheat11_code = "207-3BF-6EB"
 cheat11_enable = false 
 
 cheat12_desc = "Start With Energy At 19"
-cheat12_code = "907+3BF+6EB"
+cheat12_code = "907-3BF-6EB"
 cheat12_enable = false 
 
 cheat13_desc = "Invincibility"
-cheat13_code = "AF6+72A+A24"
+cheat13_code = "AF6-72A-A24"
 cheat13_enable = false 
 
 cheat14_desc = "Start On Level 2"
-cheat14_code = "015+F3F+E6A"
+cheat14_code = "015-F3F-E6A"
 cheat14_enable = false 
 
 cheat15_desc = "Start On Level 3"
-cheat15_code = "025+F3F+E6A"
+cheat15_code = "025-F3F-E6A"
 cheat15_enable = false 
 
 cheat16_desc = "Start On Level 4"
-cheat16_code = "035+F3F+E6A"
+cheat16_code = "035-F3F-E6A"
 cheat16_enable = false 
 
 cheat17_desc = "Start On Level 5"
-cheat17_code = "045+F3F+E6A"
+cheat17_code = "045-F3F-E6A"
 cheat17_enable = false 
 

--- a/cht/Sega - Game Gear/Jungle Book, The (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Jungle Book, The (USA, Europe) (Game Genie).cht
@@ -1,22 +1,22 @@
 cheats = 5 
 
 cheat0_desc = "Very Little Flash Time After Getting Hit"
-cheat0_code = "19C+26E+7FB"
+cheat0_code = "19C-26E-7FB"
 cheat0_enable = false 
 
 cheat1_desc = "More Flash Time After Getting Hit"
-cheat1_code = "99C+26E+7FB"
+cheat1_code = "99C-26E-7FB"
 cheat1_enable = false 
 
 cheat2_desc = "Infinite Energy"
-cheat2_code = "3AC+20E+2A2"
+cheat2_code = "3AC-20E-2A2"
 cheat2_enable = false 
 
 cheat3_desc = "1 Hit & You Die"
-cheat3_code = "AFC+1FE+19E"
+cheat3_code = "AFC-1FE-19E"
 cheat3_enable = false 
 
 cheat4_desc = "Invincible"
-cheat4_code = "C3B+7DE+E61"
+cheat4_code = "C3B-7DE-E61"
 cheat4_enable = false 
 

--- a/cht/Sega - Game Gear/Klax (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Klax (USA, Europe) (Game Genie).cht
@@ -1,22 +1,22 @@
 cheats = 5 
 
 cheat0_desc = "Unlimited Dropped Tiles"
-cheat0_code = "003+28C+19A"
+cheat0_code = "003-28C-19A"
 cheat0_enable = false 
 
 cheat1_desc = "Start On Wave 25, 30 Or 35"
-cheat1_code = "197+3CD+E6E"
+cheat1_code = "197-3CD-E6E"
 cheat1_enable = false 
 
 cheat2_desc = "Start On Wave 50, 55 Or 60"
-cheat2_code = "327+3CD+E6E"
+cheat2_code = "327-3CD-E6E"
 cheat2_enable = false 
 
 cheat3_desc = "Start On Wave 99 (Don't Choose 104 Or 109)"
-cheat3_code = "637+3CD+E6E"
+cheat3_code = "637-3CD-E6E"
 cheat3_enable = false 
 
 cheat4_desc = "Randomizes Goal For Completing Each Wave"
-cheat4_code = "008+72D+193"
+cheat4_code = "008-72D-193"
 cheat4_enable = false 
 

--- a/cht/Sega - Game Gear/Krusty's Fun House (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Krusty's Fun House (USA, Europe) (Game Genie).cht
@@ -1,38 +1,38 @@
 cheats = 9 
 
 cheat0_desc = "Start With 2 Lives"
-cheat0_code = "028+52D+E66"
+cheat0_code = "028-52D-E66"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 5 Lives"
-cheat1_code = "058+52D+E66"
+cheat1_code = "058-52D-E66"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 9 Lives"
-cheat2_code = "098+52D+E66"
+cheat2_code = "098-52D-E66"
 cheat2_enable = false 
 
 cheat3_desc = "Infinite Lives"
-cheat3_code = "21F+215+19D"
+cheat3_code = "21F-215-19D"
 cheat3_enable = false 
 
 cheat4_desc = "Infinite Energy"
-cheat4_code = "008+5E5+C42"
+cheat4_code = "008-5E5-C42"
 cheat4_enable = false 
 
 cheat5_desc = "Start With 7 Pies"
-cheat5_code = "078+87D+C4E"
+cheat5_code = "078-87D-C4E"
 cheat5_enable = false 
 
 cheat6_desc = "Start With 11 Pies"
-cheat6_code = "0B8+87D+C4E"
+cheat6_code = "0B8-87D-C4E"
 cheat6_enable = false 
 
 cheat7_desc = "Start With 15 Pies"
-cheat7_code = "0F8+87D+C4E"
+cheat7_code = "0F8-87D-C4E"
 cheat7_enable = false 
 
 cheat8_desc = "Infinite Pies"
-cheat8_code = "21C+134+19D"
+cheat8_code = "21C-134-19D"
 cheat8_enable = false 
 

--- a/cht/Sega - Game Gear/Land of Illusion Starring Mickey Mouse (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Land of Illusion Starring Mickey Mouse (USA, Europe) (Game Genie).cht
@@ -1,34 +1,34 @@
 cheats = 8 
 
 cheat0_desc = "Start With 3 Lives"
-cheat0_code = "02F+31D+E66"
+cheat0_code = "02F-31D-E66"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 5 Lives"
-cheat1_code = "04F+31D+E66"
+cheat1_code = "04F-31D-E66"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 7 Lives"
-cheat2_code = "06F+31D+E66"
+cheat2_code = "06F-31D-E66"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 9 Lives"
-cheat3_code = "08F+31D+E66"
+cheat3_code = "08F-31D-E66"
 cheat3_enable = false 
 
 cheat4_desc = "Start With 11 Lives"
-cheat4_code = "0AF+31D+E66"
+cheat4_code = "0AF-31D-E66"
 cheat4_enable = false 
 
 cheat5_desc = "Infinite Lives"
-cheat5_code = "009+FAD+E6E"
+cheat5_code = "009-FAD-E6E"
 cheat5_enable = false 
 
 cheat6_desc = "Infinite Time"
-cheat6_code = "002+4CE+E6E"
+cheat6_code = "002-4CE-E6E"
 cheat6_enable = false 
 
 cheat7_desc = "Infinite Energy"
-cheat7_code = "00C+337+E69"
+cheat7_code = "00C-337-E69"
 cheat7_enable = false 
 

--- a/cht/Sega - Game Gear/Last Action Hero (USA) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Last Action Hero (USA) (Game Genie).cht
@@ -1,46 +1,46 @@
 cheats = 11 
 
 cheat0_desc = "Start On Scene 3"
-cheat0_code = "031+20F+E6E"
+cheat0_code = "031-20F-E6E"
 cheat0_enable = false 
 
 cheat1_desc = "Start On Scene 5"
-cheat1_code = "051+20F+E6E"
+cheat1_code = "051-20F-E6E"
 cheat1_enable = false 
 
 cheat2_desc = "Start On Scene 7"
-cheat2_code = "071+20F+E6E"
+cheat2_code = "071-20F-E6E"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 1 Life"
-cheat3_code = "011+25F+E66"
+cheat3_code = "011-25F-E66"
 cheat3_enable = false 
 
 cheat4_desc = "Start With 5 Lives"
-cheat4_code = "051+25F+E66"
+cheat4_code = "051-25F-E66"
 cheat4_enable = false 
 
 cheat5_desc = "Start With 9 Lives"
-cheat5_code = "091+25F+E66"
+cheat5_code = "091-25F-E66"
 cheat5_enable = false 
 
 cheat6_desc = "Start With 1 Heart"
-cheat6_code = "011+2AF+F76"
+cheat6_code = "011-2AF-F76"
 cheat6_enable = false 
 
 cheat7_desc = "Start With 5 Heart"
-cheat7_code = "051+2AF+F76"
+cheat7_code = "051-2AF-F76"
 cheat7_enable = false 
 
 cheat8_desc = "Start With 9 Heart"
-cheat8_code = "091+2AF+F76"
+cheat8_code = "091-2AF-F76"
 cheat8_enable = false 
 
 cheat9_desc = "Collect 1 Token To Get Fire Extinguisher"
-cheat9_code = "AFE+9CF+19E"
+cheat9_code = "AFE-9CF-19E"
 cheat9_enable = false 
 
 cheat10_desc = "Infinite Timer"
-cheat10_code = "3A1+B1F+2A2"
+cheat10_code = "3A1-B1F-2A2"
 cheat10_enable = false 
 

--- a/cht/Sega - Game Gear/Lemmings (World) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Lemmings (World) (Game Genie).cht
@@ -1,14 +1,14 @@
 cheats = 3 
 
 cheat0_desc = "Infinite Use Of All Types Of Lemmings"
-cheat0_code = "00D+34D+19E"
+cheat0_code = "00D-34D-19E"
 cheat0_enable = false 
 
 cheat1_desc = "Infinite Time"
-cheat1_code = "009+FFF+3BE"
+cheat1_code = "009-FFF-3BE"
 cheat1_enable = false 
 
 cheat2_desc = "1 Lemming Equals 100"
-cheat2_code = "3E8+57C+082+3E8+59C+805+648+5AC+E64"
+cheat2_code = "3E8-57C-082+3E8-59C-805+648-5AC-E64"
 cheat2_enable = false 
 

--- a/cht/Sega - Game Gear/Lion King, The (World) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Lion King, The (World) (Game Genie).cht
@@ -1,26 +1,26 @@
 cheats = 6 
 
 cheat0_desc = "Start With 1 Life"
-cheat0_code = "017+B98+E66"
+cheat0_code = "017-B98-E66"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 5 Lives"
-cheat1_code = "057+B98+E66"
+cheat1_code = "057-B98-E66"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 9 Lives"
-cheat2_code = "097+B98+E66"
+cheat2_code = "097-B98-E66"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 1/2 Of A Circle of Life"
-cheat3_code = "027+BB8+C4A"
+cheat3_code = "027-BB8-C4A"
 cheat3_enable = false 
 
 cheat4_desc = "Start With 1 Circle of Life"
-cheat4_code = "047+BB8+C4A"
+cheat4_code = "047-BB8-C4A"
 cheat4_enable = false 
 
 cheat5_desc = "Start With No Circles of Life"
-cheat5_code = "007+BB8+C4A"
+cheat5_code = "007-BB8-C4A"
 cheat5_enable = false 
 

--- a/cht/Sega - Game Gear/Lucky Dime Caper Starring Donald Duck, The (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Lucky Dime Caper Starring Donald Duck, The (USA, Europe) (Game Genie).cht
@@ -1,38 +1,38 @@
 cheats = 9 
 
 cheat0_desc = "Start With 4 Lives"
-cheat0_code = "047+B1F+E66"
+cheat0_code = "047-B1F-E66"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 6 Lives"
-cheat1_code = "067+B1F+E66"
+cheat1_code = "067-B1F-E66"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 8 Lives"
-cheat2_code = "087+B1F+E66"
+cheat2_code = "087-B1F-E66"
 cheat2_enable = false 
 
 cheat3_desc = "Infinite Lives"
-cheat3_code = "000+93D+E69"
+cheat3_code = "000-93D-E69"
 cheat3_enable = false 
 
 cheat4_desc = "*Start With 5 Energy Units"
-cheat4_code = "047+E0E+E6E"
+cheat4_code = "047-E0E-E6E"
 cheat4_enable = false 
 
 cheat5_desc = "*Start With 7 Energy Units"
-cheat5_code = "067+E0E+E6E"
+cheat5_code = "067-E0E-E6E"
 cheat5_enable = false 
 
 cheat6_desc = "*Start With 9 Energy Units"
-cheat6_code = "087+E0E+E6E"
+cheat6_code = "087-E0E-E6E"
 cheat6_enable = false 
 
 cheat7_desc = "Infinite Energy"
-cheat7_code = "21C+04E+91D"
+cheat7_code = "21C-04E-91D"
 cheat7_enable = false 
 
 cheat8_desc = "After Donald Loses 1 Energy Unit He Is Invincible"
-cheat8_code = "219+B3E+91D"
+cheat8_code = "219-B3E-91D"
 cheat8_enable = false 
 

--- a/cht/Sega - Game Gear/Madden NFL 95 (USA) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Madden NFL 95 (USA) (Game Genie).cht
@@ -1,66 +1,66 @@
 cheats = 16 
 
 cheat0_desc = "Infinite Time Outs"
-cheat0_code = "3A2+6DB+2A2"
+cheat0_code = "3A2-6DB-2A2"
 cheat0_enable = false 
 
 cheat1_desc = "No Time Outs"
-cheat1_code = "00C+DAF+E66"
+cheat1_code = "00C-DAF-E66"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 5 Time Outs"
-cheat2_code = "05C+DAF+E66"
+cheat2_code = "05C-DAF-E66"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 10 Time Outs"
-cheat3_code = "10C+DAF+E66"
+cheat3_code = "10C-DAF-E66"
 cheat3_enable = false 
 
 cheat4_desc = "Only Have Enough Time For 1 Play After Kick Off In Each Quarter"
-cheat4_code = "00C+F4F+F7E"
+cheat4_code = "00C-F4F-F7E"
 cheat4_enable = false 
 
 cheat5_desc = "2-Minute Quarters"
-cheat5_code = "02C+F4F+F7E"
+cheat5_code = "02C-F4F-F7E"
 cheat5_enable = false 
 
 cheat6_desc = "60-Minute Quarters"
-cheat6_code = "3CC+F4F+F7E"
+cheat6_code = "3CC-F4F-F7E"
 cheat6_enable = false 
 
 cheat7_desc = "Infinite Play Timer"
-cheat7_code = "3A8+D7E+2A2"
+cheat7_code = "3A8-D7E-2A2"
 cheat7_enable = false 
 
 cheat8_desc = "Start With 10 Seconds On Play Clock After Most Plays"
-cheat8_code = "0A0+79B+4CA"
+cheat8_code = "0A0-79B-4CA"
 cheat8_enable = false 
 
 cheat9_desc = "Touchdowns Worth 0 Points"
-cheat9_code = "006+B09+F72"
+cheat9_code = "006-B09-F72"
 cheat9_enable = false 
 
 cheat10_desc = "Touchdowns Worth 1 Point"
-cheat10_code = "016+B09+F72"
+cheat10_code = "016-B09-F72"
 cheat10_enable = false 
 
 cheat11_desc = "Touchdowns Worth 3 Points"
-cheat11_code = "036+B09+F72"
+cheat11_code = "036-B09-F72"
 cheat11_enable = false 
 
 cheat12_desc = "Touchdowns Worth 5 Points"
-cheat12_code = "056+B09+F72"
+cheat12_code = "056-B09-F72"
 cheat12_enable = false 
 
 cheat13_desc = "Touchdowns Worth 9 Points"
-cheat13_code = "096+B09+F72"
+cheat13_code = "096-B09-F72"
 cheat13_enable = false 
 
 cheat14_desc = "Extra Points Worth 0 Points"
-cheat14_code = "000+6C9+3BA"
+cheat14_code = "000-6C9-3BA"
 cheat14_enable = false 
 
 cheat15_desc = "Always 4th And Goal After A Kickoff"
-cheat15_code = "049+35E+E6E+509+30E+C42"
+cheat15_code = "049-35E-E6E+509-30E-C42"
 cheat15_enable = false 
 

--- a/cht/Sega - Game Gear/Majors Pro Baseball, The (USA) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Majors Pro Baseball, The (USA) (Game Genie).cht
@@ -1,18 +1,18 @@
 cheats = 4 
 
 cheat0_desc = "No Strikeouts"
-cheat0_code = "003+91C+19A"
+cheat0_code = "003-91C-19A"
 cheat0_enable = false 
 
 cheat1_desc = "4 Strikes And You're Out"
-cheat1_code = "043+93C+E66"
+cheat1_code = "043-93C-E66"
 cheat1_enable = false 
 
 cheat2_desc = "6 Strikes And You're Out"
-cheat2_code = "063+93C+E66"
+cheat2_code = "063-93C-E66"
 cheat2_enable = false 
 
 cheat3_desc = "1 Ball And You Walk"
-cheat3_code = "003+56C+19A"
+cheat3_code = "003-56C-19A"
 cheat3_enable = false 
 

--- a/cht/Sega - Game Gear/Mick _ Mack as the Global Gladiators (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Mick _ Mack as the Global Gladiators (USA, Europe) (Game Genie).cht
@@ -1,46 +1,46 @@
 cheats = 11 
 
 cheat0_desc = "Infinite Timer"
-cheat0_code = "219+82B+6E2"
+cheat0_code = "219-82B-6E2"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 10 Minutes"
-cheat1_code = "0A2+88B+F76"
+cheat1_code = "0A2-88B-F76"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 6 Minutes"
-cheat2_code = "062+88B+F76"
+cheat2_code = "062-88B-F76"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 4 Minutes"
-cheat3_code = "042+88B+F76"
+cheat3_code = "042-88B-F76"
 cheat3_enable = false 
 
 cheat4_desc = "Start With 2 Minutes"
-cheat4_code = "022+88B+F76"
+cheat4_code = "022-88B-F76"
 cheat4_enable = false 
 
 cheat5_desc = "Each M Logo Counts As 5"
-cheat5_code = "05F+ACD+E6E"
+cheat5_code = "05F-ACD-E6E"
 cheat5_enable = false 
 
 cheat6_desc = "Each M Logo Counts As 3"
-cheat6_code = "03F+ACD+E6E"
+cheat6_code = "03F-ACD-E6E"
 cheat6_enable = false 
 
 cheat7_desc = "Start With 1 Life"
-cheat7_code = "012+51E+F7E"
+cheat7_code = "012-51E-F7E"
 cheat7_enable = false 
 
 cheat8_desc = "Start With 5 Lives"
-cheat8_code = "052+51E+F7E"
+cheat8_code = "052-51E-F7E"
 cheat8_enable = false 
 
 cheat9_desc = "Start 10 Lives"
-cheat9_code = "0A2+51E+F7E"
+cheat9_code = "0A2-51E-F7E"
 cheat9_enable = false 
 
 cheat10_desc = "Infinite Lives"
-cheat10_code = "002+08E+A29"
+cheat10_code = "002-08E-A29"
 cheat10_enable = false 
 

--- a/cht/Sega - Game Gear/Mighty Morphin Power Rangers (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Mighty Morphin Power Rangers (USA, Europe) (Game Genie).cht
@@ -1,66 +1,66 @@
 cheats = 16 
 
 cheat0_desc = "Power Rangers Start With 12 Energy"
-cheat0_code = "7AE+12B+2A9"
+cheat0_code = "7AE-12B-2A9"
 cheat0_enable = false 
 
 cheat1_desc = "Power Rangers Start With 34 Energy"
-cheat1_code = "AFE+12B+2A9"
+cheat1_code = "AFE-12B-2A9"
 cheat1_enable = false 
 
 cheat2_desc = "Power Rangers Start With 14 Energy"
-cheat2_code = "45E+12B+2A9"
+cheat2_code = "45E-12B-2A9"
 cheat2_enable = false 
 
 cheat3_desc = "Only Throws Do Damage"
-cheat3_code = "212+D5E+91D"
+cheat3_code = "212-D5E-91D"
 cheat3_enable = false 
 
 cheat4_desc = "Grey Putty Is Harder To Kill"
-cheat4_code = "25D+D95+F7E"
+cheat4_code = "25D-D95-F7E"
 cheat4_enable = false 
 
 cheat5_desc = "Goldar Is Easier To Kill"
-cheat5_code = "10E+155+2A9"
+cheat5_code = "10E-155-2A9"
 cheat5_enable = false 
 
 cheat6_desc = "Green Putty Is Harder To Kill"
-cheat6_code = "20E+245+C42"
+cheat6_code = "20E-245-C42"
 cheat6_enable = false 
 
 cheat7_desc = "Don't Get Any Energy From Defeating An Opponent"
-cheat7_code = "3A3+AEA+2A2"
+cheat7_code = "3A3-AEA-2A2"
 cheat7_enable = false 
 
 cheat8_desc = "Get Max Energy From Defeating An Opponent"
-cheat8_code = "3E3+A2A+082+003+A4A+C49+FF3+A3A+916"
+cheat8_code = "3E3-A2A-082+003-A4A-C49+FF3-A3A-916"
 cheat8_enable = false 
 
 cheat9_desc = "After Defeating Some Enemies You Fight Other Power Rangers"
-cheat9_code = "3EE+9EB+193+02E+9FB+6E6"
+cheat9_code = "3EE-9EB-193+02E-9FB-6E6"
 cheat9_enable = false 
 
 cheat10_desc = "Always Fight On Park Stage"
-cheat10_code = "3E9+E6A+082+009+E7A+E6A+009+E8A+C49"
+cheat10_code = "3E9-E6A-082+009-E7A-E6A+009-E8A-C49"
 cheat10_enable = false 
 
 cheat11_desc = "Always Fight On Mountain Stage"
-cheat11_code = "3E9+E6A+082+019+E7A+E6A+009+E8A+C49"
+cheat11_code = "3E9-E6A-082+019-E7A-E6A+009-E8A-C49"
 cheat11_enable = false 
 
 cheat12_desc = "Always Fight On Alley Stage"
-cheat12_code = "3E9+E6A+082+029+E7A+E6A+009+E8A+C49"
+cheat12_code = "3E9-E6A-082+029-E7A-E6A+009-E8A-C49"
 cheat12_enable = false 
 
 cheat13_desc = "Always Fight On City Stage"
-cheat13_code = "3E9+E6A+082+039+E7A+E6A+009+E8A+C49"
+cheat13_code = "3E9-E6A-082+039-E7A-E6A+009-E8A-C49"
 cheat13_enable = false 
 
 cheat14_desc = "Always Fight On Construction Stage"
-cheat14_code = "3E9+E6A+082+039+E7A+E6A+009+E8A+C49"
+cheat14_code = "3E9-E6A-082+039-E7A-E6A+009-E8A-C49"
 cheat14_enable = false 
 
 cheat15_desc = "Always Fight On Refinery Stage"
-cheat15_code = "3E9+E6A+082+059+E7A+E6A+009+E8A+C49"
+cheat15_code = "3E9-E6A-082+059-E7A-E6A+009-E8A-C49"
 cheat15_enable = false 
 

--- a/cht/Sega - Game Gear/Mortal Kombat (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Mortal Kombat (USA, Europe) (Game Genie).cht
@@ -1,130 +1,130 @@
 cheats = 32 
 
 cheat0_desc = "Each Round Is 69 Seconds"
-cheat0_code = "063+7B4+C4E"
+cheat0_code = "063-7B4-C4E"
 cheat0_enable = false 
 
 cheat1_desc = "Each Round Is 29 Seconds"
-cheat1_code = "023+7B4+C4E"
+cheat1_code = "023-7B4-C4E"
 cheat1_enable = false 
 
 cheat2_desc = "Infinite Time"
-cheat2_code = "00B+40C+3BE"
+cheat2_code = "00B-40C-3BE"
 cheat2_enable = false 
 
 cheat3_desc = "Infinite Credits"
-cheat3_code = "004+2D6+19E"
+cheat3_code = "004-2D6-19E"
 cheat3_enable = false 
 
 cheat4_desc = "Blood"
-cheat4_code = "DEB+9F6+5D3"
+cheat4_code = "DEB-9F6-5D3"
 cheat4_enable = false 
 
 cheat5_desc = "Player 1 Is Invincible"
-cheat5_code = "003+48B+F79"
+cheat5_code = "003-48B-F79"
 cheat5_enable = false 
 
 cheat6_desc = "Player 1 Starts With 1/2 Health"
-cheat6_code = "240+BFD+C4B"
+cheat6_code = "240-BFD-C4B"
 cheat6_enable = false 
 
 cheat7_desc = "Player 2 Usually Starts With 1/2 Health"
-cheat7_code = "240+C5D+C4B"
+cheat7_code = "240-C5D-C4B"
 cheat7_enable = false 
 
 cheat8_desc = "Punches Do More Damage"
-cheat8_code = "20B+06F+F7A"
+cheat8_code = "20B-06F-F7A"
 cheat8_enable = false 
 
 cheat9_desc = "Most Kicks Do More Damage"
-cheat9_code = "2CB+26F+C42"
+cheat9_code = "2CB-26F-C42"
 cheat9_enable = false 
 
 cheat10_desc = "Foot Sweeps Do More Damage"
-cheat10_code = "30B+86F+C42"
+cheat10_code = "30B-86F-C42"
 cheat10_enable = false 
 
 cheat11_desc = "Flying Punches Do More Damage"
-cheat11_code = "30B+2EF+D5A"
+cheat11_code = "30B-2EF-D5A"
 cheat11_enable = false 
 
 cheat12_desc = "Uppercuts Do More Damage"
-cheat12_code = "33B+56F+A2E"
+cheat12_code = "33B-56F-A2E"
 cheat12_enable = false 
 
 cheat13_desc = "Throws Do More Damage"
-cheat13_code = "2AF+237+D5A"
+cheat13_code = "2AF-237-D5A"
 cheat13_enable = false 
 
 cheat14_desc = "Sonya Blade's Leg-Grab Does More Damage"
-cheat14_code = "2BB+76F+F7A"
+cheat14_code = "2BB-76F-F7A"
 cheat14_enable = false 
 
 cheat15_desc = "Scorpion's Harpoon Does More Damage"
-cheat15_code = "2BB+66F+F7A"
+cheat15_code = "2BB-66F-F7A"
 cheat15_enable = false 
 
 cheat16_desc = "Rayden's Flying Thunderbolt Does More Damage"
-cheat16_code = "2BB+6EF+F7A"
+cheat16_code = "2BB-6EF-F7A"
 cheat16_enable = false 
 
 cheat17_desc = "Johhny Cage's Shadow Kick Does More Damage"
-cheat17_code = "2BB+4EF+D56"
+cheat17_code = "2BB-4EF-D56"
 cheat17_enable = false 
 
 cheat18_desc = "Some Other Special Moves Do More Damage"
-cheat18_code = "37B+36F+D52"
+cheat18_code = "37B-36F-D52"
 cheat18_enable = false 
 
 cheat19_desc = "Start On Match 2"
-cheat19_code = "01B+C9A+E6A"
+cheat19_code = "01B-C9A-E6A"
 cheat19_enable = false 
 
 cheat20_desc = "Start On Match 3"
-cheat20_code = "02B+C9A+E6A"
+cheat20_code = "02B-C9A-E6A"
 cheat20_enable = false 
 
 cheat21_desc = "Start On Match 4"
-cheat21_code = "03B+C9A+E6A"
+cheat21_code = "03B-C9A-E6A"
 cheat21_enable = false 
 
 cheat22_desc = "Start On Match 5"
-cheat22_code = "04B+C9A+E6A"
+cheat22_code = "04B-C9A-E6A"
 cheat22_enable = false 
 
 cheat23_desc = "Start On Mirror Match"
-cheat23_code = "05B+C9A+E6A"
+cheat23_code = "05B-C9A-E6A"
 cheat23_enable = false 
 
 cheat24_desc = "Start On Endurance Match 1"
-cheat24_code = "06B+C9A+E6A"
+cheat24_code = "06B-C9A-E6A"
 cheat24_enable = false 
 
 cheat25_desc = "Start On Endurance Match 2"
-cheat25_code = "07B+C9A+E6A"
+cheat25_code = "07B-C9A-E6A"
 cheat25_enable = false 
 
 cheat26_desc = "Start On Endurance Match 3"
-cheat26_code = "08B+C9A+E6A"
+cheat26_code = "08B-C9A-E6A"
 cheat26_enable = false 
 
 cheat27_desc = "Start On Match Against Goro"
-cheat27_code = "09B+C9A+E6A"
+cheat27_code = "09B-C9A-E6A"
 cheat27_enable = false 
 
 cheat28_desc = "Start On Match Against Shang Tsung"
-cheat28_code = "0AB+C9A+E6A"
+cheat28_code = "0AB-C9A-E6A"
 cheat28_enable = false 
 
 cheat29_desc = "Start With 1 Credit"
-cheat29_code = "02B+E1A+F76"
+cheat29_code = "02B-E1A-F76"
 cheat29_enable = false 
 
 cheat30_desc = "Start With 5 Credits"
-cheat30_code = "06B+E1A+F76"
+cheat30_code = "06B-E1A-F76"
 cheat30_enable = false 
 
 cheat31_desc = "Start With 10 Credits"
-cheat31_code = "0BB+E1A+F76"
+cheat31_code = "0BB-E1A-F76"
 cheat31_enable = false 
 

--- a/cht/Sega - Game Gear/Mortal Kombat II (World) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Mortal Kombat II (World) (Game Genie).cht
@@ -1,75 +1,75 @@
 cheats = 35 
 
 cheat0_desc = "Infinite Energy"
-cheat0_code = "00B+B19+F79"
+cheat0_code = "00B-B19-F79"
 cheat0_enable = false 
 
 cheat1_desc = "View Ending"
-cheat1_code = "001+30A+082+3E1+31A+C42+001+32A+F7A"
+cheat1_code = "001-30A-082+3E1-31A-C42+001-32A-F7A"
 cheat1_enable = false 
 
 cheat2_desc = "Infinite Credits"
-cheat2_code = "3A4+026+2A2"
+cheat2_code = "3A4-026-2A2"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 0 Credits"
-cheat3_code = "001+2CA+F76"
+cheat3_code = "001-2CA-F76"
 cheat3_enable = false 
 
 cheat4_desc = "Start With 10 Credits"
-cheat4_code = "0B1+2CA+F76"
+cheat4_code = "0B1-2CA-F76"
 cheat4_enable = false 
 
 cheat5_desc = "Start With 15 Credits"
-cheat5_code = "101+2CA+F76"
+cheat5_code = "101-2CA-F76"
 cheat5_enable = false 
 
 cheat6_desc = "Start With 49 Seconds"
-cheat6_code = "04B+7C6+C4E"
+cheat6_code = "04B-7C6-C4E"
 cheat6_enable = false 
 
 cheat7_desc = "Start With 79 Seconds"
-cheat7_code = "07B+7C6+C4E"
+cheat7_code = "07B-7C6-C4E"
 cheat7_enable = false 
 
 cheat8_desc = "Start With 9 Seconds"
-cheat8_code = "00B+7C6+C4E"
+cheat8_code = "00B-7C6-C4E"
 cheat8_enable = false 
 
 cheat9_desc = "Infinite Time"
-cheat9_code = "005+3F5+3BE"
+cheat9_code = "005-3F5-3BE"
 cheat9_enable = false 
 
 cheat10_desc = "Start With 3/4 Energy - Player 1"
-cheat10_code = "32B+A3E+F77"
+cheat10_code = "32B-A3E-F77"
 cheat10_enable = false 
 
 cheat11_desc = "Start With 1/2 Energy - Player 1"
-cheat11_code = "22B+A3E+F77"
+cheat11_code = "22B-A3E-F77"
 cheat11_enable = false 
 
 cheat12_desc = "Start With 1/4 Energy - Player 1"
-cheat12_code = "12B+A3E+F77"
+cheat12_code = "12B-A3E-F77"
 cheat12_enable = false 
 
 cheat13_desc = "Start With Very Little Energy - Player 1"
-cheat13_code = "02B+A3E+F77"
+cheat13_code = "02B-A3E-F77"
 cheat13_enable = false 
 
 cheat14_desc = "Start With 3/4 Energy - Player 2"
-cheat14_code = "32B+A6E+F77"
+cheat14_code = "32B-A6E-F77"
 cheat14_enable = false 
 
 cheat15_desc = "Start With 1/2 Energy - Player 2"
-cheat15_code = "22B+A6E+F77"
+cheat15_code = "22B-A6E-F77"
 cheat15_enable = false 
 
 cheat16_desc = "Start With 1/4 Energy - Player 2"
-cheat16_code = "12B+A6E+F77"
+cheat16_code = "12B-A6E-F77"
 cheat16_enable = false 
 
 cheat17_desc = "Start With Very Little Energy - Player 2"
-cheat17_code = "02B+A6E+F77"
+cheat17_code = "02B-A6E-F77"
 cheat17_enable = false 
 
 cheat18_desc = "Flying Kick Does No Damage"
@@ -113,15 +113,15 @@ cheat27_code = "996-AEF-C42"
 cheat27_enable = false 
 
 cheat28_desc = "CPU Dead At Start"
-cheat28_code = "00B+A9E+F77"
+cheat28_code = "00B-A9E-F77"
 cheat28_enable = false 
 
 cheat29_desc = "Both Invisible"
-cheat29_code = "990+567+470"
+cheat29_code = "990-567-470"
 cheat29_enable = false 
 
 cheat30_desc = "Wacky Mode"
-cheat30_code = "B45+45C+321"
+cheat30_code = "B45-45C-321"
 cheat30_enable = false 
 
 cheat31_desc = "Character Select"

--- a/cht/Sega - Game Gear/Ms. Pac-Man (USA) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Ms. Pac-Man (USA) (Game Genie).cht
@@ -1,22 +1,22 @@
 cheats = 5 
 
 cheat0_desc = "After A Power Pill Runs Out, The Ghosts Go Mad"
-cheat0_code = "C92+D1A+C45"
+cheat0_code = "C92-D1A-C45"
 cheat0_enable = false 
 
 cheat1_desc = "Infinite Lives"
-cheat1_code = "00C+F29+19E"
+cheat1_code = "00C-F29-19E"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 1 Life"
-cheat2_code = "014+DF9+E66"
+cheat2_code = "014-DF9-E66"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 9 Lives"
-cheat3_code = "094+DF9+E66"
+cheat3_code = "094-DF9-E66"
 cheat3_enable = false 
 
 cheat4_desc = "Ghosts Are Faster Than Normal After 1st Level"
-cheat4_code = "3E1+93A+6EA+099+94A+E62"
+cheat4_code = "3E1-93A-6EA+099-94A-E62"
 cheat4_enable = false 
 

--- a/cht/Sega - Game Gear/NBA Jam (World) (Game Genie).cht
+++ b/cht/Sega - Game Gear/NBA Jam (World) (Game Genie).cht
@@ -89,66 +89,66 @@ cheat21_code = "81D-2AA-5D2"
 cheat21_enable = false 
 
 cheat22_desc = "Turbo Doesn't Recharge Until End Of Quarter"
-cheat22_code = "C9D+5DA+91D"
+cheat22_code = "C9D-5DA-91D"
 cheat22_enable = false 
 
 cheat23_desc = "Infinite Shot Clock Time"
-cheat23_code = "001+4CD+19E"
+cheat23_code = "001-4CD-19E"
 cheat23_enable = false 
 
 cheat24_desc = "3-Second Shot Clock For Computer"
-cheat24_code = "031+25A+80A"
+cheat24_code = "031-25A-80A"
 cheat24_enable = false 
 
 cheat25_desc = "5-Second Shot Clock For Computer"
-cheat25_code = "051+25A+80A"
+cheat25_code = "051-25A-80A"
 cheat25_enable = false 
 
 cheat26_desc = "15-Second Shot Clock For Computer"
-cheat26_code = "0F1+25A+80A"
+cheat26_code = "0F1-25A-80A"
 cheat26_enable = false 
 
 cheat27_desc = "Gravity Mode 1"
-cheat27_code = "007+D09+E62"
+cheat27_code = "007-D09-E62"
 cheat27_enable = false 
 
 cheat28_desc = "Gravity Mode 2"
-cheat28_code = "017+D09+E62"
+cheat28_code = "017-D09-E62"
 cheat28_enable = false 
 
 cheat29_desc = "Infinite Time"
-cheat29_code = "3A5+D9E+2A2"
+cheat29_code = "3A5-D9E-2A2"
 cheat29_enable = false 
 
 cheat30_desc = "1-Minute Quarters"
-cheat30_code = "018+C7F+E66+01A+C6F+E66"
+cheat30_code = "018-C7F-E66+01A-C6F-E66"
 cheat30_enable = false 
 
 cheat31_desc = "1-Shot Game"
-cheat31_code = "008+C7F+E66+00A+C6F+E66"
+cheat31_code = "008-C7F-E66+00A-C6F-E66"
 cheat31_enable = false 
 
 cheat32_desc = "9-Minute Quarters"
-cheat32_code = "098+C7F+E66+09A+C6F+E66"
+cheat32_code = "098-C7F-E66+09A-C6F-E66"
 cheat32_enable = false 
 
 cheat33_desc = "1-Minute Quarters"
-cheat33_code = "018+C7F+E66+01A+C6F+E66"
+cheat33_code = "018-C7F-E66+01A-C6F-E66"
 cheat33_enable = false 
 
 cheat34_desc = "Computer Can't Score"
-cheat34_code = "3AA+5F9+2A2"
+cheat34_code = "3AA-5F9-2A2"
 cheat34_enable = false 
 
 cheat35_desc = "Games Last 3 Quarters"
-cheat35_code = "028+8CF+E6E"
+cheat35_code = "028-8CF-E6E"
 cheat35_enable = false 
 
 cheat36_desc = "Games Last 2 Quarters"
-cheat36_code = "038+8CF+E6E"
+cheat36_code = "038-8CF-E6E"
 cheat36_enable = false 
 
 cheat37_desc = "Shot Clock Always Displayed"
-cheat37_code = "200+CFD+C46"
+cheat37_code = "200-CFD-C46"
 cheat37_enable = false 
 

--- a/cht/Sega - Game Gear/Ninja Gaiden (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Ninja Gaiden (USA, Europe) (Game Genie).cht
@@ -1,43 +1,43 @@
 cheats = 16 
 
 cheat0_desc = "Infinite Energy"
-cheat0_code = "C90+CBE+2A2"
+cheat0_code = "C90-CBE-2A2"
 cheat0_enable = false 
 
 cheat1_desc = "Infinite Lives"
-cheat1_code = "009+439+F79"
+cheat1_code = "009-439-F79"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 1 Life"
-cheat2_code = "011+EDF+E66"
+cheat2_code = "011-EDF-E66"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 5 Lives"
-cheat3_code = "051+EDF+E66"
+cheat3_code = "051-EDF-E66"
 cheat3_enable = false 
 
 cheat4_desc = "Start With 8 Lives"
-cheat4_code = "081+EDF+E66"
+cheat4_code = "081-EDF-E66"
 cheat4_enable = false 
 
 cheat5_desc = "Start On Act 2 (Smuggling)"
-cheat5_code = "021+6CF+E6E"
+cheat5_code = "021-6CF-E6E"
 cheat5_enable = false 
 
 cheat6_desc = "Start On Act 3 (Skyscraper)"
-cheat6_code = "031+6CF+E6E"
+cheat6_code = "031-6CF-E6E"
 cheat6_enable = false 
 
 cheat7_desc = "Start On Act 4 - Part 1 (Counterattack)"
-cheat7_code = "041+6CF+E6E"
+cheat7_code = "041-6CF-E6E"
 cheat7_enable = false 
 
 cheat8_desc = "Start On Act 4 - Part 2 (Counterattack)"
-cheat8_code = "051+6CF+E6E"
+cheat8_code = "051-6CF-E6E"
 cheat8_enable = false 
 
 cheat9_desc = "See End Credits"
-cheat9_code = "061+6CF+E6E"
+cheat9_code = "061-6CF-E6E"
 cheat9_enable = false 
 
 cheat10_desc = "Infinite Time"

--- a/cht/Sega - Game Gear/Out Run Europa (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Out Run Europa (USA, Europe) (Game Genie).cht
@@ -1,22 +1,22 @@
 cheats = 5 
 
 cheat0_desc = "Infinite Time"
-cheat0_code = "007+6BD+E6E"
+cheat0_code = "007-6BD-E6E"
 cheat0_enable = false 
 
 cheat1_desc = "Infinite Turbos"
-cheat1_code = "00C+8EF+19E"
+cheat1_code = "00C-8EF-19E"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 8 Shields"
-cheat2_code = "054+27F+C42"
+cheat2_code = "054-27F-C42"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 5 Shields"
-cheat3_code = "024+27F+C42"
+cheat3_code = "024-27F-C42"
 cheat3_enable = false 
 
 cheat4_desc = "Infinite Ammo"
-cheat4_code = "007+E4E+19E"
+cheat4_code = "007-E4E-19E"
 cheat4_enable = false 
 

--- a/cht/Sega - Game Gear/PGA Tour Golf (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/PGA Tour Golf (USA, Europe) (Game Genie).cht
@@ -1,22 +1,22 @@
 cheats = 5 
 
 cheat0_desc = "Strong Wind"
-cheat0_code = "3E7+71C+191+407+72C+105+187+73C+6EA"
+cheat0_code = "3E7-71C-191+407-72C-105+187-73C-6EA"
 cheat0_enable = false 
 
 cheat1_desc = "Massive Wind"
-cheat1_code = "3E7+71C+191+1F7+71C+195+187+73C+6EA"
+cheat1_code = "3E7-71C-191+1F7-71C-195+187-73C-6EA"
 cheat1_enable = false 
 
 cheat2_desc = "Hit Longer Shots"
-cheat2_code = "017+A2C+4CA"
+cheat2_code = "017-A2C-4CA"
 cheat2_enable = false 
 
 cheat3_desc = "Hit Even Longer Shots"
-cheat3_code = "FF7+A2C+4CA"
+cheat3_code = "FF7-A2C-4CA"
 cheat3_enable = false 
 
 cheat4_desc = "Shots Don't Count (Always Hole In One)"
-cheat4_code = "006+50D+19A"
+cheat4_code = "006-50D-19A"
 cheat4_enable = false 
 

--- a/cht/Sega - Game Gear/Pac-Man (USA, Japan) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Pac-Man (USA, Japan) (Game Genie).cht
@@ -1,22 +1,22 @@
 cheats = 5 
 
 cheat0_desc = "Start With 3 Lives"
-cheat0_code = "027+9C6+E66"
+cheat0_code = "027-9C6-E66"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 5 Lives"
-cheat1_code = "057+9C6+E66"
+cheat1_code = "057-9C6-E66"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 7 Lives"
-cheat2_code = "077+9C6+E66"
+cheat2_code = "077-9C6-E66"
 cheat2_enable = false 
 
 cheat3_desc = "Infinite Lives"
-cheat3_code = "00A+896+19E"
+cheat3_code = "00A-896-19E"
 cheat3_enable = false 
 
 cheat4_desc = "Collect Power Pill And Ghosts Stay Blue Until Eaten"
-cheat4_code = "008+396+4C6"
+cheat4_code = "008-396-4C6"
 cheat4_enable = false 
 

--- a/cht/Sega - Game Gear/Paperboy (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Paperboy (USA, Europe) (Game Genie).cht
@@ -1,34 +1,34 @@
 cheats = 8 
 
 cheat0_desc = "Start With 2 Lives"
-cheat0_code = "012+3CF+E66"
+cheat0_code = "012-3CF-E66"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 7 Lives"
-cheat1_code = "062+3CF+E66"
+cheat1_code = "062-3CF-E66"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 10 Lives"
-cheat2_code = "092+3CF+E66"
+cheat2_code = "092-3CF-E66"
 cheat2_enable = false 
 
 cheat3_desc = "Infinite Lives"
-cheat3_code = "00C+57F+19E"
+cheat3_code = "00C-57F-19E"
 cheat3_enable = false 
 
 cheat4_desc = "Start With 5 Papers"
-cheat4_code = "052+41F+C42"
+cheat4_code = "052-41F-C42"
 cheat4_enable = false 
 
 cheat5_desc = "Start With 15 Papers"
-cheat5_code = "0F2+41F+C42"
+cheat5_code = "0F2-41F-C42"
 cheat5_enable = false 
 
 cheat6_desc = "Start With 20 Papers"
-cheat6_code = "142+41F+C42"
+cheat6_code = "142-41F-C42"
 cheat6_enable = false 
 
 cheat7_desc = "Infinite Papers"
-cheat7_code = "00C+6C9+19E"
+cheat7_code = "00C-6C9-19E"
 cheat7_enable = false 
 

--- a/cht/Sega - Game Gear/Paperboy 2 (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Paperboy 2 (USA, Europe) (Game Genie).cht
@@ -1,6 +1,6 @@
 cheats = 1 
 
 cheat0_desc = "Makes It Much Harder To Pick Up Speed"
-cheat0_code = "003+6FF+6E6"
+cheat0_code = "003-6FF-6E6"
 cheat0_enable = false 
 

--- a/cht/Sega - Game Gear/Pengo (World) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Pengo (World) (Game Genie).cht
@@ -1,38 +1,38 @@
 cheats = 9 
 
 cheat0_desc = "Stop Timer And Keep Sno-Bee Eggs Flashing"
-cheat0_code = "00C+F9D+E6E"
+cheat0_code = "00C-F9D-E6E"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 2 Lives"
-cheat1_code = "020+85F+F7E"
+cheat1_code = "020-85F-F7E"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 7 Lives"
-cheat2_code = "070+85F+F7E"
+cheat2_code = "070-85F-F7E"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 9 Lives"
-cheat3_code = "090+85F+F7E"
+cheat3_code = "090-85F-F7E"
 cheat3_enable = false 
 
 cheat4_desc = "Infinite Lives"
-cheat4_code = "007+3EF+3BE"
+cheat4_code = "007-3EF-3BE"
 cheat4_enable = false 
 
 cheat5_desc = "Start On Act 10"
-cheat5_code = "0A0+8AF+E6E"
+cheat5_code = "0A0-8AF-E6E"
 cheat5_enable = false 
 
 cheat6_desc = "Start On Act 20"
-cheat6_code = "130+8AF+E6E"
+cheat6_code = "130-8AF-E6E"
 cheat6_enable = false 
 
 cheat7_desc = "Start On Act 40"
-cheat7_code = "280+8AF+E6E"
+cheat7_code = "280-8AF-E6E"
 cheat7_enable = false 
 
 cheat8_desc = "Start On Act 64"
-cheat8_code = "400+8AF+E6E"
+cheat8_code = "400-8AF-E6E"
 cheat8_enable = false 
 

--- a/cht/Sega - Game Gear/Pinball Dreams (USA) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Pinball Dreams (USA) (Game Genie).cht
@@ -1,26 +1,26 @@
 cheats = 6 
 
 cheat0_desc = "Can't Tilt"
-cheat0_code = "C9B+64C+6EE"
+cheat0_code = "C9B-64C-6EE"
 cheat0_enable = false 
 
 cheat1_desc = "Infinite Balls"
-cheat1_code = "01C+E2F+B3D"
+cheat1_code = "01C-E2F-B3D"
 cheat1_enable = false 
 
 cheat2_desc = "1 Ball"
-cheat2_code = "01C+E6F+E66"
+cheat2_code = "01C-E6F-E66"
 cheat2_enable = false 
 
 cheat3_desc = "5 Balls"
-cheat3_code = "05C+E6F+E66"
+cheat3_code = "05C-E6F-E66"
 cheat3_enable = false 
 
 cheat4_desc = "15 Balls"
-cheat4_code = "0FC+E6F+E66"
+cheat4_code = "0FC-E6F-E66"
 cheat4_enable = false 
 
 cheat5_desc = "Always Start With 5X Bonus"
-cheat5_code = "3E0+E5E+2A2+040+E6E+4CE+000+E7E+B3D"
+cheat5_code = "3E0-E5E-2A2+040-E6E-4CE+000-E7E-B3D"
 cheat5_enable = false 
 

--- a/cht/Sega - Game Gear/Poker Face Paul's Poker (USA) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Poker Face Paul's Poker (USA) (Game Genie).cht
@@ -1,15 +1,15 @@
 cheats = 4 
 
 cheat0_desc = "Bet As Much As You Want In 5 Card Stud (Ignore Counter)"
-cheat0_code = "FF2+EBE+2A2"
+cheat0_code = "FF2-EBE-2A2"
 cheat0_enable = false 
 
 cheat1_desc = "Start With $9,900"
-cheat1_code = "995+FDF+6EA"
+cheat1_code = "995-FDF-6EA"
 cheat1_enable = false 
 
 cheat2_desc = "Max Bet Is About $250"
-cheat2_code = "FF2+EBE+2A2"
+cheat2_code = "FF2-EBE-2A2"
 cheat2_enable = false 
 
 cheat3_desc = "Don't Lose Money In 5 Card Stud"

--- a/cht/Sega - Game Gear/Predator 2 (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Predator 2 (USA, Europe) (Game Genie).cht
@@ -1,11 +1,11 @@
 cheats = 9 
 
 cheat0_desc = "Infinite Lives"
-cheat0_code = "00F+D2E+3BE"
+cheat0_code = "00F-D2E-3BE"
 cheat0_enable = false 
 
 cheat1_desc = "Infinite Ammo (All Weapons)"
-cheat1_code = "001+8EE+19E"
+cheat1_code = "001-8EE-19E"
 cheat1_enable = false 
 
 cheat2_desc = "Start On Level 2"

--- a/cht/Sega - Game Gear/Prince of Persia (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Prince of Persia (USA, Europe) (Game Genie).cht
@@ -1,27 +1,27 @@
 cheats = 19 
 
 cheat0_desc = "Infinite Time"
-cheat0_code = "004+03B+19E"
+cheat0_code = "004-03B-19E"
 cheat0_enable = false 
 
 cheat1_desc = "45-Minute Game"
-cheat1_code = "2D2+08F+19A"
+cheat1_code = "2D2-08F-19A"
 cheat1_enable = false 
 
 cheat2_desc = "20-Minute Game"
-cheat2_code = "142+08F+19A"
+cheat2_code = "142-08F-19A"
 cheat2_enable = false 
 
 cheat3_desc = "10-Minute Game"
-cheat3_code = "0A2+08F+19A"
+cheat3_code = "0A2-08F-19A"
 cheat3_enable = false 
 
 cheat4_desc = "*Start With More Health Units"
-cheat4_code = "081+38C+E66"
+cheat4_code = "081-38C-E66"
 cheat4_enable = false 
 
 cheat5_desc = "Don't Lose Health Units When You Drop Off Some Ledges"
-cheat5_code = "001+E9E+3BE"
+cheat5_code = "001-E9E-3BE"
 cheat5_enable = false 
 
 cheat6_desc = "Start On Level 2"

--- a/cht/Sega - Game Gear/Quest for the Shaven Yak Starring Ren Hoek _ Stimpy (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Quest for the Shaven Yak Starring Ren Hoek _ Stimpy (USA, Europe) (Game Genie).cht
@@ -1,54 +1,54 @@
 cheats = 13 
 
 cheat0_desc = "Start With 1 Life"
-cheat0_code = "013+4EE+E66"
+cheat0_code = "013-4EE-E66"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 5 Lives"
-cheat1_code = "053+4EE+E66"
+cheat1_code = "053-4EE-E66"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 9 Lives"
-cheat2_code = "093+4EE+E66"
+cheat2_code = "093-4EE-E66"
 cheat2_enable = false 
 
 cheat3_desc = "Start On A Strange Level"
-cheat3_code = "001+D8F+5D4"
+cheat3_code = "001-D8F-5D4"
 cheat3_enable = false 
 
 cheat4_desc = "Infinite Lives"
-cheat4_code = "001+B8E+3BE"
+cheat4_code = "001-B8E-3BE"
 cheat4_enable = false 
 
 cheat5_desc = "Infinite Energy"
-cheat5_code = "00E+ACB+3BE"
+cheat5_code = "00E-ACB-3BE"
 cheat5_enable = false 
 
 cheat6_desc = "Stimpy Starts With Less Energy After 1st Life"
-cheat6_code = "021+C0E+F72"
+cheat6_code = "021-C0E-F72"
 cheat6_enable = false 
 
 cheat7_desc = "Stimpy Starts With Half Energy After 1st Life"
-cheat7_code = "031+C0E+F72"
+cheat7_code = "031-C0E-F72"
 cheat7_enable = false 
 
 cheat8_desc = "Invincible After First Hit"
-cheat8_code = "00E+E7C+E6E"
+cheat8_code = "00E-E7C-E6E"
 cheat8_enable = false 
 
 cheat9_desc = "You Still Get Hurt When You Flash"
-cheat9_code = "01E+ECB+803"
+cheat9_code = "01E-ECB-803"
 cheat9_enable = false 
 
 cheat10_desc = "Flash Twice As Long After Getting Hit"
-cheat10_code = "99E+ECB+803"
+cheat10_code = "99E-ECB-803"
 cheat10_enable = false 
 
 cheat11_desc = "Flash Longer After Getting Hit"
-cheat11_code = "FFE+ECB+803"
+cheat11_code = "FFE-ECB-803"
 cheat11_enable = false 
 
 cheat12_desc = "Flash A Lot Longer After Getting Hit"
-cheat12_code = "00E+ECB+803"
+cheat12_code = "00E-ECB-803"
 cheat12_enable = false 
 

--- a/cht/Sega - Game Gear/R.B.I. Baseball '94 (Game Genie).cht
+++ b/cht/Sega - Game Gear/R.B.I. Baseball '94 (Game Genie).cht
@@ -1,50 +1,50 @@
 cheats = 12 
 
 cheat0_desc = "Almost No Strikes"
-cheat0_code = "00B+FAE+3BA"
+cheat0_code = "00B-FAE-3BA"
 cheat0_enable = false 
 
 cheat1_desc = "1 Strike Needed For An Out"
-cheat1_code = "01C+85E+E66"
+cheat1_code = "01C-85E-E66"
 cheat1_enable = false 
 
 cheat2_desc = "2 Strikes Needed For An Out"
-cheat2_code = "02C+85E+E66"
+cheat2_code = "02C-85E-E66"
 cheat2_enable = false 
 
 cheat3_desc = "5 Strikes Needed For An Out"
-cheat3_code = "05C+85E+E66"
+cheat3_code = "05C-85E-E66"
 cheat3_enable = false 
 
 cheat4_desc = "15 Strikes Needed For An Out"
-cheat4_code = "0EC+85E+E66"
+cheat4_code = "0EC-85E-E66"
 cheat4_enable = false 
 
 cheat5_desc = "Never Strike Outs"
-cheat5_code = "00C+ADE+3BA"
+cheat5_code = "00C-ADE-3BA"
 cheat5_enable = false 
 
 cheat6_desc = "Never Walk"
-cheat6_code = "00C+07E+D59"
+cheat6_code = "00C-07E-D59"
 cheat6_enable = false 
 
 cheat7_desc = "1 Ball Needed For Walk"
-cheat7_code = "01C+8DE+F7A"
+cheat7_code = "01C-8DE-F7A"
 cheat7_enable = false 
 
 cheat8_desc = "5 Balls Needed For Walk"
-cheat8_code = "05C+8DE+F7A"
+cheat8_code = "05C-8DE-F7A"
 cheat8_enable = false 
 
 cheat9_desc = "10 Balls Needed For Walk"
-cheat9_code = "0AC+8DE+F7A"
+cheat9_code = "0AC-8DE-F7A"
 cheat9_enable = false 
 
 cheat10_desc = "15 Balls Needed For Walk"
-cheat10_code = "0EC+8DE+F7A"
+cheat10_code = "0EC-8DE-F7A"
 cheat10_enable = false 
 
 cheat11_desc = "No Scoring (Switch Off When You're At Bat)"
-cheat11_code = "000+0C5+3BA"
+cheat11_code = "000-0C5-3BA"
 cheat11_enable = false 
 

--- a/cht/Sega - Game Gear/Revenge of Drancon (USA) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Revenge of Drancon (USA) (Game Genie).cht
@@ -1,46 +1,46 @@
 cheats = 11 
 
 cheat0_desc = "Start With 5 Lives"
-cheat0_code = "05D+DDF+E66"
+cheat0_code = "05D-DDF-E66"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 7 Lives"
-cheat1_code = "07D+DDF+E66"
+cheat1_code = "07D-DDF-E66"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 12 Lives"
-cheat2_code = "0CD+DDF+E66"
+cheat2_code = "0CD-DDF-E66"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 25 Lives"
-cheat3_code = "195+DDF+E66"
+cheat3_code = "195-DDF-E66"
 cheat3_enable = false 
 
 cheat4_desc = "Start With 50 Lives"
-cheat4_code = "325+DDF+E66"
+cheat4_code = "325-DDF-E66"
 cheat4_enable = false 
 
 cheat5_desc = "Start With 99 Lives"
-cheat5_code = "635+DDF+E66"
+cheat5_code = "635-DDF-E66"
 cheat5_enable = false 
 
 cheat6_desc = "Start With 5 Health/Vitality Units"
-cheat6_code = "055+649+D5A"
+cheat6_code = "055-649-D5A"
 cheat6_enable = false 
 
 cheat7_desc = "Start With 8 Health/Vitality Units"
-cheat7_code = "085+649+D5A"
+cheat7_code = "085-649-D5A"
 cheat7_enable = false 
 
 cheat8_desc = "*Start With 25 Health/Vitality Units"
-cheat8_code = "195+649+D5A"
+cheat8_code = "195-649-D5A"
 cheat8_enable = false 
 
 cheat9_desc = "*Start With 50 Health/Vitality Units"
-cheat9_code = "325+649+D5A"
+cheat9_code = "325-649-D5A"
 cheat9_enable = false 
 
 cheat10_desc = "*Start With 99 Health/Vitality Units"
-cheat10_code = "635+649+D5A"
+cheat10_code = "635-649-D5A"
 cheat10_enable = false 
 

--- a/cht/Sega - Game Gear/Road Rash (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Road Rash (USA, Europe) (Game Genie).cht
@@ -1,34 +1,34 @@
 cheats = 8 
 
 cheat0_desc = "Don't Lose Speed On Grass"
-cheat0_code = "00A+C6C+E62"
+cheat0_code = "00A-C6C-E62"
 cheat0_enable = false 
 
 cheat1_desc = "Always Travel At Max Speed"
-cheat1_code = "3EA+C3C+08A+FFA+C4C+E62"
+cheat1_code = "3EA-C3C-08A+FFA-C4C-E62"
 cheat1_enable = false 
 
 cheat2_desc = "Start With Very Little Bike Energy"
-cheat2_code = "058+49C+916"
+cheat2_code = "058-49C-916"
 cheat2_enable = false 
 
 cheat3_desc = "Start With Mega Bike Energy"
-cheat3_code = "FF8+49C+916"
+cheat3_code = "FF8-49C-916"
 cheat3_enable = false 
 
 cheat4_desc = "Infinite Bike Energy"
-cheat4_code = "213+054+91D"
+cheat4_code = "213-054-91D"
 cheat4_enable = false 
 
 cheat5_desc = "Biker Information Disappears"
-cheat5_code = "001+24A+A2C"
+cheat5_code = "001-24A-A2C"
 cheat5_enable = false 
 
 cheat6_desc = "Infinite Time"
-cheat6_code = "00D+B5E+E6E"
+cheat6_code = "00D-B5E-E6E"
 cheat6_enable = false 
 
 cheat7_desc = "Inflict More Damage When You Punch Other Bikers"
-cheat7_code = "3EE+9A5+4CA+00E+9B5+F7A"
+cheat7_code = "3EE-9A5-4CA+00E-9B5-F7A"
 cheat7_enable = false 
 

--- a/cht/Sega - Game Gear/RoboCop 3 (World) (Game Genie).cht
+++ b/cht/Sega - Game Gear/RoboCop 3 (World) (Game Genie).cht
@@ -1,42 +1,42 @@
 cheats = 10 
 
 cheat0_desc = "Start With 1 Life"
-cheat0_code = "31E+13F+2A6"
+cheat0_code = "31E-13F-2A6"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 5 Lives"
-cheat1_code = "35E+13F+2A6"
+cheat1_code = "35E-13F-2A6"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 9 Lives"
-cheat2_code = "39E+13F+2A6"
+cheat2_code = "39E-13F-2A6"
 cheat2_enable = false 
 
 cheat3_desc = "Infinite Lives"
-cheat3_code = "3AB+30D+2A2"
+cheat3_code = "3AB-30D-2A2"
 cheat3_enable = false 
 
 cheat4_desc = "Infinite Energy"
-cheat4_code = "3AA+BF6+2A2+3AC+156+2A2"
+cheat4_code = "3AA-BF6-2A2+3AC-156-2A2"
 cheat4_enable = false 
 
 cheat5_desc = "Power-Ups Do Nothing"
-cheat5_code = "3AD+346+2A2"
+cheat5_code = "3AD-346-2A2"
 cheat5_enable = false 
 
 cheat6_desc = "Infinite Timer"
-cheat6_code = "000+E05+E6E"
+cheat6_code = "000-E05-E6E"
 cheat6_enable = false 
 
 cheat7_desc = "100 Bullets On Pick-Up"
-cheat7_code = "019+86F+E6E"
+cheat7_code = "019-86F-E6E"
 cheat7_enable = false 
 
 cheat8_desc = "Start 1st Life With 900 Bullets And Get 200 On Each Pick-Up"
-cheat8_code = "099+86F+E6E"
+cheat8_code = "099-86F-E6E"
 cheat8_enable = false 
 
 cheat9_desc = "Infinite Ammo - All Guns"
-cheat9_code = "006+64D+A2C"
+cheat9_code = "006-64D-A2C"
 cheat9_enable = false 
 

--- a/cht/Sega - Game Gear/RoboCop versus The Terminator (Game Genie).cht
+++ b/cht/Sega - Game Gear/RoboCop versus The Terminator (Game Genie).cht
@@ -1,43 +1,43 @@
 cheats = 12 
 
 cheat0_desc = "Start On Level 3 - Streets of Detroit"
-cheat0_code = "039+09D+E6E"
+cheat0_code = "039-09D-E6E"
 cheat0_enable = false 
 
 cheat1_desc = "Start On Level 5 - Delta City Under Construction"
-cheat1_code = "059+09D+E6E"
+cheat1_code = "059-09D-E6E"
 cheat1_enable = false 
 
 cheat2_desc = "Start On A Secret Level"
-cheat2_code = "079+09D+E6E"
+cheat2_code = "079-09D-E6E"
 cheat2_enable = false 
 
 cheat3_desc = "Start With Very Little Energy"
-cheat3_code = "014+2FA+6EA"
+cheat3_code = "014-2FA-6EA"
 cheat3_enable = false 
 
 cheat4_desc = "Infinite Energy"
-cheat4_code = "00C+61B+A29"
+cheat4_code = "00C-61B-A29"
 cheat4_enable = false 
 
 cheat5_desc = "Don't Flash After Getting Hit"
-cheat5_code = "01C+56B+E62"
+cheat5_code = "01C-56B-E62"
 cheat5_enable = false 
 
 cheat6_desc = "Flash Longer After Getting Hit"
-cheat6_code = "59C+56B+E62"
+cheat6_code = "59C-56B-E62"
 cheat6_enable = false 
 
 cheat7_desc = "Invincible After Getting Hit Once"
-cheat7_code = "C9D+FAD+3BF"
+cheat7_code = "C9D-FAD-3BF"
 cheat7_enable = false 
 
 cheat8_desc = "Full Energy Pots Restore A Small Amount Of Energy"
-cheat8_code = "01A+5F8+912"
+cheat8_code = "01A-5F8-912"
 cheat8_enable = false 
 
 cheat9_desc = "Full Energy Pots Restore All Your Energy"
-cheat9_code = "19A+5F8+912"
+cheat9_code = "19A-5F8-912"
 cheat9_enable = false 
 
 cheat10_desc = "Mega-Lives"

--- a/cht/Sega - Game Gear/Samurai Shodown (USA) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Samurai Shodown (USA) (Game Genie).cht
@@ -1,46 +1,46 @@
 cheats = 11 
 
 cheat0_desc = "Infinite Time"
-cheat0_code = "00C+B3D+3BE"
+cheat0_code = "00C-B3D-3BE"
 cheat0_enable = false 
 
 cheat1_desc = "Start Round With 50 Seconds"
-cheat1_code = "3EC+62D+80E+32C+63D+193"
+cheat1_code = "3EC-62D-80E+32C-63D-193"
 cheat1_enable = false 
 
 cheat2_desc = "Start Round With 60 Seconds"
-cheat2_code = "3EC+62D+80E+3CC+63D+193"
+cheat2_code = "3EC-62D-80E+3CC-63D-193"
 cheat2_enable = false 
 
 cheat3_desc = "Start Round With 75 Seconds"
-cheat3_code = "3EC+62D+80E+4BC+63D+193"
+cheat3_code = "3EC-62D-80E+4BC-63D-193"
 cheat3_enable = false 
 
 cheat4_desc = "Both Players Start With 1/4 Energy"
-cheat4_code = "14F+4BF+E6B"
+cheat4_code = "14F-4BF-E6B"
 cheat4_enable = false 
 
 cheat5_desc = "Both Players Start With 1/2 Energy"
-cheat5_code = "22F+4BF+E6B"
+cheat5_code = "22F-4BF-E6B"
 cheat5_enable = false 
 
 cheat6_desc = "Both Players Start With 3/4 Energy"
-cheat6_code = "30F+4BF+E6B"
+cheat6_code = "30F-4BF-E6B"
 cheat6_enable = false 
 
 cheat7_desc = "Infinite Energy"
-cheat7_code = "01B+F4D+EB9"
+cheat7_code = "01B-F4D-EB9"
 cheat7_enable = false 
 
 cheat8_desc = "Get Pow From Every Hit"
-cheat8_code = "3EC+51D+191+01C+53D+08A"
+cheat8_code = "3EC-51D-191+01C-53D-08A"
 cheat8_enable = false 
 
 cheat9_desc = "Once You Have Pow You Keep It"
-cheat9_code = "007+CAD+3B2"
+cheat9_code = "007-CAD-3B2"
 cheat9_enable = false 
 
 cheat10_desc = "All Hits Do Massive Damage"
-cheat10_code = "20B+4BC+F77+06B+4AC+E68"
+cheat10_code = "20B-4BC-F77+06B-4AC-E68"
 cheat10_enable = false 
 

--- a/cht/Sega - Game Gear/Shinobi (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Shinobi (USA, Europe) (Game Genie).cht
@@ -1,26 +1,26 @@
 cheats = 6 
 
 cheat0_desc = "Infinite Energy"
-cheat0_code = "21F+055+2A2"
+cheat0_code = "21F-055-2A2"
 cheat0_enable = false 
 
 cheat1_desc = "Infinite Lives"
-cheat1_code = "006+06D+3BE"
+cheat1_code = "006-06D-3BE"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 6 Lives"
-cheat2_code = "06B+75C+F72"
+cheat2_code = "06B-75C-F72"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 8 Lives"
-cheat3_code = "08B+75C+F72"
+cheat3_code = "08B-75C-F72"
 cheat3_enable = false 
 
 cheat4_desc = "Start With 9 Lives"
-cheat4_code = "09B+75C+F72"
+cheat4_code = "09B-75C-F72"
 cheat4_enable = false 
 
 cheat5_desc = "On Highway Stage, Jump Onto Road And Stop Traffic"
-cheat5_code = "21E+BA5+2A2"
+cheat5_code = "21E-BA5-2A2"
 cheat5_enable = false 
 

--- a/cht/Sega - Game Gear/Shinobi II - The Silent Fury (World) (Japan) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Shinobi II - The Silent Fury (World) (Japan) (Game Genie).cht
@@ -1,38 +1,38 @@
 cheats = 9 
 
 cheat0_desc = "Start With 4 Energy Bars"
-cheat0_code = "052+50F+F7A"
+cheat0_code = "052-50F-F7A"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 6 Energy Bars"
-cheat1_code = "072+50F+F7A"
+cheat1_code = "072-50F-F7A"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 9 Energy Bars (Ignore Counter)"
-cheat2_code = "0A2+50F+F7A"
+cheat2_code = "0A2-50F-F7A"
 cheat2_enable = false 
 
 cheat3_desc = "Infinite Energy"
-cheat3_code = "21A+41C+2A2"
+cheat3_code = "21A-41C-2A2"
 cheat3_enable = false 
 
 cheat4_desc = "Infinite Ninjitsu Magic"
-cheat4_code = "008+30D+3BE"
+cheat4_code = "008-30D-3BE"
 cheat4_enable = false 
 
 cheat5_desc = "Start With 4 Lives"
-cheat5_code = "032+58F+F7A"
+cheat5_code = "032-58F-F7A"
 cheat5_enable = false 
 
 cheat6_desc = "Start With 7 Lives"
-cheat6_code = "062+58F+F7A"
+cheat6_code = "062-58F-F7A"
 cheat6_enable = false 
 
 cheat7_desc = "Start With 10 Lives"
-cheat7_code = "092+58F+F7A"
+cheat7_code = "092-58F-F7A"
 cheat7_enable = false 
 
 cheat8_desc = "Infinite Lives"
-cheat8_code = "00B+A0C+3BE"
+cheat8_code = "00B-A0C-3BE"
 cheat8_enable = false 
 

--- a/cht/Sega - Game Gear/Simpsons, The - Bart vs. the Space Mutants (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Simpsons, The - Bart vs. the Space Mutants (USA, Europe) (Game Genie).cht
@@ -1,22 +1,22 @@
 cheats = 5 
 
 cheat0_desc = "Infinite Coins"
-cheat0_code = "002+D09+E6E"
+cheat0_code = "002-D09-E6E"
 cheat0_enable = false 
 
 cheat1_desc = "Infinite Time"
-cheat1_code = "009+5DC+E6E"
+cheat1_code = "009-5DC-E6E"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 5 Coins"
-cheat2_code = "21D+18B+2A2+05E+A3E+A2A"
+cheat2_code = "21D-18B-2A2+05E-A3E-A2A"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 15 Coins"
-cheat3_code = "15E+A3E+A2A+21D+18B+2A2"
+cheat3_code = "15E-A3E-A2A+21D-18B-2A2"
 cheat3_enable = false 
 
 cheat4_desc = "Start With 20 Coins"
-cheat4_code = "21D+18B+2A2+20E+A3E+A2A"
+cheat4_code = "21D-18B-2A2+20E-A3E-A2A"
 cheat4_enable = false 
 

--- a/cht/Sega - Game Gear/Slider (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Slider (USA, Europe) (Game Genie).cht
@@ -1,22 +1,22 @@
 cheats = 5 
 
 cheat0_desc = "Start With 3 Lives"
-cheat0_code = "023+46F+F7A"
+cheat0_code = "023-46F-F7A"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 8 Lives"
-cheat1_code = "073+46F+F7A"
+cheat1_code = "073-46F-F7A"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 12 Lives"
-cheat2_code = "0B3+46F+F7A"
+cheat2_code = "0B3-46F-F7A"
 cheat2_enable = false 
 
 cheat3_desc = "Infinite Lives"
-cheat3_code = "007+01F+19E"
+cheat3_code = "007-01F-19E"
 cheat3_enable = false 
 
 cheat4_desc = "Infinite Time (Ignore Counter)"
-cheat4_code = "OOB+F6E+E65"
+cheat4_code = "00B-F6E-E65"
 cheat4_enable = false 
 

--- a/cht/Sega - Game Gear/Sonic Chaos (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Sonic Chaos (USA, Europe) (Game Genie).cht
@@ -1,103 +1,103 @@
 cheats = 28 
 
 cheat0_desc = "Infinite Time"
-cheat0_code = "008+3BD+E6E"
+cheat0_code = "008-3BD-E6E"
 cheat0_enable = false 
 
 cheat1_desc = "Each Ring Worth 2"
-cheat1_code = "022+1EC+E6E"
+cheat1_code = "022-1EC-E6E"
 cheat1_enable = false 
 
 cheat2_desc = "Each Ring Worth 4"
-cheat2_code = "042+1EC+E6E"
+cheat2_code = "042-1EC-E6E"
 cheat2_enable = false 
 
 cheat3_desc = "Each Ring Worth 6"
-cheat3_code = "062+1EC+E6E"
+cheat3_code = "062-1EC-E6E"
 cheat3_enable = false 
 
 cheat4_desc = "Each Ring Worth 8"
-cheat4_code = "082+1EC+E6E"
+cheat4_code = "082-1EC-E6E"
 cheat4_enable = false 
 
 cheat5_desc = "Each Ring Worth 10"
-cheat5_code = "0A2+1EC+E6E"
+cheat5_code = "0A2-1EC-E6E"
 cheat5_enable = false 
 
 cheat6_desc = "Never Lose Rings"
-cheat6_code = "3A9+DCB+2A2"
+cheat6_code = "3A9-DCB-2A2"
 cheat6_enable = false 
 
 cheat7_desc = "Start With Some Rings Most Of The Time"
-cheat7_code = "22A+91D+2A2"
+cheat7_code = "22A-91D-2A2"
 cheat7_enable = false 
 
 cheat8_desc = "Sonic Starts With 1 Life"
-cheat8_code = "016+93C+E66"
+cheat8_code = "016-93C-E66"
 cheat8_enable = false 
 
 cheat9_desc = "Sonic Starts With 9 Lives"
-cheat9_code = "096+93C+E66"
+cheat9_code = "096-93C-E66"
 cheat9_enable = false 
 
 cheat10_desc = "Sonic Starts With 50 Lives"
-cheat10_code = "506+93C+E66"
+cheat10_code = "506-93C-E66"
 cheat10_enable = false 
 
 cheat11_desc = "Sonic Starts With 99 Lives"
-cheat11_code = "996+93C+E66"
+cheat11_code = "996-93C-E66"
 cheat11_enable = false 
 
 cheat12_desc = "Sonic Continues With 1 Life"
-cheat12_code = "014+23E+E66"
+cheat12_code = "014-23E-E66"
 cheat12_enable = false 
 
 cheat13_desc = "Sonic Continues With 9 Lives"
-cheat13_code = "094+23E+E66"
+cheat13_code = "094-23E-E66"
 cheat13_enable = false 
 
 cheat14_desc = "Sonic Continues With 50 Lives"
-cheat14_code = "504+23E+E66"
+cheat14_code = "504-23E-E66"
 cheat14_enable = false 
 
 cheat15_desc = "Sonic Continues With 99 Lives"
-cheat15_code = "994+23E+E66"
+cheat15_code = "994-23E-E66"
 cheat15_enable = false 
 
 cheat16_desc = "Tails Starts With 1 Life"
-cheat16_code = "016+99C+F7E"
+cheat16_code = "016-99C-F7E"
 cheat16_enable = false 
 
 cheat17_desc = "Tails Starts With 9 Lives"
-cheat17_code = "096+99C+F7E"
+cheat17_code = "096-99C-F7E"
 cheat17_enable = false 
 
 cheat18_desc = "Tails Starts With 50 Lives"
-cheat18_code = "506+99C+F7E"
+cheat18_code = "506-99C-F7E"
 cheat18_enable = false 
 
 cheat19_desc = "Tails Starts With 99 Lives"
-cheat19_code = "996+99C+F7E"
+cheat19_code = "996-99C-F7E"
 cheat19_enable = false 
 
 cheat20_desc = "Tails Continues With 1 Life"
-cheat20_code = "014+28E+F7E"
+cheat20_code = "014-28E-F7E"
 cheat20_enable = false 
 
 cheat21_desc = "Tails Continues With 9 Lives"
-cheat21_code = "094+28E+F7E"
+cheat21_code = "094-28E-F7E"
 cheat21_enable = false 
 
 cheat22_desc = "Tails Continues With 50 Lives"
-cheat22_code = "504+28E+F7E"
+cheat22_code = "504-28E-F7E"
 cheat22_enable = false 
 
 cheat23_desc = "Tails Continues With 99 Lives"
-cheat23_code = "994+28E+F7E"
+cheat23_code = "994-28E-F7E"
 cheat23_enable = false 
 
 cheat24_desc = "Infinite Lives"
-cheat24_code = "3A6+24E+2A2"
+cheat24_code = "3A6-24E-2A2"
 cheat24_enable = false 
 
 cheat25_desc = "Character Modifier"

--- a/cht/Sega - Game Gear/Sonic The Hedgehog - Triple Trouble (diff) (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Sonic The Hedgehog - Triple Trouble (diff) (USA, Europe) (Game Genie).cht
@@ -1,78 +1,78 @@
 cheats = 19 
 
 cheat0_desc = "Infinite Lives"
-cheat0_code = "003+E0E+E6E"
+cheat0_code = "003-E0E-E6E"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 1 Lives"
-cheat1_code = "00A+E6E+E66"
+cheat1_code = "00A-E6E-E66"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 5 Lives"
-cheat2_code = "04A+E6E+E66"
+cheat2_code = "04A-E6E-E66"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 15 Lives"
-cheat3_code = "14A+E6E+E66"
+cheat3_code = "14A-E6E-E66"
 cheat3_enable = false 
 
 cheat4_desc = "Start With 100 Lives"
-cheat4_code = "99A+E6E+E66"
+cheat4_code = "99A-E6E-E66"
 cheat4_enable = false 
 
 cheat5_desc = "Start High In The Air On Act 1"
-cheat5_code = "00A+EFE+5D4"
+cheat5_code = "00A-EFE-5D4"
 cheat5_enable = false 
 
 cheat6_desc = "Each Ring Worth 5"
-cheat6_code = "053+AFC+E6E"
+cheat6_code = "053-AFC-E6E"
 cheat6_enable = false 
 
 cheat7_desc = "Each Ring Worth 10"
-cheat7_code = "0A3+AFC+E6E"
+cheat7_code = "0A3-AFC-E6E"
 cheat7_enable = false 
 
 cheat8_desc = "Infinite Rings"
-cheat8_code = "3A8+E4C+2A2+3A8+E7C+2A2"
+cheat8_code = "3A8-E4C-2A2+3A8-E7C-2A2"
 cheat8_enable = false 
 
 cheat9_desc = "Finish The First Part Of An Act And Warp To The Next Act"
-cheat9_code = "3E3+A4E+082+023+A5E+F77+003+A6E+A2D"
+cheat9_code = "3E3-A4E-082+023-A5E-F77+003-A6E-A2D"
 cheat9_enable = false 
 
 cheat10_desc = "Flash Less Time After Getting Hit"
-cheat10_code = "008+FFC+08B"
+cheat10_code = "008-FFC-08B"
 cheat10_enable = false 
 
 cheat11_desc = "Flash Longer After Getting Hit"
-cheat11_code = "998+FFC+08B"
+cheat11_code = "998-FFC-08B"
 cheat11_enable = false 
 
 cheat12_desc = "Get Hit And Stay Invincible"
-cheat12_code = "3A9+D5C+2A2"
+cheat12_code = "3A9-D5C-2A2"
 cheat12_enable = false 
 
 cheat13_desc = "Invincible (Spikes Still Kill You)"
-cheat13_code = "C37+F2C+E61"
+cheat13_code = "C37-F2C-E61"
 cheat13_enable = false 
 
 cheat14_desc = "Start With No Continues"
-cheat14_code = "00A+EBE+E6E"
+cheat14_code = "00A-EBE-E6E"
 cheat14_enable = false 
 
 cheat15_desc = "Start With 5 Continues"
-cheat15_code = "05A+EBE+E6E"
+cheat15_code = "05A-EBE-E6E"
 cheat15_enable = false 
 
 cheat16_desc = "Start With 10 Continues"
-cheat16_code = "0AA+EBE+E6E"
+cheat16_code = "0AA-EBE-E6E"
 cheat16_enable = false 
 
 cheat17_desc = "Infinite Continues"
-cheat17_code = "3A5+60E+2A2"
+cheat17_code = "3A5-60E-2A2"
 cheat17_enable = false 
 
 cheat18_desc = "Infinite Timer"
-cheat18_code = "00F+88D+3B7"
+cheat18_code = "00F-88D-3B7"
 cheat18_enable = false 
 

--- a/cht/Sega - Game Gear/Space Harrier (World) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Space Harrier (World) (Game Genie).cht
@@ -1,94 +1,94 @@
 cheats = 23 
 
 cheat0_desc = "Start With 5 Lives"
-cheat0_code = "040+8DF+E62"
+cheat0_code = "040-8DF-E62"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 7 Lives"
-cheat1_code = "060+8DF+E62"
+cheat1_code = "060-8DF-E62"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 9 Lives"
-cheat2_code = "080+8DF+E62"
+cheat2_code = "080-8DF-E62"
 cheat2_enable = false 
 
 cheat3_desc = "Infinite Lives"
-cheat3_code = "21A+63D+2A2"
+cheat3_code = "21A-63D-2A2"
 cheat3_enable = false 
 
 cheat4_desc = "*Watch Ending"
-cheat4_code = "195+CCE+B3E+005+C9E+6EA+005+CAC+E62"
+cheat4_code = "195-CCE-B3E+005-C9E-6EA+005-CAC-E62"
 cheat4_enable = false 
 
 cheat5_desc = "Floor Doesn't Move"
-cheat5_code = "004+A6E+3BE"
+cheat5_code = "004-A6E-3BE"
 cheat5_enable = false 
 
 cheat6_desc = "*Start On Stage 2"
-cheat6_code = "025+CCE+B3E+005+C9E+6EA+005+CAC+E62"
+cheat6_code = "025-CCE-B3E+005-C9E-6EA+005-CAC-E62"
 cheat6_enable = false 
 
 cheat7_desc = "*Start On Stage 3"
-cheat7_code = "035+CCE+B3E+005+C9E+6EA+005+CAC+E62"
+cheat7_code = "035-CCE-B3E+005-C9E-6EA+005-CAC-E62"
 cheat7_enable = false 
 
 cheat8_desc = "*Start On Stage 4"
-cheat8_code = "045+CCE+B3E+005+C9E+6EA+005+CAC+E62"
+cheat8_code = "045-CCE-B3E+005-C9E-6EA+005-CAC-E62"
 cheat8_enable = false 
 
 cheat9_desc = "*Start On Stage 5"
-cheat9_code = "065+CCE+B3E+005+C9E+6EA+005+CAC+E62"
+cheat9_code = "065-CCE-B3E+005-C9E-6EA+005-CAC-E62"
 cheat9_enable = false 
 
 cheat10_desc = "*Start On Stage 6"
-cheat10_code = "075+CCE+B3E+005+C9E+6EA+005+CAC+E62"
+cheat10_code = "075-CCE-B3E+005-C9E-6EA+005-CAC-E62"
 cheat10_enable = false 
 
 cheat11_desc = "*Start On Stage 7"
-cheat11_code = "0A5+CCE+B3E+005+C9E+6EA+005+CAC+E62"
+cheat11_code = "0A5-CCE-B3E+005-C9E-6EA+005-CAC-E62"
 cheat11_enable = false 
 
 cheat12_desc = "*Start On Stage 8"
-cheat12_code = "0B5+CCE+B3E+005+C9E+6EA+005+CAC+E62"
+cheat12_code = "0B5-CCE-B3E+005-C9E-6EA+005-CAC-E62"
 cheat12_enable = false 
 
 cheat13_desc = "*Start On Stage 9"
-cheat13_code = "0D5+CCE+B3E+005+C9E+6EA+005+CAC+E62"
+cheat13_code = "0D5-CCE-B3E+005-C9E-6EA+005-CAC-E62"
 cheat13_enable = false 
 
 cheat14_desc = "*Start On Stage 10"
-cheat14_code = "0E5+CCE+B3E+005+C9E+6EA+005+CAC+E62"
+cheat14_code = "0E5-CCE-B3E+005-C9E-6EA+005-CAC-E62"
 cheat14_enable = false 
 
 cheat15_desc = "*Start On Stage 11"
-cheat15_code = "0F5+CCE+B3E+005+C9E+6EA+005+CAC+E62"
+cheat15_code = "0F5-CCE-B3E+005-C9E-6EA+005-CAC-E62"
 cheat15_enable = false 
 
 cheat16_desc = "*Start On Stage 12-1"
-cheat16_code = "115+CCE+B3E+005+C9E+6EA+005+CAC+E62"
+cheat16_code = "115-CCE-B3E+005-C9E-6EA+005-CAC-E62"
 cheat16_enable = false 
 
 cheat17_desc = "*Start On Stage 12-2"
-cheat17_code = "125+CCE+B3E+005+C9E+6EA+005+CAC+E62"
+cheat17_code = "125-CCE-B3E+005-C9E-6EA+005-CAC-E62"
 cheat17_enable = false 
 
 cheat18_desc = "*Start On Stage 12-3"
-cheat18_code = "135+CCE+B3E+005+C9E+6EA+005+CAC+E62"
+cheat18_code = "135-CCE-B3E+005-C9E-6EA+005-CAC-E62"
 cheat18_enable = false 
 
 cheat19_desc = "*Start On Stage 12-4"
-cheat19_code = "145+CCE+B3E+005+C9E+6EA+005+CAC+E62"
+cheat19_code = "145-CCE-B3E+005-C9E-6EA+005-CAC-E62"
 cheat19_enable = false 
 
 cheat20_desc = "*Start On Stage 12-5"
-cheat20_code = "165+CCE+B3E+005+C9E+6EA+005+CAC+E62"
+cheat20_code = "165-CCE-B3E+005-C9E-6EA+005-CAC-E62"
 cheat20_enable = false 
 
 cheat21_desc = "*Start On Stage 12-6"
-cheat21_code = "175+CCE+B3E+005+C9E+6EA+005+CAC+E62"
+cheat21_code = "175-CCE-B3E+005-C9E-6EA+005-CAC-E62"
 cheat21_enable = false 
 
 cheat22_desc = "*Start On Stage 12-7"
-cheat22_code = "185+CCE+B3E+005+C9E+6EA+005+CAC+E62"
+cheat22_code = "185-CCE-B3E+005-C9E-6EA+005-CAC-E62"
 cheat22_enable = false 
 

--- a/cht/Sega - Game Gear/Spider-Man - Return of the Sinister Six (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Spider-Man - Return of the Sinister Six (USA, Europe) (Game Genie).cht
@@ -1,34 +1,34 @@
 cheats = 8 
 
 cheat0_desc = "Begin With Web Fluid"
-cheat0_code = "003+39F+5D4"
+cheat0_code = "003-39F-5D4"
 cheat0_enable = false 
 
 cheat1_desc = "Start With Less Energy"
-cheat1_code = "013+35F+C4A"
+cheat1_code = "013-35F-C4A"
 cheat1_enable = false 
 
 cheat2_desc = "Start With More Energy"
-cheat2_code = "0A3+35F+C4A"
+cheat2_code = "0A3-35F-C4A"
 cheat2_enable = false 
 
 cheat3_desc = "Start With A Lot More Energy"
-cheat3_code = "0F3+35F+C4A"
+cheat3_code = "0F3-35F-C4A"
 cheat3_enable = false 
 
 cheat4_desc = "Gives You 2,540 Points"
-cheat4_code = "FF3+2FF+E6E"
+cheat4_code = "FF3-2FF-E6E"
 cheat4_enable = false 
 
 cheat5_desc = "Start With 5 Continues"
-cheat5_code = "063+1DF+E66"
+cheat5_code = "063-1DF-E66"
 cheat5_enable = false 
 
 cheat6_desc = "Start With 8 Continues"
-cheat6_code = "093+1DF+E66"
+cheat6_code = "093-1DF-E66"
 cheat6_enable = false 
 
 cheat7_desc = "Infinite Energy"
-cheat7_code = "3A4+0DD+2A2"
+cheat7_code = "3A4-0DD-2A2"
 cheat7_enable = false 
 

--- a/cht/Sega - Game Gear/Super Golf (USA, Japan) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Super Golf (USA, Japan) (Game Genie).cht
@@ -1,82 +1,82 @@
 cheats = 20 
 
 cheat0_desc = "Turn Codes On And Bad Shots Won't Be Scored"
-cheat0_code = "21F+4CE+19D"
+cheat0_code = "21F-4CE-19D"
 cheat0_enable = false 
 
 cheat1_desc = "Take Points On Character Select And Put Them Into Point Bin"
-cheat1_code = "OOF+16C+3BE"
+cheat1_code = "00F-16C-3BE"
 cheat1_enable = false 
 
 cheat2_desc = "No Wind"
-cheat2_code = "AF2+83E+08F"
+cheat2_code = "AF2-83E-08F"
 cheat2_enable = false 
 
 cheat3_desc = "Start On Hole 2"
-cheat3_code = "02F+6DF+E6E"
+cheat3_code = "02F-6DF-E6E"
 cheat3_enable = false 
 
 cheat4_desc = "Start On Hole 3"
-cheat4_code = "03F+6DF+E6E"
+cheat4_code = "03F-6DF-E6E"
 cheat4_enable = false 
 
 cheat5_desc = "Start On Hole 4"
-cheat5_code = "04F+6DF+E6E"
+cheat5_code = "04F-6DF-E6E"
 cheat5_enable = false 
 
 cheat6_desc = "Start On Hole 5"
-cheat6_code = "05F+6DF+E6E"
+cheat6_code = "05F-6DF-E6E"
 cheat6_enable = false 
 
 cheat7_desc = "Start On Hole 6"
-cheat7_code = "06F+6DF+E6E"
+cheat7_code = "06F-6DF-E6E"
 cheat7_enable = false 
 
 cheat8_desc = "Start On Hole 7"
-cheat8_code = "07F+6DF+E6E"
+cheat8_code = "07F-6DF-E6E"
 cheat8_enable = false 
 
 cheat9_desc = "Start On Hole 8"
-cheat9_code = "08F+6DF+E6E"
+cheat9_code = "08F-6DF-E6E"
 cheat9_enable = false 
 
 cheat10_desc = "Start On Hole 9"
-cheat10_code = "09F+6DF+E6E"
+cheat10_code = "09F-6DF-E6E"
 cheat10_enable = false 
 
 cheat11_desc = "Start On Hole 10"
-cheat11_code = "0AF+6DF+E6E"
+cheat11_code = "0AF-6DF-E6E"
 cheat11_enable = false 
 
 cheat12_desc = "Start On Hole 11"
-cheat12_code = "0BF+6DF+E6E"
+cheat12_code = "0BF-6DF-E6E"
 cheat12_enable = false 
 
 cheat13_desc = "Start On Hole 12"
-cheat13_code = "0CF+6DF+E6E"
+cheat13_code = "0CF-6DF-E6E"
 cheat13_enable = false 
 
 cheat14_desc = "Start On Hole 13"
-cheat14_code = "0DF+6DF+E6E"
+cheat14_code = "0DF-6DF-E6E"
 cheat14_enable = false 
 
 cheat15_desc = "Start On Hole 14"
-cheat15_code = "0EF+6DF+E6E"
+cheat15_code = "0EF-6DF-E6E"
 cheat15_enable = false 
 
 cheat16_desc = "Start On Hole 15"
-cheat16_code = "0FF+6DF+E6E"
+cheat16_code = "0FF-6DF-E6E"
 cheat16_enable = false 
 
 cheat17_desc = "Start On Hole 16"
-cheat17_code = "10F+6DF+E6E"
+cheat17_code = "10F-6DF-E6E"
 cheat17_enable = false 
 
 cheat18_desc = "Start On Hole 17"
-cheat18_code = "11F+6DF+E6E"
+cheat18_code = "11F-6DF-E6E"
 cheat18_enable = false 
 
 cheat19_desc = "Start On Hole 18"
-cheat19_code = "12F+6DF+E6E"
+cheat19_code = "12F-6DF-E6E"
 cheat19_enable = false 
 

--- a/cht/Sega - Game Gear/Super Off Road (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Super Off Road (USA, Europe) (Game Genie).cht
@@ -1,26 +1,26 @@
 cheats = 6 
 
 cheat0_desc = "Start With 5 Nitros"
-cheat0_code = "05A+D8F+80E"
+cheat0_code = "05A-D8F-80E"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 10 Nitros"
-cheat1_code = "0AA+D8F+80E"
+cheat1_code = "0AA-D8F-80E"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 15 Nitros"
-cheat2_code = "0FA+D8F+80E"
+cheat2_code = "0FA-D8F-80E"
 cheat2_enable = false 
 
 cheat3_desc = "Infinite Nitros"
-cheat3_code = "215+B0C+91D"
+cheat3_code = "215-B0C-91D"
 cheat3_enable = false 
 
 cheat4_desc = "Almost Infinite Money"
-cheat4_code = "001+98B+A2C"
+cheat4_code = "001-98B-A2C"
 cheat4_enable = false 
 
 cheat5_desc = "Infinite Time (Ignore Counter)"
-cheat5_code = "004+50E+A22"
+cheat5_code = "004-50E-A22"
 cheat5_enable = false 
 

--- a/cht/Sega - Game Gear/Super Return of the Jedi (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Super Return of the Jedi (USA, Europe) (Game Genie).cht
@@ -1,6 +1,6 @@
 cheats = 1 
 
 cheat0_desc = "Infinite Energy"
-cheat0_code = "00D+92B+3B7+3AD+93B+2A2"
+cheat0_code = "00D-92B-3B7+3AD-93B-2A2"
 cheat0_enable = false 
 

--- a/cht/Sega - Game Gear/Super Smash T.V. (World) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Super Smash T.V. (World) (Game Genie).cht
@@ -1,34 +1,34 @@
 cheats = 8 
 
 cheat0_desc = "Infinite Lives"
-cheat0_code = "001+76D+19E"
+cheat0_code = "001-76D-19E"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 5 Lives"
-cheat1_code = "050+809+F76"
+cheat1_code = "050-809-F76"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 8 Lives"
-cheat2_code = "080+809+F76"
+cheat2_code = "080-809-F76"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 10 Lives"
-cheat3_code = "0A0+809+F76"
+cheat3_code = "0A0-809-F76"
 cheat3_enable = false 
 
 cheat4_desc = "Green Men Freeze"
-cheat4_code = "C93+605+91D"
+cheat4_code = "C93-605-91D"
 cheat4_enable = false 
 
 cheat5_desc = "Start With 5 Credits"
-cheat5_code = "051+299+F76"
+cheat5_code = "051-299-F76"
 cheat5_enable = false 
 
 cheat6_desc = "Start With 8 Credits"
-cheat6_code = "081+299+F76"
+cheat6_code = "081-299-F76"
 cheat6_enable = false 
 
 cheat7_desc = "Start With 10 Credits"
-cheat7_code = "0A1+299+F76"
+cheat7_code = "0A1-299-F76"
 cheat7_enable = false 
 

--- a/cht/Sega - Game Gear/Super Space Invaders (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Super Space Invaders (USA, Europe) (Game Genie).cht
@@ -1,34 +1,34 @@
 cheats = 8 
 
 cheat0_desc = "Start With 2 Lives"
-cheat0_code = "02A+E1C+E66"
+cheat0_code = "02A-E1C-E66"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 5 Lives"
-cheat1_code = "05A+E1C+E66"
+cheat1_code = "05A-E1C-E66"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 7 Lives"
-cheat2_code = "07A+E1C+E66"
+cheat2_code = "07A-E1C-E66"
 cheat2_enable = false 
 
 cheat3_desc = "Infinite Lives"
-cheat3_code = "00F+D5B+3BE"
+cheat3_code = "00F-D5B-3BE"
 cheat3_enable = false 
 
 cheat4_desc = "Start With 3 Shields"
-cheat4_code = "02B+09E+E66"
+cheat4_code = "02B-09E-E66"
 cheat4_enable = false 
 
 cheat5_desc = "Start With 6 Shields"
-cheat5_code = "05B+09E+E66"
+cheat5_code = "05B-09E-E66"
 cheat5_enable = false 
 
 cheat6_desc = "Start With 8 Shields"
-cheat6_code = "07B+09E+E66"
+cheat6_code = "07B-09E-E66"
 cheat6_enable = false 
 
 cheat7_desc = "Infinite Shields (Except When Stomped)"
-cheat7_code = "007+43E+E6E"
+cheat7_code = "007-43E-E6E"
 cheat7_enable = false 
 

--- a/cht/Sega - Game Gear/Taito Chase H.Q. (USA, Japan) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Taito Chase H.Q. (USA, Japan) (Game Genie).cht
@@ -1,22 +1,22 @@
 cheats = 5 
 
 cheat0_desc = "Infinite Turbos"
-cheat0_code = "006+B4D+3BE"
+cheat0_code = "006-B4D-3BE"
 cheat0_enable = false 
 
 cheat1_desc = "Timer Starts At 50 Seconds (1st Life)"
-cheat1_code = "324+74D+10A"
+cheat1_code = "324-74D-10A"
 cheat1_enable = false 
 
 cheat2_desc = "Timer Starts At 70 Seconds (1st Life)"
-cheat2_code = "464+74D+10A"
+cheat2_code = "464-74D-10A"
 cheat2_enable = false 
 
 cheat3_desc = "Timer Starts At 90 Seconds (1st Life)"
-cheat3_code = "5A4+74D+10A"
+cheat3_code = "5A4-74D-10A"
 cheat3_enable = false 
 
 cheat4_desc = "Timer Starts At 50 Seconds (After 1st Life)"
-cheat4_code = "327+61C+10A"
+cheat4_code = "327-61C-10A"
 cheat4_enable = false 
 

--- a/cht/Sega - Game Gear/TaleSpin (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/TaleSpin (USA, Europe) (Game Genie).cht
@@ -1,34 +1,34 @@
 cheats = 8 
 
 cheat0_desc = "Start With 2 Lives"
-cheat0_code = "013+43F+E66"
+cheat0_code = "013-43F-E66"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 7 Lives"
-cheat1_code = "063+43F+E66"
+cheat1_code = "063-43F-E66"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 10 Lives"
-cheat2_code = "093+43F+E66"
+cheat2_code = "093-43F-E66"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 1 Credits"
-cheat3_code = "013+48F+E66"
+cheat3_code = "013-48F-E66"
 cheat3_enable = false 
 
 cheat4_desc = "Start With 6 Credits"
-cheat4_code = "063+48F+E66"
+cheat4_code = "063-48F-E66"
 cheat4_enable = false 
 
 cheat5_desc = "Start With 9 Credits"
-cheat5_code = "093+48F+E66"
+cheat5_code = "093-48F-E66"
 cheat5_enable = false 
 
 cheat6_desc = "Infinite Lives"
-cheat6_code = "3AB+B5D+2A2"
+cheat6_code = "3AB-B5D-2A2"
 cheat6_enable = false 
 
 cheat7_desc = "Infinite Continues"
-cheat7_code = "3A6+3CB+2A2"
+cheat7_code = "3A6-3CB-2A2"
 cheat7_enable = false 
 

--- a/cht/Sega - Game Gear/Taz in Escape from Mars (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Taz in Escape from Mars (USA, Europe) (Game Genie).cht
@@ -1,30 +1,30 @@
 cheats = 7 
 
 cheat0_desc = "Infinite Lives"
-cheat0_code = "3AE+916+2A2"
+cheat0_code = "3AE-916-2A2"
 cheat0_enable = false 
 
 cheat1_desc = "Infinite Energy"
-cheat1_code = "215+545+6E2"
+cheat1_code = "215-545-6E2"
 cheat1_enable = false 
 
 cheat2_desc = "Start With Bubble Gum Float"
-cheat2_code = "304+7B6+E6A"
+cheat2_code = "304-7B6-E6A"
 cheat2_enable = false 
 
 cheat3_desc = "Keep Weapons For A Little While After You Die"
-cheat3_code = "C94+7C6+2A2"
+cheat3_code = "C94-7C6-2A2"
 cheat3_enable = false 
 
 cheat4_desc = "Less Flash Time After Getting Hit"
-cheat4_code = "015+735+197"
+cheat4_code = "015-735-197"
 cheat4_enable = false 
 
 cheat5_desc = "More Flash Time After Getting Hit"
-cheat5_code = "995+735+197"
+cheat5_code = "995-735-197"
 cheat5_enable = false 
 
 cheat6_desc = "Always Invincible"
-cheat6_code = "004+E46+3BA+004+E06+3BE"
+cheat6_code = "004-E46-3BA+004-E06-3BE"
 cheat6_enable = false 
 

--- a/cht/Sega - Game Gear/Taz-Mania - The Search for the Lost Seabirds (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Taz-Mania - The Search for the Lost Seabirds (USA, Europe) (Game Genie).cht
@@ -1,18 +1,18 @@
 cheats = 4 
 
 cheat0_desc = "Start Level 1 With 3 Lives"
-cheat0_code = "031+CFD+F7E"
+cheat0_code = "031-CFD-F7E"
 cheat0_enable = false 
 
 cheat1_desc = "Start Level 1 With 7 Lives"
-cheat1_code = "071+CFD+F7E"
+cheat1_code = "071-CFD-F7E"
 cheat1_enable = false 
 
 cheat2_desc = "Start Level 1 With 9 Lives"
-cheat2_code = "091+CFD+F7E"
+cheat2_code = "091-CFD-F7E"
 cheat2_enable = false 
 
 cheat3_desc = "Infinite Lives"
-cheat3_code = "00E+32E+3B7"
+cheat3_code = "00E-32E-3B7"
 cheat3_enable = false 
 

--- a/cht/Sega - Game Gear/Tengen World Cup Soccer (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Tengen World Cup Soccer (USA, Europe) (Game Genie).cht
@@ -1,18 +1,18 @@
 cheats = 4 
 
 cheat0_desc = "Infinite Time (Switch On To Freeze Time)"
-cheat0_code = "002+D4C+19E"
+cheat0_code = "002-D4C-19E"
 cheat0_enable = false 
 
 cheat1_desc = "1 Minute Per Half"
-cheat1_code = "002+6DC+F7A+012+6EC+F7E"
+cheat1_code = "002-6DC-F7A+012-6EC-F7E"
 cheat1_enable = false 
 
 cheat2_desc = "5 Minutes Per Half"
-cheat2_code = "002+6DC+F7A+052+6EC+F7E"
+cheat2_code = "002-6DC-F7A+052-6EC-F7E"
 cheat2_enable = false 
 
 cheat3_desc = "60 Minutes Per Half"
-cheat3_code = "062+6DC+F7A+002+6EC+F7E"
+cheat3_code = "062-6DC-F7A+002-6EC-F7E"
 cheat3_enable = false 
 

--- a/cht/Sega - Game Gear/Tom and Jerry - The Movie (World) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Tom and Jerry - The Movie (World) (Game Genie).cht
@@ -1,82 +1,82 @@
 cheats = 20 
 
 cheat0_desc = "Infinite Energy"
-cheat0_code = "C90+AFA+2A2"
+cheat0_code = "C90-AFA-2A2"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 5 Hearts"
-cheat1_code = "0A8+D4E+C4A"
+cheat1_code = "0A8-D4E-C4A"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 6 Hearts"
-cheat2_code = "0C8+D4E+C4A"
+cheat2_code = "0C8-D4E-C4A"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 4 Continues"
-cheat3_code = "04B+E77+F76"
+cheat3_code = "04B-E77-F76"
 cheat3_enable = false 
 
 cheat4_desc = "Start With 8 Continues"
-cheat4_code = "08B+E77+F76"
+cheat4_code = "08B-E77-F76"
 cheat4_enable = false 
 
 cheat5_desc = "Infinite Continues"
-cheat5_code = "00D+E56+19E"
+cheat5_code = "00D-E56-19E"
 cheat5_enable = false 
 
 cheat6_desc = "Infinite Energy"
-cheat6_code = "000+AEA+19E"
+cheat6_code = "000-AEA-19E"
 cheat6_enable = false 
 
 cheat7_desc = "Start With Very Little Energy"
-cheat7_code = "018+D4E+C4A"
+cheat7_code = "018-D4E-C4A"
 cheat7_enable = false 
 
 cheat8_desc = "Start With Less Energy"
-cheat8_code = "028+D4E+C4A"
+cheat8_code = "028-D4E-C4A"
 cheat8_enable = false 
 
 cheat9_desc = "Start With More Energy"
-cheat9_code = "0A8+D4E+C4A"
+cheat9_code = "0A8-D4E-C4A"
 cheat9_enable = false 
 
 cheat10_desc = "Start With Even More Energy"
-cheat10_code = "0F8+D4E+C4A"
+cheat10_code = "0F8-D4E-C4A"
 cheat10_enable = false 
 
 cheat11_desc = "Start With No Continues"
-cheat11_code = "00B+E77+F76"
+cheat11_code = "00B-E77-F76"
 cheat11_enable = false 
 
 cheat12_desc = "Start With 10 Continues"
-cheat12_code = "0AB+E77+F76"
+cheat12_code = "0AB-E77-F76"
 cheat12_enable = false 
 
 cheat13_desc = "Start With 15 Continues"
-cheat13_code = "0FB+E77+F76"
+cheat13_code = "0FB-E77-F76"
 cheat13_enable = false 
 
 cheat14_desc = "Infinite Continues"
-cheat14_code = "00E+CD6+19E"
+cheat14_code = "00E-CD6-19E"
 cheat14_enable = false 
 
 cheat15_desc = "Start On Level 1"
-cheat15_code = "3EB+FE7+2A2+01B+FF7+F7A+00C+007+E6D"
+cheat15_code = "3EB-FE7-2A2+01B-FF7-F7A+00C-007-E6D"
 cheat15_enable = false 
 
 cheat16_desc = "Start On Level 2"
-cheat16_code = "3EB+FE7+2A2+02B+FF7+F7A+00C+007+E6D"
+cheat16_code = "3EB-FE7-2A2+02B-FF7-F7A+00C-007-E6D"
 cheat16_enable = false 
 
 cheat17_desc = "Start On Level 3"
-cheat17_code = "3EB+FE7+2A2+03B+FF7+F7A+00C+007+E6D"
+cheat17_code = "3EB-FE7-2A2+03B-FF7-F7A+00C-007-E6D"
 cheat17_enable = false 
 
 cheat18_desc = "Start On Level 4"
-cheat18_code = "3EB+FE7+2A2+04B+FF7+F7A+00C+007+E6D"
+cheat18_code = "3EB-FE7-2A2+04B-FF7-F7A+00C-007-E6D"
 cheat18_enable = false 
 
 cheat19_desc = "Watch The Ending"
-cheat19_code = "3EB+FE7+2A2+05B+FF7+F7A+00C+007+E6D"
+cheat19_code = "3EB-FE7-2A2+05B-FF7-F7A+00C-007-E6D"
 cheat19_enable = false 
 

--- a/cht/Sega - Game Gear/Vampire - Master of Darkness (USA) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Vampire - Master of Darkness (USA) (Game Genie).cht
@@ -1,42 +1,42 @@
 cheats = 10 
 
 cheat0_desc = "Infinite Time"
-cheat0_code = "00B+3AB+E6E"
+cheat0_code = "00B-3AB-E6E"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 2 Lives"
-cheat1_code = "022+727+E66"
+cheat1_code = "022-727-E66"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 7 Lives"
-cheat2_code = "072+727+E66"
+cheat2_code = "072-727-E66"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 9 Lives"
-cheat3_code = "092+727+E66"
+cheat3_code = "092-727-E66"
 cheat3_enable = false 
 
 cheat4_desc = "Infinite Energy (Switch Off Codes If You Get Stuck)"
-cheat4_code = "3A7+02B+2A2"
+cheat4_code = "3A7-02B-2A2"
 cheat4_enable = false 
 
 cheat5_desc = "Infinite Lives"
-cheat5_code = "3A1+2AE+2A2"
+cheat5_code = "3A1-2AE-2A2"
 cheat5_enable = false 
 
 cheat6_desc = "Infinite Ammo For Special Weapons"
-cheat6_code = "3A3+23D+2A2"
+cheat6_code = "3A3-23D-2A2"
 cheat6_enable = false 
 
 cheat7_desc = "Die And Get Special Weapons Given To You"
-cheat7_code = "3C1+32E+5D4"
+cheat7_code = "3C1-32E-5D4"
 cheat7_enable = false 
 
 cheat8_desc = "Don't Lose Special Weapons After Dying"
-cheat8_code = "211+36E+2A2+211+39E+2A2"
+cheat8_code = "211-36E-2A2+211-39E-2A2"
 cheat8_enable = false 
 
 cheat9_desc = "Invincibility"
-cheat9_code = "3E6+FFB+2AA+207+00B+E6E+007+01B+5D4"
+cheat9_code = "3E6-FFB-2AA+207-00B-E6E+007-01B-5D4"
 cheat9_enable = false 
 

--- a/cht/Sega - Game Gear/WWF Wrestlemania Steel Cage Challenge (Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/WWF Wrestlemania Steel Cage Challenge (Europe) (Game Genie).cht
@@ -1,50 +1,50 @@
 cheats = 12 
 
 cheat0_desc = "Start With No Energy (Hulk Hogan)"
-cheat0_code = "023+327+5D5"
+cheat0_code = "023-327-5D5"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 1/4 Energy (Hulk Hogan)"
-cheat1_code = "4F3+327+5D5"
+cheat1_code = "4F3-327-5D5"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 1/2 Energy (Hulk Hogan)"
-cheat2_code = "6A3+327+5D5"
+cheat2_code = "6A3-327-5D5"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 3/4 Energy (Hulk Hogan)"
-cheat3_code = "C03+327+5D5"
+cheat3_code = "C03-327-5D5"
 cheat3_enable = false 
 
 cheat4_desc = "Start With 1/4 Energy (Opponent)"
-cheat4_code = "453+8E7+5D5"
+cheat4_code = "453-8E7-5D5"
 cheat4_enable = false 
 
 cheat5_desc = "Start With 1/2 Energy (Opponent)"
-cheat5_code = "6A3+8E7+5D5"
+cheat5_code = "6A3-8E7-5D5"
 cheat5_enable = false 
 
 cheat6_desc = "Start With 3/4 Energy (Opponent)"
-cheat6_code = "C03+8E7+5D5"
+cheat6_code = "C03-8E7-5D5"
 cheat6_enable = false 
 
 cheat7_desc = "Not Allowed Outside Ring For Long"
-cheat7_code = "03B+BAB+C42"
+cheat7_code = "03B-BAB-C42"
 cheat7_enable = false 
 
 cheat8_desc = "No Out-Of-Ring Counter (Hulk Hogan)"
-cheat8_code = "003+076+E65"
+cheat8_code = "003-076-E65"
 cheat8_enable = false 
 
 cheat9_desc = "Bodyslam Causes Max Damage"
-cheat9_code = "FFB+845+A2A"
+cheat9_code = "FFB-845-A2A"
 cheat9_enable = false 
 
 cheat10_desc = "Bodyslam Causes No Damage"
-cheat10_code = "00B+845+A2A"
+cheat10_code = "00B-845-A2A"
 cheat10_enable = false 
 
 cheat11_desc = "Bodyslam Causes 1/2 Damage"
-cheat11_code = "99B+845+A2A"
+cheat11_code = "99B-845-A2A"
 cheat11_enable = false 
 

--- a/cht/Sega - Game Gear/Wimbledon (World) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Wimbledon (World) (Game Genie).cht
@@ -1,22 +1,22 @@
 cheats = 5 
 
 cheat0_desc = "Computer Can't Score"
-cheat0_code = "005+EOE+C45"
+cheat0_code = "005-E0E-C45"
 cheat0_enable = false 
 
 cheat1_desc = "Tour Mode 9 Distribution Points"
-cheat1_code = "09B+515+D56"
+cheat1_code = "09B-515-D56"
 cheat1_enable = false 
 
 cheat2_desc = "Tour Mode 25 Distribution Points"
-cheat2_code = "19B+515+D56"
+cheat2_code = "19B-515-D56"
 cheat2_enable = false 
 
 cheat3_desc = "No Games Scored By Computer"
-cheat3_code = "006+06E+C45"
+cheat3_code = "006-06E-C45"
 cheat3_enable = false 
 
 cheat4_desc = "Most Games Are Given To You"
-cheat4_code = "076+05E+F7A"
+cheat4_code = "076-05E-F7A"
 cheat4_enable = false 
 

--- a/cht/Sega - Game Gear/Winter Olympics - Lillehammer '94 (World) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Winter Olympics - Lillehammer '94 (World) (Game Genie).cht
@@ -1,30 +1,30 @@
 cheats = 7 
 
 cheat0_desc = "Start On Any Skill Level"
-cheat0_code = "000+5A9+A29"
+cheat0_code = "000-5A9-A29"
 cheat0_enable = false 
 
 cheat1_desc = "1 Shot On Biathlon"
-cheat1_code = "01E+87D+F7E"
+cheat1_code = "01E-87D-F7E"
 cheat1_enable = false 
 
 cheat2_desc = "7 Shots On Biathlon"
-cheat2_code = "07E+87D+F7E"
+cheat2_code = "07E-87D-F7E"
 cheat2_enable = false 
 
 cheat3_desc = "9 Shots On Biathlon"
-cheat3_code = "09E+87D+F7E"
+cheat3_code = "09E-87D-F7E"
 cheat3_enable = false 
 
 cheat4_desc = "Infinite Time (Biathlon)"
-cheat4_code = "00A+02E+19A"
+cheat4_code = "00A-02E-19A"
 cheat4_enable = false 
 
 cheat5_desc = "Always Gain Speed On Luge And Bobsleigh"
-cheat5_code = "7E0+0BD+3B7+C91+B2D+91D"
+cheat5_code = "7E0-0BD-3B7+C91-B2D-91D"
 cheat5_enable = false 
 
 cheat6_desc = "Full Power On Speed Skating"
-cheat6_code = "2E8+51E+5DD+E08+52E+A23+188+53E+2AA"
+cheat6_code = "2E8-51E-5DD+E08-52E-A23+188-53E-2AA"
 cheat6_enable = false 
 

--- a/cht/Sega - Game Gear/Wonder Boy (Europe, Japan) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Wonder Boy (Europe, Japan) (Game Genie).cht
@@ -1,22 +1,22 @@
 cheats = 5 
 
 cheat0_desc = "Start With 5 Lives"
-cheat0_code = "05D+DDF+E66"
+cheat0_code = "05D-DDF-E66"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 8 Lives"
-cheat1_code = "08D+DDF+E66"
+cheat1_code = "08D-DDF-E66"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 12 Lives"
-cheat2_code = "0CD+DDF+E66"
+cheat2_code = "0CD-DDF-E66"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 5 Health/Vitality Units"
-cheat3_code = "055+7E9+D5A"
+cheat3_code = "055-7E9-D5A"
 cheat3_enable = false 
 
 cheat4_desc = "Start With 8 Health/Vitality Units"
-cheat4_code = "085+7E9+D5A"
+cheat4_code = "085-7E9-D5A"
 cheat4_enable = false 
 

--- a/cht/Sega - Game Gear/Woody Pop (World) (Game Genie).cht
+++ b/cht/Sega - Game Gear/Woody Pop (World) (Game Genie).cht
@@ -1,18 +1,18 @@
 cheats = 4 
 
 cheat0_desc = "Infinite Balls"
-cheat0_code = "009+3FE+E6D"
+cheat0_code = "009-3FE-E6D"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 15 Balls"
-cheat1_code = "0F7+16F+E66"
+cheat1_code = "0F7-16F-E66"
 cheat1_enable = false 
 
 cheat2_desc = "Start With 7 Balls"
-cheat2_code = "077+16F+E66"
+cheat2_code = "077-16F-E66"
 cheat2_enable = false 
 
 cheat3_desc = "Start With 1 Ball"
-cheat3_code = "017+16F+E66"
+cheat3_code = "017-16F-E66"
 cheat3_enable = false 
 

--- a/cht/Sega - Game Gear/World Series Baseball (USA) (Game Genie).cht
+++ b/cht/Sega - Game Gear/World Series Baseball (USA) (Game Genie).cht
@@ -1,38 +1,38 @@
 cheats = 9 
 
 cheat0_desc = "Outs Not Counted (Except Strikeouts)"
-cheat0_code = "009+76C+19A"
+cheat0_code = "009-76C-19A"
 cheat0_enable = false 
 
 cheat1_desc = "Can't Walk"
-cheat1_code = "00A+C1E+19A"
+cheat1_code = "00A-C1E-19A"
 cheat1_enable = false 
 
 cheat2_desc = "1 Ball And You Walk"
-cheat2_code = "01A+C3E+F7A"
+cheat2_code = "01A-C3E-F7A"
 cheat2_enable = false 
 
 cheat3_desc = "6 Balls And You Walk"
-cheat3_code = "06A+C3E+F7A"
+cheat3_code = "06A-C3E-F7A"
 cheat3_enable = false 
 
 cheat4_desc = "9 Balls And You Walk"
-cheat4_code = "09A+C3E+F7A"
+cheat4_code = "09A-C3E-F7A"
 cheat4_enable = false 
 
 cheat5_desc = "No Strikeouts"
-cheat5_code = "00A+37E+19A"
+cheat5_code = "00A-37E-19A"
 cheat5_enable = false 
 
 cheat6_desc = "1 Strike And You're Out"
-cheat6_code = "01A+39E+E66"
+cheat6_code = "01A-39E-E66"
 cheat6_enable = false 
 
 cheat7_desc = "6 Strikes And You're Out"
-cheat7_code = "06A+39E+E66"
+cheat7_code = "06A-39E-E66"
 cheat7_enable = false 
 
 cheat8_desc = "9 Strikes And You're Out"
-cheat8_code = "09A+39E+E66"
+cheat8_code = "09A-39E-E66"
 cheat8_enable = false 
 

--- a/cht/Sega - Game Gear/X-Men - Gamemaster's Legacy (USA, Europe) (Game Genie).cht
+++ b/cht/Sega - Game Gear/X-Men - Gamemaster's Legacy (USA, Europe) (Game Genie).cht
@@ -1,46 +1,46 @@
 cheats = 11 
 
 cheat0_desc = "Start With No Mutant Power"
-cheat0_code = "002+644+195"
+cheat0_code = "002-644-195"
 cheat0_enable = false 
 
 cheat1_desc = "Start With 1/2 Mutant Power"
-cheat1_code = "772+644+195"
+cheat1_code = "772-644-195"
 cheat1_enable = false 
 
 cheat2_desc = "Infinite Mutant Power"
-cheat2_code = "3AA+2A7+2A2"
+cheat2_code = "3AA-2A7-2A2"
 cheat2_enable = false 
 
 cheat3_desc = "Mutant Power Is Used Quicker"
-cheat3_code = "14A+267+C42"
+cheat3_code = "14A-267-C42"
 cheat3_enable = false 
 
 cheat4_desc = "Infinite Energy"
-cheat4_code = "3AA+BD7+2A2"
+cheat4_code = "3AA-BD7-2A2"
 cheat4_enable = false 
 
 cheat5_desc = "One Hit Is Fatal Most Of The Time"
-cheat5_code = "AFA+BA7+2AA+00A+BB7+E6E"
+cheat5_code = "AFA-BA7-2AA+00A-BB7-E6E"
 cheat5_enable = false 
 
 cheat6_desc = "Start With Very Little Energy"
-cheat6_code = "012+634+195"
+cheat6_code = "012-634-195"
 cheat6_enable = false 
 
 cheat7_desc = "Start With 1/2 Energy"
-cheat7_code = "772+634+195"
+cheat7_code = "772-634-195"
 cheat7_enable = false 
 
 cheat8_desc = "Flash A Lot Longer After Getting Hit"
-cheat8_code = "FFA+A97+2A2"
+cheat8_code = "FFA-A97-2A2"
 cheat8_enable = false 
 
 cheat9_desc = "1 Hit And You're Invisible"
-cheat9_code = "000+2F7+19E"
+cheat9_code = "000-2F7-19E"
 cheat9_enable = false 
 
 cheat10_desc = "Almost Invincible"
-cheat10_code = "000+2B7+806"
+cheat10_code = "000-2B7-806"
 cheat10_enable = false 
 


### PR DESCRIPTION
924 Game Gear Game Genie codes across 95 files are written `HHH+HHH+HHH` instead of `HHH-HHH-HHH`.

That form applies nothing. Both cores that handle Game Gear split the code string on `+` before validating it, then check each fragment — Genesis Plus GX in `libretro.c`, PicoDrive in `patch.c`. A three-character fragment fails, so the whole entry is rejected and toggling it does nothing.

`-` is the separator inside one Game Genie code; `+` is the separator between several codes in one entry. That is why the substitution is unambiguous: no valid Game Gear code contains `+` in those positions.

Five of the 924 also carried an O-for-0 or I-for-1 typo, corrected in the same pass.

### Tested on hardware

TrimUI handheld, PicoDrive core, `cht/Sega - Game Gear/Sonic Chaos (USA, Europe) (Game Genie).cht`:

| Cheat | Before | After |
| --- | --- | --- |
| Infinite Time | `008+3BD+E6E` — no effect | `008-3BD-E6E` — works |
| Each Ring Worth 10 | `0A2+1EC+E6E` — no effect | `0A2-1EC-E6E` — works |
| Sonic Starts With 50 Lives | `506+93C+E66` — no effect | `506-93C-E66` — works |

### Known caveat

Three Bram Stoker's Dracula codes end in a literal `XXX` user-fill placeholder and stay non-functional after this change. They are template entries rather than codes, and were equally non-functional before. 921 of the 924 are valid afterwards.

### How I checked it

- Re-implemented the accept/reject logic of Genesis Plus GX and counted the patches that would actually apply across the changed files: 130 before, 1,245 after, none lost, and no behaviour change for codes this branch does not touch.
- Audited the raw diff line by line: every changed line is a `cheatN_code` value. No files added, removed, or renamed, no other keys touched.
- Re-ran the fix over its own output: zero further changes.
