### PR TITLE
add: Import WonderSwan / Color Cheats

### DIFF
--- a/cht/Bandai - WonderSwan Color/Final Fantasy (Japan).cht
+++ b/cht/Bandai - WonderSwan Color/Final Fantasy (Japan).cht
@@ -1,0 +1,5 @@
+cheats = 1
+
+cheat0_desc = "No Random Battles"
+cheat0_code = "4474943:EB"
+cheat0_enable = false

--- a/cht/Bandai - WonderSwan Color/Final Fantasy II (Japan).cht
+++ b/cht/Bandai - WonderSwan Color/Final Fantasy II (Japan).cht
@@ -1,0 +1,9 @@
+cheats = 2
+
+cheat0_desc = "No Random Battles"
+cheat0_code = "43AB42D:00+43B0461:00"
+cheat0_enable = false
+
+cheat1_desc = "Walk Through Walls"
+cheat1_code = "43B6C30:EB"
+cheat1_enable = false

--- a/cht/Bandai - WonderSwan Color/Final Fantasy IV (Japan).cht
+++ b/cht/Bandai - WonderSwan Color/Final Fantasy IV (Japan).cht
@@ -1,0 +1,9 @@
+cheats = 2
+
+cheat0_desc = "No Random Battles"
+cheat0_code = "438B1C2:F8+438B0BD:EB"
+cheat0_enable = false
+
+cheat1_desc = "Walk Through Walls"
+cheat1_code = "435154D:EB+4350960:EB"
+cheat1_enable = false

--- a/cht/Bandai - WonderSwan Color/Guilty Gear Petit (Japan).cht
+++ b/cht/Bandai - WonderSwan Color/Guilty Gear Petit (Japan).cht
@@ -1,0 +1,9 @@
+cheats = 2
+
+cheat0_desc = "Blocking Disabled Both Players"
+cheat0_code = "414749E:EB"
+cheat0_enable = false
+
+cheat1_desc = "Hit Anywhere"
+cheat1_code = "41473A8:EB"
+cheat1_enable = false

--- a/cht/Bandai - WonderSwan Color/Guilty Gear Petit 2 (Japan).cht
+++ b/cht/Bandai - WonderSwan Color/Guilty Gear Petit 2 (Japan).cht
@@ -1,0 +1,5 @@
+cheats = 1
+
+cheat0_desc = "Hit Anywhere"
+cheat0_code = "434842E:EB"
+cheat0_enable = false

--- a/cht/Bandai - WonderSwan Color/Mr. Driller (Japan).cht
+++ b/cht/Bandai - WonderSwan Color/Mr. Driller (Japan).cht
@@ -1,0 +1,13 @@
+cheats = 3
+
+cheat0_desc = "Can Drill Brown Blocks Without Time Penalty"
+cheat0_code = "41F808F:00"
+cheat0_enable = false
+
+cheat1_desc = "Infinite Air"
+cheat1_code = "41F33DE:EB"
+cheat1_enable = false
+
+cheat2_desc = "Invincibility"
+cheat2_code = "41F327F:EB"
+cheat2_enable = false

--- a/cht/Bandai - WonderSwan Color/Rockman EXE WS (Japan).cht
+++ b/cht/Bandai - WonderSwan Color/Rockman EXE WS (Japan).cht
@@ -1,0 +1,9 @@
+cheats = 2
+
+cheat0_desc = "Invincibility"
+cheat0_code = "43D1EE4:00+43D1F0F:36+43D1F10:81+43D1F11:0E+43D1F12:DF+43D1F13:0B+43D1F14:A0+43D1F15:00"
+cheat0_enable = false
+
+cheat1_desc = "Jump in Midair"
+cheat1_code = "43D1B08:F9+43D1B0A:00+43D1B0B:04+43D1B0D:BE+43D1AD0:FC"
+cheat1_enable = false

--- a/cht/Bandai - WonderSwan Color/Tetris (Japan).cht
+++ b/cht/Bandai - WonderSwan Color/Tetris (Japan).cht
@@ -1,0 +1,5 @@
+cheats = 1
+
+cheat0_desc = "Tetromino Modifier"
+cheat0_code = "4044768:B1+4044769:??+404476A:90+404476B:90"
+cheat0_enable = false

--- a/cht/Bandai - WonderSwan Color/XI Little (Japan).cht
+++ b/cht/Bandai - WonderSwan Color/XI Little (Japan).cht
@@ -1,0 +1,5 @@
+cheats = 1
+
+cheat0_desc = "All Stages Unlocked"
+cheat0_code = "41F4971:64"
+cheat0_enable = false

--- a/cht/Bandai - WonderSwan/Chou Aniki - Otoko no Tamafuda (Japan).cht
+++ b/cht/Bandai - WonderSwan/Chou Aniki - Otoko no Tamafuda (Japan).cht
@@ -1,0 +1,5 @@
+cheats = 1
+
+cheat0_desc = "Walk Through Walls"
+cheat0_code = "4043A3A:00"
+cheat0_enable = false

