### PR TITLE
add: Create simple cheats for two PC-FX games

### DIFF
--- a/cht/NEC - PC-FX/Chip-chan Kick! (Japan).cht
+++ b/cht/NEC - PC-FX/Chip-chan Kick! (Japan).cht
@@ -1,0 +1,5 @@
+cheats = 1
+
+cheat0_desc = "Infinite Lives"
+cheat0_code = "001FBA09:09"
+cheat0_enable = false

--- a/cht/NEC - PC-FX/Choujin Heiki Zeroigar (Japan).cht
+++ b/cht/NEC - PC-FX/Choujin Heiki Zeroigar (Japan).cht
@@ -1,0 +1,5 @@
+cheats = 1
+
+cheat0_desc = "Infinite Energy"
+cheat0_code = "000F6294:FF"
+cheat0_enable = false


### PR DESCRIPTION
## What does this PR do?

This PR adds 1 simple cheat in two PC-FX games.

### Context

Cheats for this system don't seem to exist.

As I am implementing integration with Libretro's database in [OpenEmu-Silicon emulator](https://github.com/OpenEmu-Silicon/OpenEmu-Silicon/), I wanted to let the code ready for the case when someone would decide to create/add then to the database.

So I created two cheats myself :)

### What was Tested

- First, I searched for a cheat by using the Cheat Search function in OpenEmu-Silicon
- Then I created the files manually, and asked AI to review if the structure and code formatting would be accepted by OpenEmu-Silicon and other emulators
- I also checked the naming conventions from the RDB file, to guarantee the new CHT files could be found

### Linked Issues
[Libretro Cheat Database Integration | OpenEmu-Silicon](https://github.com/OpenEmu-Silicon/OpenEmu-Silicon/pull/715)

### Evidence

<img width="869" height="736" alt="Screenshot 2026-09-12 at 00 44 50" src="https://github.com/user-attachments/assets/bb432fef-bc27-4e7b-969c-ba2af979b808" />
