### PR TITLE
add: Import Virtual Boy Cheats

### DIFF
--- a/cht/Nintendo - Virtual Boy/3-D Tetris (USA).cht
+++ b/cht/Nintendo - Virtual Boy/3-D Tetris (USA).cht
@@ -1,0 +1,6 @@
+cheats = 1 
+
+cheat0_desc = "Max Score"
+cheat0_code = "05003AFC:FF+05003AFD:E0+05003AFE:F5+05003AFF:05"
+cheat0_enable = false 
+

--- a/cht/Nintendo - Virtual Boy/Galactic Pinball (Japan, USA) (En).cht
+++ b/cht/Nintendo - Virtual Boy/Galactic Pinball (Japan, USA) (En).cht
@@ -1,0 +1,10 @@
+cheats = 2 
+
+cheat0_desc = "Bonus Game"
+cheat0_code = "05004F80:05"
+cheat0_enable = false 
+
+cheat1_desc = "Infinite Pucks"
+cheat1_code = "05006F30:09"
+cheat1_enable = false 
+

--- a/cht/Nintendo - Virtual Boy/Jack Bros. (USA).cht
+++ b/cht/Nintendo - Virtual Boy/Jack Bros. (USA).cht
@@ -1,0 +1,10 @@
+cheats = 2 
+
+cheat0_desc = "Infinite Time"
+cheat0_code = "05000112:46"
+cheat0_enable = false 
+
+cheat1_desc = "Invincible, Etc."
+cheat1_code = "05000150:FF+05000151:FF"
+cheat1_enable = false 
+

--- a/cht/Nintendo - Virtual Boy/Mario's Tennis (Japan, USA) (En).cht
+++ b/cht/Nintendo - Virtual Boy/Mario's Tennis (Japan, USA) (En).cht
@@ -1,0 +1,10 @@
+cheats = 2 
+
+cheat0_desc = "CPU 6 Points"
+cheat0_code = "05002091:06"
+cheat0_enable = false 
+
+cheat1_desc = "P1 6 Points"
+cheat1_code = "05002090:06"
+cheat1_enable = false 
+

--- a/cht/Nintendo - Virtual Boy/SD Gundam - Dimension War (Japan).cht
+++ b/cht/Nintendo - Virtual Boy/SD Gundam - Dimension War (Japan).cht
@@ -1,0 +1,6 @@
+cheats = 1 
+
+cheat0_desc = "Inf Timer"
+cheat0_code = "05000300:09"
+cheat0_enable = false 
+

--- a/cht/Nintendo - Virtual Boy/Space Squash (Japan).cht
+++ b/cht/Nintendo - Virtual Boy/Space Squash (Japan).cht
@@ -1,0 +1,6 @@
+cheats = 1 
+
+cheat0_desc = "Infinite HP"
+cheat0_code = "05000130:04"
+cheat0_enable = false 
+

--- a/cht/Nintendo - Virtual Boy/Teleroboxer (Japan, USA) (En).cht
+++ b/cht/Nintendo - Virtual Boy/Teleroboxer (Japan, USA) (En).cht
@@ -1,0 +1,10 @@
+cheats = 2 
+
+cheat0_desc = "1-Hit Knock Outs"
+cheat0_code = "05004780:01"
+cheat0_enable = false 
+
+cheat1_desc = "Infinite Health"
+cheat1_code = "0500477C:7F"
+cheat1_enable = false 
+

--- a/cht/Nintendo - Virtual Boy/Vertical Force (USA).cht
+++ b/cht/Nintendo - Virtual Boy/Vertical Force (USA).cht
@@ -1,0 +1,6 @@
+cheats = 1 
+
+cheat0_desc = "Infinite Energy"
+cheat0_code = "05003F6D:08"
+cheat0_enable = false 
+

--- a/cht/Nintendo - Virtual Boy/Virtual Boy Wario Land (Japan, USA) (En).cht
+++ b/cht/Nintendo - Virtual Boy/Virtual Boy Wario Land (Japan, USA) (En).cht
@@ -1,0 +1,42 @@
+cheats = 10 
+
+cheat0_desc = "99 Hearts"
+cheat0_code = "050087A6:63"
+cheat0_enable = false 
+
+cheat1_desc = "9999 Coins"
+cheat1_code = "050087A8:0F+050087A9:27"
+cheat1_enable = false 
+
+cheat2_desc = "Always Have The King Dragon Cap"
+cheat2_code = "05001087:05"
+cheat2_enable = false 
+
+cheat3_desc = "Cap Modifier"
+cheat3_code = "05001087:??"
+cheat3_enable = false 
+
+cheat4_desc = "Have All Treasures, Quest 1"
+cheat4_code = "050091A4:01+050091A8:01+050091AC:01+050091B0:01+050091B4:01+050091B8:01+050091BC:01+050091C0:01+050091C4:01+050091C8:01"
+cheat4_enable = false 
+
+cheat5_desc = "Have All Treasures, Quest 2"
+cheat5_code = "050091A4:02+050091A8:02+050091AC:02+050091B0:02+050091B4:02+050091B8:02+050091BC:02+050091C0:02+050091C4:02+050091C8:02"
+cheat5_enable = false 
+
+cheat6_desc = "Infinite Flight Time With The Dragon Cap"
+cheat6_code = "0500103F:00"
+cheat6_enable = false 
+
+cheat7_desc = "Infinite Lives"
+cheat7_code = "050087A4:09"
+cheat7_enable = false 
+
+cheat8_desc = "Infinite Time"
+cheat8_code = "050087AA:B0"
+cheat8_enable = false 
+
+cheat9_desc = "Invincible (RAM Version)"
+cheat9_code = "05001063:01"
+cheat9_enable = false 
+

--- a/cht/Nintendo - Virtual Boy/Waterworld (USA).cht
+++ b/cht/Nintendo - Virtual Boy/Waterworld (USA).cht
@@ -1,0 +1,6 @@
+cheats = 1 
+
+cheat0_desc = "Infinite Lives"
+cheat0_code = "05009B62:03"
+cheat0_enable = false 
+


### PR DESCRIPTION
## What does this PR do?

This PR adds cheats for Virtual Boy from GameHacking.org (converted from Red Dragon format)

**I hope this is not a problem** 😅

### Context

Cheats for this system were never imported from GameHacking, even though a lot of other systems were. 

As a result, the [OpenEmu-Silicon emulator](https://github.com/OpenEmu-Silicon/OpenEmu-Silicon/) was not able to find any codes from Libretro's database.

### What was Tested

- First, I tested the converted cheats on a couple of games manually to see if cheats were working on the emulator.
- After importing the cheats, I used a script to validate the structure and consistency of the files
- I also checked the naming conventions from the RDB file, and ended up renaming few of them

### Linked Issues
[Libretro Cheat Database Integration | OpenEmu-Silicon](https://github.com/OpenEmu-Silicon/OpenEmu-Silicon/pull/715)

### Evidence

<img width="770" height="485" alt="Screenshot 2026-09-11 at 14 56 00" src="https://github.com/user-attachments/assets/894e4855-92bf-46ec-acd8-7053bf717657" />