--- a/cht/Bandai - WonderSwan/Engacho! for WonderSwan (Japan).cht
+++ b/cht/Bandai - WonderSwan/Engacho! for WonderSwan (Japan).cht
@@ -1,0 +1,9 @@
+cheats = 2
+
+cheat0_desc = "Infinite Steps"
+cheat0_code = "40F1DA7:90+40F1DA8:A1"
+cheat0_enable = false
+
+cheat1_desc = "Walk Through Walls"
+cheat1_code = "40F4E15:00+40F4E1A:00"
+cheat1_enable = false

--- a/cht/Bandai - WonderSwan/Kaze no Klonoa - Moonlight Museum (Japan).cht
+++ b/cht/Bandai - WonderSwan/Kaze no Klonoa - Moonlight Museum (Japan).cht
@@ -1,0 +1,13 @@
+cheats = 3
+
+cheat0_desc = "Invincibility"
+cheat0_code = "40455F6:C3"
+cheat0_enable = false
+
+cheat1_desc = "Jump in Midair"
+cheat1_code = "4045100:00"
+cheat1_enable = false
+
+cheat2_desc = "One Gem Equals 30"
+cheat2_code = "404A8D5:B2+404A8D6:1D+404A8D9:88"
+cheat2_enable = false

--- a/cht/Bandai - WonderSwan/Makaimura for WonderSwan (Japan).cht
+++ b/cht/Bandai - WonderSwan/Makaimura for WonderSwan (Japan).cht
@@ -1,4 +1,4 @@
-cheats = 3
+cheats = 4
 
 cheat0_desc = "Infinite Time"
 cheat0_code = "4147262:EB"
@@ -11,3 +11,7 @@ cheat1_enable = false
 cheat2_desc = "Jump in Midair"
 cheat2_code = "41481D2:00+41481D6:00"
 cheat2_enable = false
+
+cheat3_desc = "Infinite Lives"
+cheat3_code = "001E24:09"
+cheat3_enable = false

--- a/cht/Bandai - WonderSwan/Makaimura for WonderSwan (Japan).cht
+++ b/cht/Bandai - WonderSwan/Makaimura for WonderSwan (Japan).cht
@@ -1,0 +1,13 @@
+cheats = 3
+
+cheat0_desc = "Infinite Time"
+cheat0_code = "4147262:EB"
+cheat0_enable = false
+
+cheat1_desc = "Invincibility"
+cheat1_code = "41483BF:C6+41483C0:47+41483C5:C6+41483C6:47+41483C8:02"
+cheat1_enable = false
+
+cheat2_desc = "Jump in Midair"
+cheat2_code = "41481D2:00+41481D6:00"
+cheat2_enable = false

--- a/cht/Bandai - WonderSwan/Rainbow Islands - Putty's Party (Japan).cht
+++ b/cht/Bandai - WonderSwan/Rainbow Islands - Putty's Party (Japan).cht
@@ -1,0 +1,9 @@
+cheats = 2
+
+cheat0_desc = "Invincibility"
+cheat0_code = "41ECF72:C6"
+cheat0_enable = false
+
+cheat1_desc = "Jump in Midair"
+cheat1_code = "41EC64F:00+41EC654:00"
+cheat1_enable = false

--- a/cht/Bandai - WonderSwan/Rockman & Forte - Mirai Kara no Chousensha (Japan).cht
+++ b/cht/Bandai - WonderSwan/Rockman & Forte - Mirai Kara no Chousensha (Japan).cht
@@ -1,0 +1,21 @@
+cheats = 5
+
+cheat0_desc = "Can Kill Enemies With Immunities"
+cheat0_code = "44409E:EB"
+cheat0_enable = false
+
+cheat1_desc = "Can Select Sub Weapons in Pause Menu"
+cheat1_code = "414E4DB:C6+414E4DF:20+414E4E1:00"
+cheat1_enable = false
+
+cheat2_desc = "Infinite Sub Weapons"
+cheat2_code = "414870B:EB+414870C:05"
+cheat2_enable = false
+
+cheat3_desc = "Invincibility"
+cheat3_code = "41443CE:EB+4144685:EB+41449E6:C3"
+cheat3_enable = false
+
+cheat4_desc = "Jump in Midair"
+cheat4_code = "4148A4B:00+4148A51:00"
+cheat4_enable = false


### PR DESCRIPTION
## What does this PR do?

This PR adds cheats for WonderSwan and WonderSwan Color from GameHacking.org

**I hope this is not a problem** 😅

### Context

Cheats for this system were never imported from GameHacking, probably because they only have ROM-patches and RetroArch is not compatible with them. 

I implemented ROM-patch cheat codes in [OpenEmu-Silicon emulator](https://github.com/OpenEmu-Silicon/OpenEmu-Silicon/) and they worked well.

I also added my own RAM-patch cheat code that could be recognised, maybe that could incentivise the community to create more :)

### What was Tested

- First, I figured that there were only ROM-patches, so I implemented the support for it on the emulator and confirmed they worked
- After importing the cheats, I also searched for a RAM-patch cheat and added it to this PR
- I also checked the naming conventions from the RDB file, to guarantee the new CHT files could be found

### Linked Issues
[Libretro Cheat Database Integration | OpenEmu-Silicon](https://github.com/OpenEmu-Silicon/OpenEmu-Silicon/pull/715)

### Evidence

<img width="904" height="614" alt="Screenshot 2026-09-11 at 22 10 11" src="https://github.com/user-attachments/assets/345db35a-137b-4b2c-9739-e3c60be4f788" />